### PR TITLE
Fix to allow zero values for form fields

### DIFF
--- a/packages/ui/src/components/Designer/Sidebar/DetailView/index.tsx
+++ b/packages/ui/src/components/Designer/Sidebar/DetailView/index.tsx
@@ -77,7 +77,8 @@ const DetailView = (
     for (let key in newSchema) {
       if (['id', 'data'].includes(key)) continue;
       if (newSchema[key] !== (activeSchema as any)[key]) {
-        const value = newSchema[key];
+        let value = newSchema[key];
+        if (value === null && ['rotate', 'opacity'].includes(key)) value = undefined;
 
         // [position] Return the flattened position to its original form.
         if (key === 'x') key = 'position.x';

--- a/packages/ui/src/components/Designer/Sidebar/DetailView/index.tsx
+++ b/packages/ui/src/components/Designer/Sidebar/DetailView/index.tsx
@@ -78,6 +78,7 @@ const DetailView = (
       if (['id', 'data'].includes(key)) continue;
       if (newSchema[key] !== (activeSchema as any)[key]) {
         let value = newSchema[key];
+        // FIXME memo: https://github.com/pdfme/pdfme/pull/367#issuecomment-1857468274
         if (value === null && ['rotate', 'opacity'].includes(key)) value = undefined;
 
         // [position] Return the flattened position to its original form.

--- a/packages/ui/src/components/Designer/Sidebar/DetailView/index.tsx
+++ b/packages/ui/src/components/Designer/Sidebar/DetailView/index.tsx
@@ -77,7 +77,7 @@ const DetailView = (
     for (let key in newSchema) {
       if (['id', 'data'].includes(key)) continue;
       if (newSchema[key] !== (activeSchema as any)[key]) {
-        const value = newSchema[key] || undefined;
+        const value = newSchema[key];
 
         // [position] Return the flattened position to its original form.
         if (key === 'x') key = 'position.x';
@@ -138,6 +138,7 @@ Check this document: https://pdfme.com/docs/custom-schemas`);
         widget: 'inputNumber',
         required: true,
         span: 8,
+        min: 0,
       },
       height: {
         title: i18n('height'),
@@ -145,6 +146,7 @@ Check this document: https://pdfme.com/docs/custom-schemas`);
         widget: 'inputNumber',
         required: true,
         span: 8,
+        min: 0,
       },
       opacity: {
         title: i18n('opacity'),


### PR DESCRIPTION
Fixes #366 

I can't see any negative impact of this change. 

It's still technically possible to break a schema by forcibly deleting a required value and ignoring the red form error message, but it's a lot better than having the value removed from the schema entirely if it's value is 0.

You can still remove values such as rotation from the schema, but by deleting the values not by setting them as 0. If we wanted to do this we would need to check if these fields are optional or not then remove them. This is more complex to implement.

https://github.com/pdfme/pdfme/assets/7068515/b3350f0c-111d-48ec-8c1a-5a100d4ee4ba


