### PR TITLE
Add an onBlur function to SchemaUIs to allow an action when focus is lost in edit mode

### DIFF
--- a/packages/ui/src/components/Designer/Main/index.tsx
+++ b/packages/ui/src/components/Designer/Main/index.tsx
@@ -327,6 +327,7 @@ const Main = (props: Props, ref: Ref<HTMLDivElement>) => {
             onChange={(value) => {
               changeSchemas([{ key: 'data', value, schemaId: schema.id }]);
             }}
+            onBlur={() => setEditing(false)}
             outline={hoveringSchemaId === schema.id ? '1px solid #18a0fb' : '1px dashed #4af'}
             ref={inputRef}
           />

--- a/packages/ui/src/components/Designer/Main/index.tsx
+++ b/packages/ui/src/components/Designer/Main/index.tsx
@@ -327,7 +327,7 @@ const Main = (props: Props, ref: Ref<HTMLDivElement>) => {
             onChange={(value) => {
               changeSchemas([{ key: 'data', value, schemaId: schema.id }]);
             }}
-            onBlur={() => setEditing(false)}
+            onStopEditing={() => setEditing(false)}
             outline={hoveringSchemaId === schema.id ? '1px solid #18a0fb' : '1px dashed #4af'}
             ref={inputRef}
           />

--- a/packages/ui/src/components/Preview.tsx
+++ b/packages/ui/src/components/Preview.tsx
@@ -102,6 +102,7 @@ const Preview = ({ template, inputs, size, onChangeInput }: PreviewReactProps) =
               editable={editable}
               placeholder={template.sampledata?.[0]?.[key] ?? ''}
               tabIndex={index + 100}
+              onStopEditing={() => { }}
               onChange={(value) => handleChangeInput({ key, value })}
               outline={editable ? '1px dashed #4af' : 'transparent'}
             />

--- a/packages/ui/src/components/Schemas/BarcodeSchema.tsx
+++ b/packages/ui/src/components/Schemas/BarcodeSchema.tsx
@@ -69,7 +69,7 @@ const BarcodePreview = (props: { schema: BarcodeSchema; value: string }) => {
 type Props = SchemaUIProps & { schema: BarcodeSchema };
 
 const BarcodeSchemaUI = (
-  { schema, editable, placeholder, tabIndex, onChange, onBlur }: Props,
+  { schema, editable, placeholder, tabIndex, onChange, onStopEditing }: Props,
   ref: Ref<HTMLInputElement>
 ) => {
   const value = schema.data;
@@ -109,7 +109,7 @@ const BarcodeSchemaUI = (
           style={style}
           value={value}
           onChange={(e) => onChange(e.target.value)}
-          onBlur={() => (onBlur ? onBlur() : null)}
+          onBlur={onStopEditing}
         />
       ) : (
         <div style={style}>

--- a/packages/ui/src/components/Schemas/BarcodeSchema.tsx
+++ b/packages/ui/src/components/Schemas/BarcodeSchema.tsx
@@ -69,7 +69,7 @@ const BarcodePreview = (props: { schema: BarcodeSchema; value: string }) => {
 type Props = SchemaUIProps & { schema: BarcodeSchema };
 
 const BarcodeSchemaUI = (
-  { schema, editable, placeholder, tabIndex, onChange }: Props,
+  { schema, editable, placeholder, tabIndex, onChange, onBlur }: Props,
   ref: Ref<HTMLInputElement>
 ) => {
   const value = schema.data;
@@ -109,6 +109,7 @@ const BarcodeSchemaUI = (
           style={style}
           value={value}
           onChange={(e) => onChange(e.target.value)}
+          onBlur={() => (onBlur ? onBlur() : null)}
         />
       ) : (
         <div style={style}>

--- a/packages/ui/src/components/Schemas/ImageSchema.tsx
+++ b/packages/ui/src/components/Schemas/ImageSchema.tsx
@@ -8,7 +8,7 @@ import { XMarkIcon } from '@heroicons/react/24/outline';
 type Props = SchemaUIProps & { schema: ImageSchema };
 
 const ImageSchemaUI = (props: Props, ref: Ref<HTMLInputElement>) => {
-  const { editable, placeholder, tabIndex, schema, onChange, onBlur } = props;
+  const { editable, placeholder, tabIndex, schema, onChange, onStopEditing } = props;
   const [fileName, setFileName] = useState<string>('');
   const hasData = Boolean(schema.data);
 
@@ -75,7 +75,7 @@ const ImageSchemaUI = (props: Props, ref: Ref<HTMLInputElement>) => {
           onChange={(event: ChangeEvent<HTMLInputElement>) =>
             readFiles(event.target.files, 'dataURL').then((result) => onChange(result as string))
           }
-          onBlur={() => (onBlur ? onBlur() : null)}
+          onBlur={onStopEditing}
           type="file"
           accept="image/jpeg, image/png"
         />

--- a/packages/ui/src/components/Schemas/ImageSchema.tsx
+++ b/packages/ui/src/components/Schemas/ImageSchema.tsx
@@ -8,7 +8,7 @@ import { XMarkIcon } from '@heroicons/react/24/outline';
 type Props = SchemaUIProps & { schema: ImageSchema };
 
 const ImageSchemaUI = (props: Props, ref: Ref<HTMLInputElement>) => {
-  const { editable, placeholder, tabIndex, schema, onChange } = props;
+  const { editable, placeholder, tabIndex, schema, onChange, onBlur } = props;
   const [fileName, setFileName] = useState<string>('');
   const hasData = Boolean(schema.data);
 
@@ -75,6 +75,7 @@ const ImageSchemaUI = (props: Props, ref: Ref<HTMLInputElement>) => {
           onChange={(event: ChangeEvent<HTMLInputElement>) =>
             readFiles(event.target.files, 'dataURL').then((result) => onChange(result as string))
           }
+          onBlur={() => (onBlur ? onBlur() : null)}
           type="file"
           accept="image/jpeg, image/png"
         />

--- a/packages/ui/src/components/Schemas/SchemaUI.tsx
+++ b/packages/ui/src/components/Schemas/SchemaUI.tsx
@@ -9,7 +9,7 @@ export interface SchemaUIProps {
   schema: SchemaForUI;
   editable: boolean;
   onChange: (value: string) => void;
-  onBlur?: () => void;
+  onStopEditing: () => void;
   tabIndex?: number;
   placeholder?: string;
 }

--- a/packages/ui/src/components/Schemas/SchemaUI.tsx
+++ b/packages/ui/src/components/Schemas/SchemaUI.tsx
@@ -9,6 +9,7 @@ export interface SchemaUIProps {
   schema: SchemaForUI;
   editable: boolean;
   onChange: (value: string) => void;
+  onBlur?: () => void;
   tabIndex?: number;
   placeholder?: string;
 }

--- a/packages/ui/src/components/Schemas/TextSchema.tsx
+++ b/packages/ui/src/components/Schemas/TextSchema.tsx
@@ -17,7 +17,7 @@ import { FontContext } from '../../contexts';
 type Props = SchemaUIProps & { schema: TextSchema };
 
 const TextSchemaUI = (
-  { schema, editable, placeholder, tabIndex, onChange }: Props,
+  { schema, editable, placeholder, tabIndex, onChange, onBlur }: Props,
   ref: Ref<HTMLTextAreaElement>
 ) => {
   const font = useContext(FontContext);
@@ -97,6 +97,7 @@ const TextSchemaUI = (
       tabIndex={tabIndex}
       style={style}
       onChange={(e) => onChange(e.target.value)}
+      onBlur={() => (onBlur ? onBlur() : null)}
       value={schema.data}
     ></textarea>
   ) : (

--- a/packages/ui/src/components/Schemas/TextSchema.tsx
+++ b/packages/ui/src/components/Schemas/TextSchema.tsx
@@ -17,7 +17,7 @@ import { FontContext } from '../../contexts';
 type Props = SchemaUIProps & { schema: TextSchema };
 
 const TextSchemaUI = (
-  { schema, editable, placeholder, tabIndex, onChange, onBlur }: Props,
+  { schema, editable, placeholder, tabIndex, onChange, onStopEditing }: Props,
   ref: Ref<HTMLTextAreaElement>
 ) => {
   const font = useContext(FontContext);
@@ -97,7 +97,7 @@ const TextSchemaUI = (
       tabIndex={tabIndex}
       style={style}
       onChange={(e) => onChange(e.target.value)}
-      onBlur={() => (onBlur ? onBlur() : null)}
+      onBlur={onStopEditing}
       value={schema.data}
     ></textarea>
   ) : (


### PR DESCRIPTION
fixes #240 

Instead of trying to catch every other element that you might click to cancel editing, use the onBlur method of the element you are leaving to take it out of edit mode. 

This means that it doesn't matter where you click when leaving the focus of the textbox or textarea, it will be properly deselected for the next time you click it.

Questions:
* is `onBlur` a good name for the prop? Would it be better as `onStopEditing()` or similar?
* Is it better to make it an optional prop and check it exists before using it, or make it required and pass an empty function when used in `<Preview>`?