### PR TITLE
TextSchema UI fixes for dynamic font sizing

### DIFF
--- a/packages/common/__tests__/font.test.ts
+++ b/packages/common/__tests__/font.test.ts
@@ -373,6 +373,26 @@ describe('calculateDynamicFontSize with Default font', () => {
 
     expect(result).toBeGreaterThan(0);
   });
+
+  it('should calculate a dynamic font size when a starting font size is passed that is lower than the eventual', async () => {
+    const textSchema = getTextSchema();
+    textSchema.dynamicFontSize = { min: 10, max: 30 };
+    const input = 'test with a length string\n and a new line';
+    const startingFontSize = 18;
+    const result = await calculateDynamicFontSize({ textSchema, font, input, startingFontSize });
+
+    expect(result).toBe(19.25);
+  });
+
+  it('should calculate a dynamic font size when a starting font size is passed that is higher than the eventual', async () => {
+    const textSchema = getTextSchema();
+    textSchema.dynamicFontSize = { min: 10, max: 30 };
+    const input = 'test with a length string\n and a new line';
+    const startingFontSize = 36;
+    const result = await calculateDynamicFontSize({ textSchema, font, input, startingFontSize });
+
+    expect(result).toBe(19.25);
+  });
 });
 
 describe('calculateDynamicFontSize with Custom font', () => {

--- a/packages/common/src/font.ts
+++ b/packages/common/src/font.ts
@@ -209,7 +209,17 @@ export const getSplittedLines = (textLine: string, calcValues: FontWidthCalcValu
  * Calculating space usage involves splitting lines where they exceed
  * the box width based on the proposed size.
  */
-export const calculateDynamicFontSize = async ({ textSchema, font, input }: { textSchema: TextSchema; font: Font; input: string; }) => {
+export const calculateDynamicFontSize = async ({
+  textSchema,
+  font,
+  input,
+  startingFontSize,
+}: {
+  textSchema: TextSchema;
+  font: Font;
+  input: string;
+  startingFontSize?: number | undefined;
+}) => {
   const {
     fontSize: schemaFontSize,
     dynamicFontSize: dynamicFontSizeSetting,
@@ -218,7 +228,7 @@ export const calculateDynamicFontSize = async ({ textSchema, font, input }: { te
     height: boxHeight,
     lineHeight = DEFAULT_LINE_HEIGHT,
   } = textSchema;
-  const fontSize = schemaFontSize || DEFAULT_FONT_SIZE;
+  const fontSize = startingFontSize || schemaFontSize || DEFAULT_FONT_SIZE;
   if (!dynamicFontSizeSetting) return fontSize;
   if (dynamicFontSizeSetting.max < dynamicFontSizeSetting.min) return fontSize;
 

--- a/packages/ui/src/components/Schemas/TextSchema.tsx
+++ b/packages/ui/src/components/Schemas/TextSchema.tsx
@@ -27,14 +27,23 @@ const TextSchemaUI = (
 
   useEffect(() => {
     if (schema.dynamicFontSize && schema.data) {
-      calculateDynamicFontSize({ textSchema: schema, font, input: schema.data }).then(setDynamicFontSize);
+      calculateDynamicFontSize({
+        textSchema: schema,
+        font,
+        input: schema.data,
+        startingFontSize: dynamicFontSize,
+      }).then(setDynamicFontSize);
     } else {
       setDynamicFontSize(undefined);
     }
   }, [
-    schema,
     schema.data,
-    schema.dynamicFontSize,
+    schema.width,
+    schema.height,
+    schema.dynamicFontSize?.min,
+    schema.dynamicFontSize?.max,
+    schema.characterSpacing,
+    schema.lineHeight,
     font
   ]);
 
@@ -44,7 +53,6 @@ const TextSchemaUI = (
       setFontAlignmentValue(fav);
     });
   }, [
-    schema,
     schema.width,
     schema.height,
     schema.fontName,
@@ -56,7 +64,6 @@ const TextSchemaUI = (
     font,
     dynamicFontSize
   ]);
-
 
 
   const style: React.CSSProperties = {


### PR DESCRIPTION
fixes #228 

The dynamic font resize was being called for every text schema on the page on every key press, the same with the setFontAlignment.