### PR TITLE
[FIX] Use hr instead of div for divider

### DIFF
--- a/packages/ui/src/components/Divider.tsx
+++ b/packages/ui/src/components/Divider.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const Divider = () => (
-  <div style={{ marginTop: '0.5rem', marginBottom: '0.5rem', borderBottom: '1px solid #e5e5e5' }} />
+  <hr style={{ marginTop: '0.5rem', marginBottom: '0.5rem', borderColor: '#e5e5e5' }} />
 );
 
 export default Divider;


### PR DESCRIPTION
What's changed?
- Added hr instead of div for Divider component

Why?
- [Semantically](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr) appropriate

How?
- Replacing the div tag with hr tag and retaining the border color as the default color varies according to different browsers