### PR TITLE
Client-side validation added for HEX colour codes

### DIFF
--- a/packages/schemas/src/text/propPanel.ts
+++ b/packages/schemas/src/text/propPanel.ts
@@ -142,8 +142,30 @@ export const propPanel: PropPanel<TextSchema> = {
           },
         },
       },
-      fontColor: { title: i18n('schemas.textColor'), type: 'string', widget: 'color' },
-      backgroundColor: { title: i18n('schemas.bgColor'), type: 'string', widget: 'color' },
+      fontColor: {
+        title: i18n('schemas.textColor'),
+        type: 'string',
+        widget: 'color',
+        rules: [
+          {
+            // Pattern to support hex color codes with alpha channel and shorthand hex color codes
+            pattern: '^#(?:[A-Fa-f0-9]{3,4}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$',
+            message: 'Please enter a valid hex color code.',
+          },
+        ],
+      },
+      backgroundColor: {
+        title: i18n('schemas.bgColor'),
+        type: 'string',
+        widget: 'color',
+        rules: [
+          {
+            // Pattern to support hex color codes with alpha channel and shorthand hex color codes
+            pattern: '^#(?:[A-Fa-f0-9]{3,4}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$',
+            message: 'Please enter a valid hex color code.',
+          },
+        ],
+      },
     };
 
     return textSchema;


### PR DESCRIPTION
- Some client-side validation has been added to both the `Text Color` and `Background Color` fields in the UI. 
- The validation check will check HEX colour codes to see if they contain a valid HEX shorthand code, general HEX code (6 digits between [0 -9] and [A-F], as well as accounting for alpha transparency in HEX codes (8 digits [0-9] & [A-F]

