### PR TITLE
Change name to @pdfme in root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "root",
+  "name": "@pdfme",
   "version": "0.0.0",
   "private": true,
   "author": "hand-dot",


### PR DESCRIPTION
This will enable a simpler workflow for forks where the main repository is forked, and the packages are built on-the-fly locally rather than pulling from npm.

Currently when adding your forked monorepo as yarn package you need to do:

```
yarn add @pdfme@git+https://github.com/my-fork/pdfme.git#main
```

but with this change it will be slightly simpler:

```
yarn add git+https://github.com/my-fork/pdfme.git#main
```

(if you do the latter currently it will add it as package "root" in your `package.json`):
```
"root": "git+https://github.com/pennyblack-io/pdfme.git#main",
```