### PR TITLE
Improve checkFont to adjust provided input rather than fatal Error

### DIFF
--- a/packages/common/__tests__/font.test.ts
+++ b/packages/common/__tests__/font.test.ts
@@ -100,9 +100,8 @@ describe('checkFont test', () => {
 
     const font = getFont();
     checkFont({ template: getTemplate(), font });
-    const expectedFont = getFont();
-    expectedFont.SauceHanSansJP.fallback = true;
-    expect(font).toEqual(expectedFont);
+    expect(font.SauceHanSansJP.fallback).toEqual(true);
+    expect(font.SauceHanSerifJP.fallback).toBeUndefined();
   });
 
   test('fonts updated to remove a fallback', () => {
@@ -113,9 +112,8 @@ describe('checkFont test', () => {
 
     const font = getFont();
     checkFont({ template: getTemplate(), font });
-    const expectedFont = getFont();
-    expectedFont.SauceHanSerifJP.fallback = false;
-    expect(font).toEqual(expectedFont);
+    expect(font.SauceHanSansJP.fallback).toEqual(true);
+    expect(font.SauceHanSerifJP.fallback).toEqual(false);
   });
 
   test('schema font updated to use fallback if not found in provided fonts', () => {

--- a/packages/common/src/font.ts
+++ b/packages/common/src/font.ts
@@ -25,7 +25,7 @@ export const getFallbackFontName = (font: Font) => {
     return !acc && fontValue.fallback ? fontName : acc;
   }, initial);
   if (fallbackFontName === initial) {
-    throw Error(`fallback flag is not found in font. true fallback flag must be only one.`);
+    throw Error(`no fallback flag is set for provided fonts, you must set (only) one.`);
   }
 
   return fallbackFontName;

--- a/packages/generator/__tests__/generate.test.ts
+++ b/packages/generator/__tests__/generate.test.ts
@@ -250,7 +250,8 @@ ERROR MESSAGE: Array must contain at least 1 element(s)
 --------------------------`);
     }
   });
-  test(`missing fallback font`, async () => {
+
+  test(`missing fallback font is set`, async () => {
     const inputs = [{ a: 'test' }];
     const template: Template = {
       basePdf: BLANK_PDF,
@@ -268,14 +269,9 @@ ERROR MESSAGE: Array must contain at least 1 element(s)
     const font = getFont();
     font.SauceHanSansJP.fallback = false;
     font.SauceHanSerifJP.fallback = false;
-    try {
-      await generate({ inputs, template, options: { font } });
-      fail();
-    } catch (e: any) {
-      expect(e.message).toEqual(
-        'fallback flag is not found in font. true fallback flag must be only one.'
-      );
-    }
+    await generate({ inputs, template, options: { font } });
+    expect(font.SauceHanSansJP.fallback).toEqual(true);
+    expect(font.SauceHanSerifJP.fallback).toEqual(false);
   });
   test(`too many fallback font`, async () => {
     const inputs = [{ a: 'test' }];
@@ -295,14 +291,9 @@ ERROR MESSAGE: Array must contain at least 1 element(s)
     const font = getFont();
     font.SauceHanSansJP.fallback = true;
     font.SauceHanSerifJP.fallback = true;
-    try {
-      await generate({ inputs, template, options: { font } });
-      fail();
-    } catch (e: any) {
-      expect(e.message).toEqual(
-        '2 fallback flags found in font. true fallback flag must be only one.'
-      );
-    }
+    await generate({ inputs, template, options: { font } });
+    expect(font.SauceHanSansJP.fallback).toEqual(true);
+    expect(font.SauceHanSerifJP.fallback).toEqual(false);
   });
   test(`missing font in template.schemas`, async () => {
     const inputs = [{ a: 'test' }];
@@ -312,7 +303,7 @@ ERROR MESSAGE: Array must contain at least 1 element(s)
         {
           a: {
             type: 'text',
-            fontName: 'SauceHanSansJP2',
+            fontName: 'MissingFont',
             position: { x: 0, y: 0 },
             width: 100,
             height: 100,
@@ -326,12 +317,9 @@ ERROR MESSAGE: Array must contain at least 1 element(s)
         },
       ],
     };
-    try {
-      await generate({ inputs, template, options: { font: getFont() } });
-      fail();
-    } catch (e: any) {
-      expect(e.message).toEqual('SauceHanSansJP2 of template.schemas is not found in font.');
-    }
+    await generate({ inputs, template, options: { font: getFont() } });
+    // @ts-ignore
+    expect(template.schemas[0].a.fontName).toEqual('SauceHanSansJP');
   });
 
   test(`check digit error`, async () => {


### PR DESCRIPTION
implements #269 

Instead of throwing Errors when the input doesn't work, adjust the schema or font settings so that it the situation can recover.

If no font is, or too many are, set as default then we can adjust this and continue processing (with a warning).
Similarly, once we have a fallback set we can use it when a font is missing rather than being unrecoverable.