### PR TITLE
Improve the UX for adding an image

### DIFF
--- a/packages/schemas/src/image/uiRender.ts
+++ b/packages/schemas/src/image/uiRender.ts
@@ -3,6 +3,7 @@ import type * as CSS from 'csstype';
 import type { ImageSchema } from './types';
 import { UIRenderProps, ZOOM } from '@pdfme/common';
 import { addAlphaToHex, isEditable } from '../renderUtils.js';
+import { propPanel } from "./propPanel";
 
 const fullSize = { width: '100%', height: '100%' };
 
@@ -38,6 +39,7 @@ export const uiRender = async (arg: UIRenderProps<ImageSchema>) => {
   const { value, rootElement, mode, onChange, stopEditing, tabIndex, placeholder, schema, theme } =
     arg;
   const editable = isEditable(mode);
+  const isDefault = value === propPanel.defaultValue;
 
   const size = { width: schema.width * ZOOM, height: schema.height * ZOOM };
 
@@ -66,7 +68,7 @@ export const uiRender = async (arg: UIRenderProps<ImageSchema>) => {
   }
 
   // remove button
-  if (value && editable) {
+  if (value && !isDefault && editable) {
     const button = document.createElement('button');
     button.textContent = 'x';
     const buttonStyle: CSS.Properties = {
@@ -93,7 +95,7 @@ export const uiRender = async (arg: UIRenderProps<ImageSchema>) => {
   }
 
   // file input
-  if (!value && editable) {
+  if ((!value || isDefault) && editable) {
     const label = document.createElement('label');
     const labelStyle: CSS.Properties = {
       ...fullSize,

--- a/playground/src/helper.ts
+++ b/playground/src/helper.ts
@@ -100,8 +100,6 @@ export const getPlugins = () => {
     Signature: plugins.signature,
     Line: line,
     QR: barcodes.qrcode,
-    EAN13: barcodes.ean13,
-    EAN8: barcodes.ean8,
     Image: image,
   };
 };

--- a/playground/src/helper.ts
+++ b/playground/src/helper.ts
@@ -100,6 +100,8 @@ export const getPlugins = () => {
     Signature: plugins.signature,
     Line: line,
     QR: barcodes.qrcode,
+    EAN13: barcodes.ean13,
+    EAN8: barcodes.ean8,
     Image: image,
   };
 };


### PR DESCRIPTION
fixes #378 

Make sure the default sample data is not mistaken for a real image in the UX, when you click you should see the form to choose a proper image.

BEFORE:

https://github.com/pdfme/pdfme/assets/7068515/31512cc8-8a90-4729-b2fb-03a26974f632


AFTER:

https://github.com/pdfme/pdfme/assets/7068515/0b354b68-ec55-4785-8032-cb952fdd8015



