### PR TITLE
MISC - TextSchema.tsx updated to fix textarea jump issue

### DIFF
--- a/packages/ui/__tests__/components/__snapshots__/Preview.test.tsx.snap
+++ b/packages/ui/__tests__/components/__snapshots__/Preview.test.tsx.snap
@@ -86,6 +86,7 @@ exports[`Preview(as Form) snapshot 1`] = `
             >
               <textarea
                 placeholder="bb"
+                rows="1"
                 style="padding: 3.436640625px 0px 0px 0px; resize: none; outline: none; background: none; font-family: inherit; color: rgb(0, 0, 0); font-size: 30pt; letter-spacing: 0pt; line-height: 1em; text-align: left; white-space: pre-wrap; word-break: break-word;"
                 tabindex="100"
               >

--- a/packages/ui/src/components/Schemas/TextSchema.tsx
+++ b/packages/ui/src/components/Schemas/TextSchema.tsx
@@ -144,6 +144,7 @@ const TextSchemaUI = (
     <div style={containerStyle}>
       <textarea
         ref={ref}
+        rows={1}
         placeholder={placeholder}
         tabIndex={tabIndex}
         style={{ ...textareaStyle, ...fontStyles }}
@@ -162,7 +163,7 @@ const TextSchemaUI = (
         }}
       >
         {/*  Set the letterSpacing of the last character to 0. */}
-        {schema.data.split('').map((l, i) => (
+        {schema.data.split('').map((l: string, i: number) => (
           <span key={i} style={{ letterSpacing: String(schema.data).length === i + 1 ? 0 : 'inherit' }}>
             {l}
           </span>


### PR DESCRIPTION
- rows={1} added in to fix an issue where textarea content jumps when switching between edit modes. 
- Test snapshots updated

**Before**

https://github.com/pdfme/pdfme/assets/45564901/d3625d33-947b-4746-b766-e623882dbd9d




**After**

https://github.com/pdfme/pdfme/assets/45564901/7f08d3a2-97f5-4a73-9b4a-3b2d1d96ea75
