### PR TITLE
Adds automated publishing workflow to NPM

### DIFF
--- a/.github/workflows/publish-commit.yml
+++ b/.github/workflows/publish-commit.yml
@@ -1,0 +1,42 @@
+# .github/workflows/publish-commit.yml
+name: Publish Commit
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Increment version and append git hash
+        run: ./scripts/increment-version.sh
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Set NPM version
+        run: npm version --no-git-tag-version $VERSION
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm run test
+        env:
+          CI: true
+        
+      - name: Publish to NPM
+        run: npm publish --workspaces --access public --tag dev
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,44 @@
+# .github/workflows/publish-release.yml
+name: Publish Release
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Set NPM version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          npm version $VERSION --no-git-tag-version
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm run test
+        env:
+          CI: true
+
+      - name: Determine NPM tag
+        run: ./scripts/determine-npm-tag.sh
+
+      - name: Publish to NPM
+        run: npm publish --workspaces --access public --tag ${{ env.NPM_TAG }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Unit Testing
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ npm i @pdfme/ui @pdfme/common
 
 \*You must install `@pdfme/common` regardless of which package you use.
 
+On NPM stable releases are published to the `latest` tag, and pre-releases are published to the `next` tag.
+On the `dev` tag you can find releases for every commit to the `main` branch.
+
 The following type, function and classes are available in pdfme.
 
 `@pdfme/common`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,22 @@
-npm version x.x.x --workspaces  
-git add .  
-git commit -m "Update version to x.x.x"  
-npm run build  
-npm publish --workspaces <!--or npm publish --tag beta --workspaces -->  
-git tag x.x.x  
-git push origin x.x.x
+# How to release and publish
+
+To create a new release on NPM, follow these steps:
+
+1. Create a new tag of the form `x.y.z`.
+2. Push the tag to GitHub.
+3. Wait for the CI to finish.
+
+The following tag naming is supported:
+
+- `x.y.z` for stable releases
+- `x.y.z-rc.n` for release candidates
+- `x.y.z-beta.n` for beta releases
+- `x.y.z-alpha.n` for alpha releases
+
+The CI will automatically publish the release to NPM if the tag is of the form `x.y.z`, and will publish the release to the `next` tag on NPM if the tag is of the form `x.y.z-rc.n`, `x.y.z-beta.n` or `x.y.z-alpha.n`.
+
+Additonally the CI creates releases to the `dev` tag on NPM for every commit to the `main` branch.
+Releases to the `dev` tag follow the following naming scheme: 
+
+- `x.y.z-dev.n`, where `x.y.z` is the version of the last stable release and `n` is the number of commits since the last stable release.
+- `x.y.z-[rc|beta|alpha].n-dev.m`, where `x.y.z-[rc|beta|alpha].n` is the version of the last pre-release and `m` is the number of commits since the last pre-release.

--- a/scripts/determine-npm-tag.sh
+++ b/scripts/determine-npm-tag.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Get the tag from the GITHUB_REF environment variable
+VERSION=${GITHUB_REF#refs/tags/}
+
+# Determine the NPM tag based on the GitHub tag
+if [[ $VERSION == *"-alpha"* ]]; then
+  echo "NPM_TAG=next" >> $GITHUB_ENV
+elif [[ $VERSION == *"-beta"* ]]; then
+  echo "NPM_TAG=next" >> $GITHUB_ENV
+elif [[ $VERSION == *"-rc"* ]]; then
+  echo "NPM_TAG=next" >> $GITHUB_ENV
+else
+  echo "NPM_TAG=latest" >> $GITHUB_ENV
+fi

--- a/scripts/increment-version.sh
+++ b/scripts/increment-version.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Extract the latest tag name
+LATEST_TAG=$(git describe --tags --abbrev=0)
+
+# Extract the base version and pre-release identifier from the latest tag
+if [[ $LATEST_TAG =~ ([0-9]+\.[0-9]+\.[0-9]+)(-(alpha|beta|rc)\.([0-9]+))? ]]; then
+    BASE_VERSION=${BASH_REMATCH[1]}
+    PRE_ID=${BASH_REMATCH[3]}
+    PRE_NUM=${BASH_REMATCH[4]}
+else
+    echo "Error: Unable to parse the latest tag name." >&2
+    exit 1
+fi
+
+# Determine the dev iteration number based on the commit count since the last tag
+DEV_ITERATION=$(git rev-list ${LATEST_TAG}..HEAD --count)
+
+# Construct the new version string
+if [[ -n $PRE_ID ]]; then
+    # If there is a pre-release identifier (alpha, beta, rc)
+    NEW_VERSION="${BASE_VERSION}-${PRE_ID}.${PRE_NUM}-dev.${DEV_ITERATION}"
+else
+    # If there is no pre-release identifier
+    NEW_VERSION="${BASE_VERSION}-dev.${DEV_ITERATION}"
+fi
+
+# Output the new version string
+echo "VERSION=$NEW_VERSION" >> $GITHUB_ENV


### PR DESCRIPTION
This pull request introduces an automated publishing workflow to NPM for the multiple packages included in this repository.

The motivation behind this PR is to simplify the use of the multiple NPM packages in this repository through NPM. In the release documentation it seemed to me that the publishing process so far was manual, and I thought automation will allow publishing of NPM packages more frequently.

The publishing process is triggered by creating a Git tag and it distinguishs between stable releases and pre-releases by publishing to different NPM channels. 
Additionally, the CI creates releases to the `dev` channel on NPM for every commit to the main branch, so it's easy to stay up-to-date with the latest development.

I tested the workflow successfully until the actual publishing to NPM, which requires to configure a NPM Authentication Token name `NPM_TOKEN` as Github secret.