### PR TITLE
Revert "Change name to @pdfme in root package.json"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pdfme",
+  "name": "root",
   "version": "0.0.0",
   "private": true,
   "author": "hand-dot",


### PR DESCRIPTION
This reverts the PR #153 that changed the `package.json`'s `name` property to `@pdfme`.

At the time I believe I encountered an issue related to the package name being `root`, but since my change was merged I'm now seeing errors like this when installing directly from a repository URL:

_Note that is part of our contributor workflow where we are testing changes in an application prior to a version being published as a package._

> ```
> yarn install v1.22.19
> [1/5] Validating package.json...
> [2/5] Resolving packages...
> [3/5] Fetching packages...
> error @pdfme@0.0.0: Name contains illegal characters
> info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
>  Error: The process '/usr/local/bin/yarn' failed with exit code 1

Yesterday I tested our workflow with `root` as the package name and everything seems fine, so I am really not sure what problem I was trying to solve by using `@pdfme` as the package name. This **does** seem like a quirk or bug in `yarn` though, because there are no illegal characters in a package name of `@pdfme` based on `npm` [package name rules](https://github.com/npm/validate-npm-package-name#naming-rules), from what I can see.

My apologies for the mixup.