### PR TITLE
Refactor to remove inefficient useEffect with side effects

### DIFF
--- a/packages/ui/src/class.ts
+++ b/packages/ui/src/class.ts
@@ -89,10 +89,10 @@ export abstract class BaseUIClass {
     this.template = generateColumnsAndSampledataIfNeeded(cloneDeep(template));
     this.options = options;
     this.size = {
-      height: this.domContainer!.clientHeight || window.innerHeight,
-      width: this.domContainer!.clientWidth || window.innerWidth,
+      height: this.domContainer.clientHeight || window.innerHeight,
+      width: this.domContainer.clientWidth || window.innerWidth,
     };
-    this.resizeObserver.observe(this.domContainer!);
+    this.resizeObserver.observe(this.domContainer);
 
     const { lang, font } = options;
     if (lang) {

--- a/packages/ui/src/components/Designer/index.tsx
+++ b/packages/ui/src/components/Designer/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect, useContext, useCallback } from 'react';
+import React, {useRef, useState, useEffect, useContext, useCallback, useMemo} from 'react';
 import {
   ZOOM,
   Template,
@@ -49,6 +49,7 @@ const TemplateEditor = ({
   const [pageCursor, setPageCursor] = useState(0);
   const [zoomLevel, setZoomLevel] = useState(1);
   const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [prevTemplate, setPrevTemplate] = useState<Template | null>(null);
 
   const { backgrounds, pageSizes, scale, error } = useUIPreProcessor({ template, size, zoomLevel });
 
@@ -148,10 +149,6 @@ const TemplateEditor = ({
     }
   }, []);
 
-  useEffect(() => {
-    updateTemplate(template);
-  }, [template, updateTemplate]);
-
   const addSchema = () => {
     const propPanel = (Object.values(pluginsRegistry)[0] as Plugin<Schema>)?.propPanel;
 
@@ -182,6 +179,11 @@ Check this document: https://pdfme.com/docs/custom-schemas`);
   const onChangeHoveringSchemaId = (id: string | null) => {
     setHoveringSchemaId(id);
   };
+
+  if (prevTemplate !== template) {
+    setPrevTemplate(template);
+    void updateTemplate(template);
+  }
 
   const sizeExcSidebar = {
     width: sidebarOpen ? size.width - SIDEBAR_WIDTH : size.width,

--- a/packages/ui/src/components/Designer/index.tsx
+++ b/packages/ui/src/components/Designer/index.tsx
@@ -1,4 +1,4 @@
-import React, {useRef, useState, useEffect, useContext, useCallback, useMemo} from 'react';
+import React, { useRef, useState, useContext, useCallback } from 'react';
 import {
   ZOOM,
   Template,

--- a/playground/src/Designer.tsx
+++ b/playground/src/Designer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { Template, checkTemplate, Lang } from "@pdfme/common";
 import { Designer } from "@pdfme/ui";
 import {
@@ -18,8 +18,9 @@ function App() {
   const designerRef = useRef<HTMLDivElement | null>(null);
   const designer = useRef<Designer | null>(null);
   const [lang, setLang] = useState<Lang>('en');
+  const [prevDesignerRef, setPrevDesignerRef] = useState<Designer | null>(null);
 
-  useEffect(() => {
+  const buildDesigner = () => {
     let template: Template = getTemplate();
     try {
       const templateString = localStorage.getItem("template");
@@ -55,12 +56,7 @@ function App() {
         designer.current.onSaveTemplate(onSaveTemplate);
       }
     });
-    return () => {
-      if (designer.current) {
-        designer.current.destroy();
-      }
-    };
-  }, [designerRef]);
+  }
 
   const onChangeBasePDF = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target && e.target.files) {
@@ -99,6 +95,14 @@ function App() {
       localStorage.removeItem("template");
     }
   };
+
+  if (designerRef != prevDesignerRef) {
+    if (prevDesignerRef && designer.current) {
+      designer.current.destroy();
+    }
+    buildDesigner();
+    setPrevDesignerRef(designerRef);
+  }
 
   return (
     <div>

--- a/playground/src/FormAndViewer.tsx
+++ b/playground/src/FormAndViewer.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { Template, checkTemplate } from "@pdfme/common";
-import {Designer, Form, Viewer} from "@pdfme/ui";
+import { Form, Viewer } from "@pdfme/ui";
 import {
   getFontsData,
   getTemplate,

--- a/playground/src/FormAndViewer.tsx
+++ b/playground/src/FormAndViewer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Template, checkTemplate } from "@pdfme/common";
-import { Form, Viewer } from "@pdfme/ui";
+import {Designer, Form, Viewer} from "@pdfme/ui";
 import {
   getFontsData,
   getTemplate,
@@ -32,12 +32,14 @@ const initTemplate = () => {
 function App() {
   const uiRef = useRef<HTMLDivElement | null>(null);
   const ui = useRef<Form | Viewer | null>(null);
+  const [prevUiRef, setPrevUiRef] = useState<Form | Viewer | null>(null);
+
 
   const [mode, setMode] = useState<Mode>(
     (localStorage.getItem("mode") as Mode) ?? "form"
   );
 
-  useEffect(() => {
+  const buildUi = () => {
     const template = initTemplate();
     let inputs = template.sampledata ?? [{}];
     try {
@@ -69,13 +71,7 @@ function App() {
         });
       }
     });
-
-    return () => {
-      if (ui.current) {
-        ui.current.destroy();
-      }
-    };
-  }, [uiRef, mode]);
+  };
 
   const onChangeMode = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value as Mode;
@@ -119,6 +115,14 @@ function App() {
       ui.current.setInputs(template.sampledata ?? [{}]);
     }
   };
+
+  if (uiRef != prevUiRef) {
+    if (prevUiRef && ui.current) {
+      ui.current.destroy();
+    }
+    buildUi();
+    setPrevUiRef(uiRef);
+  }
 
   return (
     <div>

--- a/website/src/pages/template-design.tsx
+++ b/website/src/pages/template-design.tsx
@@ -8,7 +8,7 @@ import {
 } from '@mui/icons-material';
 import type { Template } from '@pdfme/common';
 import { generate } from '@pdfme/generator';
-import type { Designer } from '@pdfme/ui';
+import { Designer } from '@pdfme/ui';
 import { text, image, barcodes } from '@pdfme/schemas';
 import Layout from '@theme/Layout';
 import {
@@ -33,6 +33,7 @@ const TemplateDesign = () => {
   const designer = useRef<Designer | null>(null);
   const [template, setTemplate] = useState<Template>(getSampleTemplate());
   const [smallDisplay, setSmallDisplay] = useState(true);
+  const [prevDesignerRef, setPrevDesignerRef] = useState<Designer | null>(null);
 
   const modes = ['generator', 'designer', 'form', 'viewer'];
 
@@ -57,19 +58,17 @@ const TemplateDesign = () => {
     setSmallDisplay(window.innerWidth < 900);
   }, []);
 
-  useEffect(() => {
+  const buildDesigner = () => {
     if (designerRef.current) {
-      import('@pdfme/ui').then(({ Designer }) => {
-        designer.current = new Designer({
-          domContainer: designerRef.current,
-          template,
-          plugins: { text, image, qrcode: barcodes.qrcode },
-        });
-        designer.current.onSaveTemplate(downloadTemplate);
-        designer.current.onChangeTemplate(setTemplate);
-      })
+      designer.current = new Designer({
+        domContainer: designerRef.current,
+        template,
+        plugins: { text, image, qrcode: barcodes.qrcode },
+      });
+      designer.current.onSaveTemplate(downloadTemplate);
+      designer.current.onChangeTemplate(setTemplate);
     }
-  }, [designerRef]);
+  };
 
   const changeBasePdf = (file: File) => {
     if (designer.current) {
@@ -107,6 +106,14 @@ ${e}`);
     const blob = new Blob([pdf.buffer], { type: 'application/pdf' });
     window.open(URL.createObjectURL(blob));
   };
+
+  if (designerRef.current && designerRef != prevDesignerRef) {
+    if (prevDesignerRef && designer.current) {
+      designer.current.destroy();
+    }
+    buildDesigner();
+    setPrevDesignerRef(designerRef);
+  }
 
   return (
     <Layout title="Template Design">


### PR DESCRIPTION
fixes #347

It took a long time to track down the issues that were being exposed by `<React.StrictMode>`. 
After referring to the following [You might not need an Effect guide here](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes), it explained that we have used one of the patterns that they recommend against in a few places. Not only is it less efficient because of additional re-renders, but in our case the `useEffect` in the playgrounds were leading to duplicate calls with alternative template objects which resulted in an additional re-render and a deselection of the schema. 


**Before:**
* loses focus on resize of the window
* resize causes the canvas area to flash as schema is unnecessarily re-rendered
* can get caught in a select/unselect state if anything causes the sidebar size to increase

https://github.com/pdfme/pdfme/assets/7068515/45d29ed4-aac9-4816-88ea-4b2aa2cebdf1


**After:**
* fixes deselection issues
* much smoother re-rendering on resize

https://github.com/pdfme/pdfme/assets/7068515/669fe337-2a6a-41fa-9869-7521d97a63cf

I have not tried to refactor more widely than the areas immediately impacted, but it's worth considering whether we need a useEffect in more areas in future.

