### PR TITLE
Do not lose focus on a textarea in the designer if clicking within it

### DIFF
--- a/packages/ui/src/components/Designer/Main/index.tsx
+++ b/packages/ui/src/components/Designer/Main/index.tsx
@@ -195,6 +195,14 @@ const Main = (props: Props, ref: Ref<HTMLDivElement>) => {
     changeSchemas(flatten(arg));
   };
 
+  const currentlyEditingThisTextSchema = (target: EventTarget | null) => {
+    if (!target) return false;
+    if (target instanceof HTMLTextAreaElement)   {
+      return activeElements.map((ae) => ae.id).includes(target.parentElement?.id || '');
+    }
+    return false;
+  }
+
   const onResize = ({ target, width, height, direction }: OnResize) => {
     if (!target) return;
     const s = target.style;
@@ -235,7 +243,9 @@ const Main = (props: Props, ref: Ref<HTMLDivElement>) => {
       ref={ref}
       onClick={(e) => {
         e.stopPropagation();
-        setEditing(false);
+        if (!currentlyEditingThisTextSchema(e.target)) {
+          setEditing(false);
+        }
       }}
       style={{ overflow: 'overlay' }}
     >


### PR DESCRIPTION
fixes #160 

When you click within a textarea that is in focus you expect the text to remain in focus. Common use cases include:
- using your mouse to position the cursor
- highlighting some text for deletion, or copy & paste

Currently, the behaviour is that if you click on a textarea within the designer that is in focus, it will lose focus:

https://github.com/pdfme/pdfme/assets/7068515/bf5b5d70-c6b7-4376-b3c5-8ca2299915ec


New behaviour doesn't deselect the current textarea if clicking within it:

https://github.com/pdfme/pdfme/assets/7068515/ce7db783-2301-4bf9-ba2f-772c6cc44b47





