### PR TITLE
Add types to package exports

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -28,7 +28,8 @@
   "exports": {
     ".": {
       "import": "./dist/esm/src/index.js",
-      "require": "./dist/cjs/src/index.js"
+      "require": "./dist/cjs/src/index.js",
+      "types": "./dist/types/src/index.d.ts"
     }
   },
   "engines": {

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -28,7 +28,8 @@
   "exports": {
     ".": {
       "import": "./dist/esm/src/index.js",
-      "require": "./dist/cjs/src/index.js"
+      "require": "./dist/cjs/src/index.js",
+      "types": "./dist/types/src/index.d.ts"
     }
   },
   "engines": {

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -28,7 +28,8 @@
   "exports": {
     ".": {
       "import": "./dist/esm/src/index.js",
-      "require": "./dist/cjs/src/index.js"
+      "require": "./dist/cjs/src/index.js",
+      "types": "./dist/types/src/index.d.ts"
     }
   },
   "engines": {


### PR DESCRIPTION
This PR adds types to package exports where "exports" are defined.

This fixes issues when using the packages with moduleResolution set to "bundler" in tsconfig like Next.js defaults to.

More info on how the resolution is affected is available here: https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports

To reproduce the error you can:
Create a new Next.js app `npx create-next-app@latest`
Install pdfme common package `npm i @pdfme/common`
Attempt to `import { BLANK_PDF } from '@pdfme/common'`

You should see the following error:

<img width="587" alt="Screenshot 2023-11-10 at 12 41 29" src="https://github.com/pdfme/pdfme/assets/1162399/bc7dc3f1-da73-4cc9-a760-e1889b951e01">
