### PR TITLE
Fix switching selections between an in-focus schema and another schema in the UI.

### DIFF
--- a/packages/ui/src/components/Designer/Main/index.tsx
+++ b/packages/ui/src/components/Designer/Main/index.tsx
@@ -196,14 +196,6 @@ const Main = (props: Props, ref: Ref<HTMLDivElement>) => {
     changeSchemas(flatten(arg));
   };
 
-  const currentlyEditingThisTextSchema = (target: EventTarget | null) => {
-    if (!target) return false;
-    if (target instanceof HTMLTextAreaElement) {
-      return activeElements.map((ae) => ae.id).includes(target.parentElement?.id || '');
-    }
-    return false;
-  };
-
   const onResize = ({ target, width, height, direction }: OnResize) => {
     if (!target) return;
     const s = target.style;
@@ -240,20 +232,7 @@ const Main = (props: Props, ref: Ref<HTMLDivElement>) => {
   };
 
   return (
-    <div
-      ref={ref}
-      onClick={(e) => {
-        e.stopPropagation();
-        if (!currentlyEditingThisTextSchema(e.target)) {
-          setEditing(false);
-        }
-        // For MacOS CMD+SHIFT+3/4 screenshots where the keydown event is never received, check mouse too
-        if (!e.shiftKey) {
-          setIsPressShiftKey(false);
-        }
-      }}
-      style={{ overflow: 'overlay' }}
-    >
+    <div ref={ref} style={{ overflow: 'overlay' }}>
       <Selecto
         container={paperRefs.current[pageCursor]}
         continueSelect={isPressShiftKey}
@@ -280,8 +259,15 @@ const Main = (props: Props, ref: Ref<HTMLDivElement>) => {
           if (!isClick && removed.length > 0) {
             newActiveElements = activeElements.filter((ae) => !removed.includes(ae));
           }
-
           onEdit(newActiveElements);
+
+          if (newActiveElements != activeElements) {
+            setEditing(false);
+          }
+          // For MacOS CMD+SHIFT+3/4 screenshots where the keydown event is never received, check mouse too
+          if (!inputEvent.shiftKey) {
+            setIsPressShiftKey(false);
+          }
         }}
       />
       <Paper


### PR DESCRIPTION
This appears to be due to Selecto somehow inhibiting onClick events under certain conditions (including when a textarea is in focus)

The solution was to move the logic currently in top-level onClick into Selecto.onSelect, as this is definitely called.  

https://github.com/pdfme/pdfme/assets/7068515/c975887f-9453-4c83-ab0c-35d3cb7af23d


