### PR TITLE
remove React.StrictMode in playground to avoid full rerender on screen resize

### DIFF
--- a/playground/src/index.tsx
+++ b/playground/src/index.tsx
@@ -10,12 +10,10 @@ import Navigation from "./Navigation";
 const container = document.getElementById('root')!;
 const root = createRoot(container);
 root.render(
-  <React.StrictMode>
-    <BrowserRouter>
-      <Navigation />
-      <Routes>
-        <Route path="/" element={<Designer />}></Route>
-        <Route path="/form-viewer" element={<FormAndViewer />}></Route>
-      </Routes>
-    </BrowserRouter>
-  </React.StrictMode>);
+  <BrowserRouter>
+    <Navigation />
+    <Routes>
+      <Route path="/" element={<Designer />}></Route>
+      <Route path="/form-viewer" element={<FormAndViewer />}></Route>
+    </Routes>
+  </BrowserRouter>);


### PR DESCRIPTION
See #347, but there might be a better way...