### PR TITLE
Fix barcode cache key to capture uniqueness properly

### DIFF
--- a/packages/schemas/src/barcodes/pdfRender.ts
+++ b/packages/schemas/src/barcodes/pdfRender.ts
@@ -1,5 +1,5 @@
 import { PDFRenderProps } from '@pdfme/common';
-import { getCacheKey, convertForPdfLayoutProps } from '../renderUtils';
+import { convertForPdfLayoutProps } from '../renderUtils';
 import type { BarcodeSchema } from './types';
 import { createBarCode, validateBarcodeInput } from './helper';
 
@@ -7,7 +7,7 @@ export const pdfRender = async (arg: PDFRenderProps<BarcodeSchema>) => {
   const { value, schema, pdfDoc, page, _cache } = arg;
   if (!validateBarcodeInput(schema.type, value)) return;
 
-  const inputBarcodeCacheKey = getCacheKey(schema, value);
+  const inputBarcodeCacheKey = getBarcodeCacheKey(schema, value);
   let image = _cache.get(inputBarcodeCacheKey);
   if (!image) {
     const imageBuf = await createBarCode(
@@ -27,3 +27,7 @@ export const pdfRender = async (arg: PDFRenderProps<BarcodeSchema>) => {
 
   page.drawImage(image, { x, y, rotate, width, height });
 };
+
+const getBarcodeCacheKey = (schema: BarcodeSchema, value: string) => {
+  return `${schema.type}${schema.backgroundColor}${schema.barColor}${schema.textColor}${value}`;
+}

--- a/website/docs/custom-schemas.md
+++ b/website/docs/custom-schemas.md
@@ -146,3 +146,15 @@ Specifically, it should be possible to input the signature using [signature_pad]
 
 - Demo: https://playground.pdfme.com/
 - Code: [pdfme-playground/src/plugins/signature.ts](https://github.com/pdfme/pdfme-playground/blob/main/src/plugins/signature.ts)
+
+
+### Caveats for writing Custom Schemas
+
+#### Renderer schema caching
+
+pdfme supports caching of memory or cpu-intensive content so that it can be re-used within the same rendering process.
+
+The most common use-case for this is when you're rendering a large number of PDFs with the same template. Often these
+inputs might be the same and your schema could benefit from caching them. This is optional, but if you're intending for your custom schema to be used by others then you should consider it.
+
+Examples of caching are available in both [image](https://github.com/pdfme/pdfme/blob/main/packages/schemas/src/image/pdfRender.ts) and [barcode](https://github.com/pdfme/pdfme/blob/main/packages/schemas/src/barcodes/pdfRender.ts) schema render functions. You will need to choosing a caching key that captures the uniqueness of your generated PDF artifact (excluding attributes such as size and position, which are usually handled by pdf-lib on rendering). You will notice in the barcode schema that it requires more attributes to describe it's uniqueness compare to images which use the default `getCacheKey` function.


### PR DESCRIPTION
I went for a simple solution of just editing the barcode code. 

Since we only have 2 types of cacheable schemas right now, doing anything more complicated seemed like over-engineering at this point.

Let me know what you think @hand-dot 