### PR TITLE
Tune the integration test speed checks

### DIFF
--- a/packages/generator/__tests__/assets/templates/index.ts
+++ b/packages/generator/__tests__/assets/templates/index.ts
@@ -69,6 +69,7 @@ export const envelope = {
 
 export const barcode = {
   Aone31555QRコード,
+  Aone31553QRコード,
   Aone72230JANコード短縮,
   Aone72230JANコード標準,
   barcodes,
@@ -87,8 +88,7 @@ export const business = {
 };
 
 // These tests are slower, so we allow more time for them to pass
-export const slowerAndTextType = {
-  Aone31553QRコード,
+export const textType = {
   dynamicFontSizeHorizontal,
   dynamicFontSizeVertical,
   verticalAlignmentTop,

--- a/packages/generator/__tests__/assets/templates/index.ts
+++ b/packages/generator/__tests__/assets/templates/index.ts
@@ -69,7 +69,6 @@ export const envelope = {
 
 export const barcode = {
   Aone31555QRコード,
-  Aone31553QRコード,
   Aone72230JANコード短縮,
   Aone72230JANコード標準,
   barcodes,
@@ -87,7 +86,9 @@ export const business = {
   労働条件通知書,
 };
 
-export const textType = {
+// These tests are slower, so we allow more time for them to pass
+export const slowerAndTextType = {
+  Aone31553QRコード,
   dynamicFontSizeHorizontal,
   dynamicFontSizeVertical,
   verticalAlignmentTop,

--- a/packages/generator/__tests__/integration1.test.ts
+++ b/packages/generator/__tests__/integration1.test.ts
@@ -31,7 +31,9 @@ describe('generate integration test(label, envelope)', () => {
         });
 
         const hrend = process.hrtime(hrstart);
-        expect(hrend[0]).toBeLessThanOrEqual(1);
+        const execSeconds = hrend[0] + hrend[1] / 1000000000;
+        expect(execSeconds).toBeLessThan(1.5);
+
 
         const tmpFile = getPdfTmpPath(`${key}.pdf`);
         const assertFile = getPdfAssertPath(`${key}.pdf`);

--- a/packages/generator/__tests__/integration1.test.ts
+++ b/packages/generator/__tests__/integration1.test.ts
@@ -34,7 +34,6 @@ describe('generate integration test(label, envelope)', () => {
         const execSeconds = hrend[0] + hrend[1] / 1000000000;
         expect(execSeconds).toBeLessThan(1.5);
 
-
         const tmpFile = getPdfTmpPath(`${key}.pdf`);
         const assertFile = getPdfAssertPath(`${key}.pdf`);
 

--- a/packages/generator/__tests__/integration2.test.ts
+++ b/packages/generator/__tests__/integration2.test.ts
@@ -32,7 +32,7 @@ describe('generate integration test(barcode, business)', () => {
 
         const hrend = process.hrtime(hrstart);
         const execSeconds = hrend[0] + hrend[1] / 1000000000;
-        expect(execSeconds).toBeLessThan(1.5);
+        expect(execSeconds).toBeLessThan(2);
 
         const tmpFile = getPdfTmpPath(`${key}.pdf`);
         const assertFile = getPdfAssertPath(`${key}.pdf`);

--- a/packages/generator/__tests__/integration2.test.ts
+++ b/packages/generator/__tests__/integration2.test.ts
@@ -34,7 +34,6 @@ describe('generate integration test(barcode, business)', () => {
         const execSeconds = hrend[0] + hrend[1] / 1000000000;
         expect(execSeconds).toBeLessThan(1.5);
 
-
         const tmpFile = getPdfTmpPath(`${key}.pdf`);
         const assertFile = getPdfAssertPath(`${key}.pdf`);
 

--- a/packages/generator/__tests__/integration2.test.ts
+++ b/packages/generator/__tests__/integration2.test.ts
@@ -31,7 +31,9 @@ describe('generate integration test(barcode, business)', () => {
         });
 
         const hrend = process.hrtime(hrstart);
-        expect(hrend[0]).toBeLessThanOrEqual(1);
+        const execSeconds = hrend[0] + hrend[1] / 1000000000;
+        expect(execSeconds).toBeLessThan(1.5);
+
 
         const tmpFile = getPdfTmpPath(`${key}.pdf`);
         const assertFile = getPdfAssertPath(`${key}.pdf`);

--- a/packages/generator/__tests__/integration4.test.ts
+++ b/packages/generator/__tests__/integration4.test.ts
@@ -1,11 +1,11 @@
 import { writeFileSync } from 'fs';
 import generate from '../src/generate';
-import { slowerAndTextType } from './assets/templates';
+import { textType } from './assets/templates';
 import { text, image, barcodes } from '@pdfme/schemas';
 import { getFont, getPdf, getPdfTmpPath, getPdfAssertPath } from './utils';
 
 describe('generate integration test(slower)', () => {
-  describe.each([slowerAndTextType])('%s', (templateData) => {
+  describe.each([textType])('%s', (templateData) => {
     const entries = Object.entries(templateData);
     for (let l = 0; l < entries.length; l += 1) {
       const [key, template] = entries[l];

--- a/packages/generator/__tests__/integration4.test.ts
+++ b/packages/generator/__tests__/integration4.test.ts
@@ -1,11 +1,11 @@
 import { writeFileSync } from 'fs';
 import generate from '../src/generate';
-import { other } from './assets/templates';
-import { text, image } from '@pdfme/schemas';
+import { slowerAndTextType } from './assets/templates';
+import { text, image, barcodes } from '@pdfme/schemas';
 import { getFont, getPdf, getPdfTmpPath, getPdfAssertPath } from './utils';
 
-describe('generate integration test(other)', () => {
-  describe.each([other])('%s', (templateData) => {
+describe('generate integration test(slower)', () => {
+  describe.each([slowerAndTextType])('%s', (templateData) => {
     const entries = Object.entries(templateData);
     for (let l = 0; l < entries.length; l += 1) {
       const [key, template] = entries[l];
@@ -26,13 +26,13 @@ describe('generate integration test(other)', () => {
         const pdf = await generate({
           inputs,
           template,
-          plugins: { text, image },
+          plugins: { text, image, ...barcodes },
           options: { font },
         });
 
         const hrend = process.hrtime(hrstart);
         const execSeconds = hrend[0] + hrend[1] / 1000000000;
-        expect(execSeconds).toBeLessThan(1.5);
+        expect(execSeconds).toBeLessThan(2.5);
 
         const tmpFile = getPdfTmpPath(`${key}.pdf`);
         const assertFile = getPdfAssertPath(`${key}.pdf`);


### PR DESCRIPTION
After checking the times locally for all tests, I've consolidated the longer-running tests into their own file, with an extra 0.5 seconds allow to run.

I have also reduced the time required from up to 1.999 seconds to 1.5 seconds for some of the other tests (which should be much faster to run)