### PR TITLE
Ability to change PDF Size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 dist
 coverage/
 __tests__/assets/pdfs/tmp/*.pdf
+/my-app

--- a/packages/common/src/schema.ts
+++ b/packages/common/src/schema.ts
@@ -87,6 +87,7 @@ export const GeneratorOptions = CommonOptions.extend({
 export const GenerateProps = CommonProps.extend({
   inputs: Inputs,
   options: GeneratorOptions.optional(),
+  pdfSize: z.tuple([z.number(), z.number()]).optional(),
 }).strict();
 
 // ---------------------------------------------

--- a/packages/generator/src/generate.ts
+++ b/packages/generator/src/generate.ts
@@ -39,7 +39,7 @@ const postProcessing = (pdfDoc: PDFDocument) => {
 
 const generate = async (props: GenerateProps) => {
   checkGenerateProps(props);
-  const { inputs, template, options = {} } = props;
+  const { inputs, template, options = {}, pdfSize } = props;
   const { font = getDefaultFont(), splitThreshold = 3 } = options;
   const { schemas } = template;
 
@@ -55,7 +55,7 @@ const generate = async (props: GenerateProps) => {
       const { width: pageWidth, height: pageHeight } = embeddedPage;
       const embedPdfBox = embedPdfBoxes[j];
 
-      const page = pdfDoc.addPage([pageWidth, pageHeight]);
+      const page = pdfDoc.addPage(pdfSize || [pageWidth, pageHeight]);
 
       drawEmbeddedPage({ page, embeddedPage, embedPdfBox });
       for (let l = 0; l < keys.length; l += 1) {
@@ -71,7 +71,7 @@ const generate = async (props: GenerateProps) => {
           templateSchema,
           pdfDoc,
           page,
-          pageHeight,
+          pageHeight: pdfSize ? pdfSize[1] : pageHeight,
           textSchemaSetting,
           inputImageCache,
         });


### PR DESCRIPTION
Hi there,

I am still quite new to open source, so please forgive any obvious flaws and issues if present. The tests passed for me. The functionality is working when testing. So just need to have it pushed live if others find it useful as well. I'd also like to keep getting updates etc instead of using a forked personal verison. 

Our customers use printers such as the Brother QL-800 label printers. Which can print a single label at a time. This means we cannot do a full sheet. Unless I missed something in the library that can allow me to achieve this. I decided to add the functionality. 

Ability to change the PDF size when calling the generate method.

Added new property to the schema for the generateProps. pdfSize. An array of 2 numbers. 
  pdfSize: z.tuple([z.number(), z.number()]).optional(),
  
  These are used to create the pdf page, and for the pageheight.
      const page = pdfDoc.addPage(pdfSize || [pageWidth, pageHeight]);
                pageHeight: pdfSize ? pdfSize[1] : pageHeight,
                
                