### PR TITLE
Dynamic Font Sizing - Unit test fixes

### DIFF
--- a/packages/common/src/helpers/__tests__/calculateTextWidthInMm.test.ts
+++ b/packages/common/src/helpers/__tests__/calculateTextWidthInMm.test.ts
@@ -1,7 +1,7 @@
 import * as fontkit from 'fontkit';
 import { PDFDocument, PDFFont } from '@pdfme/pdf-lib';
 import { calculateTextWidthInMm } from '../calculateTextWidthInMm';
-import { HELVETICA } from "../../constants"
+import { HELVETICA } from '../../constants';
 
 describe('calculateTextWidthInMm', () => {
   let font: PDFFont;
@@ -20,7 +20,7 @@ describe('calculateTextWidthInMm', () => {
 
     const width = calculateTextWidthInMm(textContent, textFontSize, font, textCharacterSpacing);
 
-    expect(width).toBe(23.139414575999997);
+    expect(width).toBe(23.29306875);
   });
 
   it('accounts for character spacing', () => {
@@ -30,7 +30,7 @@ describe('calculateTextWidthInMm', () => {
 
     const width = calculateTextWidthInMm(textContent, textFontSize, font, textCharacterSpacing);
 
-    expect(width).toBe(27.372750575999998);
+    expect(width).toBe(27.52666875);
   });
 
   it('returns 0 for an empty string', () => {

--- a/packages/ui/__tests__/test-helpers.js
+++ b/packages/ui/__tests__/test-helpers.js
@@ -1,0 +1,3 @@
+const { TextEncoder, TextDecoder } = require('util');
+
+Object.assign(global, { TextDecoder, TextEncoder });

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -68,6 +68,9 @@
     "setupFiles": [
       "jest-canvas-mock"
     ],
+    "setupFilesAfterEnv": [
+      "./__tests__/test-helpers.js"
+    ],
     "moduleNameMapper": {
       "\\.(png)$": "<rootDir>/../../assetsTransformer.js"
     },


### PR DESCRIPTION
- After updates to the PDFMe package relating to the Dynamic Font Sizing feature, we noticed that the unit tests for font calculations had not been updated causing them to break. 
- In addition to this, we noticed additional errors with some snapshot tests returning the following error `ReferenceError: TextEncoder is not defined`

To address this, the `package.json` in the UI package has been updated to include `TextDecoder` and `TextEncoder` to make them available for use in testing.

**Before**
<img width="758" alt="Screenshot 2023-05-30 at 10 50 02" src="https://github.com/pdfme/pdfme/assets/45564901/62916693-52a1-448d-9dd7-d5099e2e3036">

**After**
<img width="758" alt="Screenshot 2023-05-30 at 10 53 52" src="https://github.com/pdfme/pdfme/assets/45564901/0427efab-5e20-4b9d-8cf4-104532b09829">
