### PR TITLE
Sets the button type to "button"

### DIFF
--- a/packages/ui/__tests__/components/__snapshots__/Designer.test.tsx.snap
+++ b/packages/ui/__tests__/components/__snapshots__/Designer.test.tsx.snap
@@ -75,6 +75,7 @@ exports[`Designer snapshot 1`] = `
       >
         <button
           style="position: absolute; top: 1.75rem; right: 0.5rem; z-index: 100; border-radius: 2px; padding: 0.5rem; cursor: pointer; background: rgb(238, 238, 238); width: 30px; height: 30px;"
+          type="button"
         >
           <svg
             aria-hidden="true"
@@ -216,6 +217,7 @@ exports[`Designer snapshot 1`] = `
             />
             <button
               style="padding: 0.5rem; background: rgb(24, 160, 251); border-radius: 2px; cursor: pointer; margin: 0px auto; display: block;"
+              type="button"
             >
               <strong
                 style="color: rgb(255, 255, 255);"

--- a/packages/ui/src/components/Designer/Sidebar/index.tsx
+++ b/packages/ui/src/components/Designer/Sidebar/index.tsx
@@ -45,6 +45,7 @@ const Sidebar = (props: SidebarProps) => {
     >
       <div style={{ position: 'sticky', top: 0, zIndex: 1, fontSize: '1rem' }}>
         <button
+          type="button"
           style={{
             position: 'absolute',
             top: '1.75rem',
@@ -101,6 +102,7 @@ const Sidebar = (props: SidebarProps) => {
           >
             <div style={{ marginBottom: '1rem', borderBottom: '1px solid #e5e5e5' }} />
             <button
+              type="button"
               style={{
                 padding: '0.5rem',
                 background: '#18a0fb',


### PR DESCRIPTION
**Problem**

When the designer is embedded in a form element, clicking on the sidebar expand `>` button or the "Add new field" button submits the form.

**Proposed solution**

When the buttons are declared as `type="button"` clicking does not trigger a form submit.