### PR TITLE
Check whether shiftkey is not held on more events to prevent situations where it can get stuck

### DIFF
--- a/packages/ui/src/components/Designer/Main/index.tsx
+++ b/packages/ui/src/components/Designer/Main/index.tsx
@@ -110,7 +110,7 @@ const Main = (props: Props, ref: Ref<HTMLDivElement>) => {
     if (e.shiftKey) setIsPressShiftKey(true);
   };
   const onKeyup = (e: KeyboardEvent) => {
-    if (e.key === 'Shift') setIsPressShiftKey(false);
+    if (e.key === 'Shift' || !e.shiftKey) setIsPressShiftKey(false);
     if (e.key === 'Escape' || e.key === 'Esc') setEditing(false);
   };
 
@@ -197,11 +197,11 @@ const Main = (props: Props, ref: Ref<HTMLDivElement>) => {
 
   const currentlyEditingThisTextSchema = (target: EventTarget | null) => {
     if (!target) return false;
-    if (target instanceof HTMLTextAreaElement)   {
+    if (target instanceof HTMLTextAreaElement) {
       return activeElements.map((ae) => ae.id).includes(target.parentElement?.id || '');
     }
     return false;
-  }
+  };
 
   const onResize = ({ target, width, height, direction }: OnResize) => {
     if (!target) return;
@@ -245,6 +245,10 @@ const Main = (props: Props, ref: Ref<HTMLDivElement>) => {
         e.stopPropagation();
         if (!currentlyEditingThisTextSchema(e.target)) {
           setEditing(false);
+        }
+        // For MacOS CMD+SHIFT+3/4 screenshots where the keydown event is never received, check mouse too
+        if (!e.shiftKey) {
+          setIsPressShiftKey(false);
         }
       }}
       style={{ overflow: 'overlay' }}


### PR DESCRIPTION
Fixes #198 

Tested on playground. 

It's not 100% perfect as if the first action you do is click to drag a previously selected element it will still remain shifted, but after that it will be gone. I think this is a reasonable compromise for what is an edge case situation anyway.