### PR TITLE
Reorganise text render props for wider font name field

### DIFF
--- a/packages/schemas/src/text/propPanel.ts
+++ b/packages/schemas/src/text/propPanel.ts
@@ -63,8 +63,16 @@ export const propPanel: PropPanel<TextSchema> = {
         widget: 'select',
         default: fallbackFontName,
         props: { options: fontNames.map((name) => ({ label: name, value: name })) },
-        span: 8,
+        span: 12,
       },
+      fontSize: {
+        title: 'Size',
+        type: 'number',
+        widget: 'inputNumber',
+        span: 6,
+        disabled: enableDynamicFont,
+      },
+      characterSpacing: { title: 'Spacing', type: 'number', widget: 'inputNumber', span: 6 },
       alignment: {
         title: 'Text Align',
         type: 'string',
@@ -91,15 +99,7 @@ export const propPanel: PropPanel<TextSchema> = {
         },
         span: 8,
       },
-      fontSize: {
-        title: 'Font Size',
-        type: 'number',
-        widget: 'inputNumber',
-        span: 8,
-        disabled: enableDynamicFont,
-      },
       lineHeight: { title: 'Line Height', type: 'number', widget: 'inputNumber', span: 8 },
-      characterSpacing: { title: 'Char Spc', type: 'number', widget: 'inputNumber', span: 8 },
       useDynamicFontSize: { type: 'boolean', widget: 'UseDynamicFontSize', bind: false },
       dynamicFontSize: {
         type: 'object',


### PR DESCRIPTION
Improves #285:

<img width="358" alt="Screenshot 2023-10-23 at 16 26 21" src="https://github.com/pdfme/pdfme/assets/7068515/5805ebd4-a56b-45d3-9741-c358ef760390">
