### PR TITLE
Fix layout for multi-page PDFs in the Designer

### DIFF
--- a/packages/ui/__tests__/components/__snapshots__/Preview.test.tsx.snap
+++ b/packages/ui/__tests__/components/__snapshots__/Preview.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`Preview(as Form) snapshot 1`] = `
       >
         <div
           id="@pdfme/ui-paper0"
-          style="font-family: 'Roboto'; top: 30px; left: 203.14960629450002px; position: relative; background-image: url(data:image/png;base64,a...); background-size: 793.700787411px 1122.5196850527px; width: 793.700787411px; height: 1122.5196850527px;"
+          style="font-family: 'Roboto'; top: 0px; left: 203.14960629450002px; position: relative; background-image: url(data:image/png;base64,a...); background-size: 793.700787411px 1122.5196850527px; width: 793.700787411px; height: 1122.5196850527px;"
         >
           <div>
             <div
@@ -208,7 +208,7 @@ exports[`Preview(as Viewer) snapshot 1`] = `
       >
         <div
           id="@pdfme/ui-paper0"
-          style="font-family: 'Roboto'; top: 30px; left: 203.14960629450002px; position: relative; background-image: url(data:image/png;base64,a...); background-size: 793.700787411px 1122.5196850527px; width: 793.700787411px; height: 1122.5196850527px;"
+          style="font-family: 'Roboto'; top: 0px; left: 203.14960629450002px; position: relative; background-image: url(data:image/png;base64,a...); background-size: 793.700787411px 1122.5196850527px; width: 793.700787411px; height: 1122.5196850527px;"
         >
           <div>
             <div

--- a/packages/ui/src/components/Designer/Canvas/index.tsx
+++ b/packages/ui/src/components/Designer/Canvas/index.tsx
@@ -306,6 +306,7 @@ const Canvas = (props: Props, ref: Ref<HTMLDivElement>) => {
         schemasList={schemasList}
         pageSizes={pageSizes}
         backgrounds={backgrounds}
+        hasRulers={true}
         renderPaper={({ index, paperSize }) => (
           <>
             {!editing && activeElements.length > 0 && (
@@ -325,7 +326,10 @@ const Canvas = (props: Props, ref: Ref<HTMLDivElement>) => {
               }}
             />
             {pageCursor !== index ? (
-              <Mask width={paperSize.width + RULER_HEIGHT} height={paperSize.height} />
+              <Mask
+                width={paperSize.width + RULER_HEIGHT}
+                height={paperSize.height + RULER_HEIGHT}
+              />
             ) : (
               !editing && (
                 <Moveable

--- a/packages/ui/src/components/Paper.tsx
+++ b/packages/ui/src/components/Paper.tsx
@@ -1,7 +1,7 @@
 import React, { MutableRefObject, ReactNode, useContext } from 'react';
 import { ZOOM, SchemaForUI, Size, getFallbackFontName } from '@pdfme/common';
 import { FontContext } from '../contexts';
-import { RULER_HEIGHT } from '../constants';
+import { RULER_HEIGHT, PAGE_GAP } from '../constants';
 
 const Paper = (props: {
   paperRefs: MutableRefObject<HTMLDivElement[]>;
@@ -12,10 +12,21 @@ const Paper = (props: {
   backgrounds: string[];
   renderPaper?: (arg: { index: number; paperSize: Size }) => ReactNode;
   renderSchema: (arg: { index: number; schema: SchemaForUI }) => ReactNode;
+  hasRulers?: boolean;
 }) => {
-  const { paperRefs, scale, size, schemasList, pageSizes, backgrounds, renderPaper, renderSchema } =
-    props;
+  const {
+    paperRefs,
+    scale,
+    size,
+    schemasList,
+    pageSizes,
+    backgrounds,
+    renderPaper,
+    renderSchema,
+    hasRulers,
+  } = props;
   const font = useContext(FontContext);
+  const rulerHeight = hasRulers ? RULER_HEIGHT : 0;
 
   if (pageSizes.length !== backgrounds.length || pageSizes.length !== schemasList.length) {
     return null;
@@ -41,9 +52,13 @@ const Paper = (props: {
         // However, we want to display the content centrally, so we apply a left indent for
         // when the content does not exceed its container
         const leftCenteringIndent =
-          paperSize.width * scale + RULER_HEIGHT < size.width
+          paperSize.width * scale + rulerHeight < size.width
             ? `${(size.width / scale - paperSize.width) / 2}px`
-            : `${RULER_HEIGHT}px`;
+            : `${rulerHeight}px`;
+
+        // Rulers are drawn above/before the top of each page, so we place the start of the page below them
+        const pageTop =
+          paperIndex > 0 ? `${(rulerHeight + PAGE_GAP) * (paperIndex + 1)}px` : `${rulerHeight}px`;
 
         return (
           <div
@@ -66,7 +81,7 @@ const Paper = (props: {
             }}
             style={{
               fontFamily: `'${getFallbackFontName(font)}'`,
-              top: `${RULER_HEIGHT}px`,
+              top: pageTop,
               left: leftCenteringIndent,
               position: 'relative',
               backgroundImage: `url(${background})`,

--- a/packages/ui/src/constants.ts
+++ b/packages/ui/src/constants.ts
@@ -6,4 +6,6 @@ export const SELECTABLE_CLASSNAME = 'selectable';
 
 export const RULER_HEIGHT = 30;
 
+export const PAGE_GAP = 10;
+
 export const SIDEBAR_WIDTH = 350;


### PR DESCRIPTION
fixes #155 
- ensure pages do not overlap
- add a small gap between pages
- place the mask correctly over each page

BEFORE:
![Screenshot 2023-10-27 at 13 44 47](https://github.com/pdfme/pdfme/assets/7068515/66f4f99e-6630-45c4-8cc5-c22faa8d3c73)


AFTER:
![Screenshot 2023-10-27 at 13 43 23](https://github.com/pdfme/pdfme/assets/7068515/6fb62203-ad33-4340-9cf1-983dec02f1c8)

