### PR TITLE
Fix \r\n line breaks in generator

### DIFF
--- a/packages/schemas/src/text/pdfRender.ts
+++ b/packages/schemas/src/text/pdfRender.ts
@@ -162,7 +162,7 @@ export const pdfRender = async (arg: PDFRenderProps<TextSchema>) => {
   };
 
   let lines: string[] = [];
-  value.split(/\r|\n|\r\n/g).forEach((line: string) => {
+  value.split(/\r\n|\r|\n/g).forEach((line: string) => {
     lines = lines.concat(getSplittedLines(line, fontWidthCalcValues));
   });
 


### PR DESCRIPTION
The precedence of this regex was wrong and it would lead to double line breaks for `\r\n`.  You don't see this when working with the UI because browsers will convert `\r\n` to just `\n`, but you see it when data is passed directly to the generator.

example:

```
const inputs = [{ a: "Dear Pete,\r\nI hope you like this.\r\nLove Mum."}];
```

before:
![Screenshot 2023-12-15 at 13 50 54](https://github.com/pdfme/pdfme/assets/7068515/677c1fc8-b6af-427a-bd16-5bbddefbe808)

after:
![Screenshot 2023-12-15 at 16 28 04](https://github.com/pdfme/pdfme/assets/7068515/cd08360d-70c0-42b4-95cf-2874b3a5c224)
