### PR TITLE
Fix drag-selecting text beyond the schema was de-selecting it

### DIFF
--- a/packages/ui/src/components/Paper.tsx
+++ b/packages/ui/src/components/Paper.tsx
@@ -74,7 +74,7 @@ const Paper = (props: {
                 paperRefs.current[paperIndex] = e;
               }
             }}
-            onClick={(e) => {
+            onMouseDown={(e) => {
               if (
                 e.currentTarget === e.target &&
                 document &&


### PR DESCRIPTION
fixes #219 

Previously if you drag-selected text, but accidentally dragged beyond the window it would deselect the schema:

https://github.com/pdfme/pdfme/assets/7068515/0c164e3f-8a06-489a-a2d5-a44fd4268a3f


Now by checking `onMouseDown` instead this behaviour no longer happens:

https://github.com/pdfme/pdfme/assets/7068515/cc2057d3-43e0-4bb5-a401-6f8e312b75ba

