### PR TITLE
Performance test handling

### DIFF
--- a/packages/generator/__tests__/integration1.test.ts
+++ b/packages/generator/__tests__/integration1.test.ts
@@ -4,6 +4,8 @@ import { label, envelope } from './assets/templates';
 import { text, image } from '@pdfme/schemas';
 import { getFont, getPdf, getPdfTmpPath, getPdfAssertPath } from './utils';
 
+const PERFORMANCE_THRESHOLD = parseFloat(process.env.PERFORMANCE_THRESHOLD || '1.5');
+
 describe('generate integration test(label, envelope)', () => {
   describe.each([label, envelope])('%s', (templateData) => {
     const entries = Object.entries(templateData);
@@ -32,8 +34,10 @@ describe('generate integration test(label, envelope)', () => {
 
         const hrend = process.hrtime(hrstart);
         const execSeconds = hrend[0] + hrend[1] / 1000000000;
-        if (execSeconds >= 1.5) {
-          console.warn(`Warning: Execution time for ${key} is ${execSeconds} seconds, which is above the threshold.`);
+        if (process.env.CI) {
+          expect(execSeconds).toBeLessThan(PERFORMANCE_THRESHOLD);
+        } else if (execSeconds >= PERFORMANCE_THRESHOLD) {
+          console.warn(`Warning: Execution time for ${key} is ${execSeconds} seconds, which is above the threshold of ${PERFORMANCE_THRESHOLD} seconds.`);
         }
 
         const tmpFile = getPdfTmpPath(`${key}.pdf`);

--- a/packages/generator/__tests__/integration1.test.ts
+++ b/packages/generator/__tests__/integration1.test.ts
@@ -32,7 +32,9 @@ describe('generate integration test(label, envelope)', () => {
 
         const hrend = process.hrtime(hrstart);
         const execSeconds = hrend[0] + hrend[1] / 1000000000;
-        expect(execSeconds).toBeLessThan(1.5);
+        if (execSeconds >= 1.5) {
+          console.warn(`Warning: Execution time for ${key} is ${execSeconds} seconds, which is above the threshold.`);
+        }
 
         const tmpFile = getPdfTmpPath(`${key}.pdf`);
         const assertFile = getPdfAssertPath(`${key}.pdf`);

--- a/packages/generator/__tests__/integration2.test.ts
+++ b/packages/generator/__tests__/integration2.test.ts
@@ -32,7 +32,9 @@ describe('generate integration test(barcode, business)', () => {
 
         const hrend = process.hrtime(hrstart);
         const execSeconds = hrend[0] + hrend[1] / 1000000000;
-        expect(execSeconds).toBeLessThan(2);
+        if (execSeconds >= 2) {
+          console.warn(`Warning: Execution time for ${key} is ${execSeconds} seconds, which is above the threshold.`);
+        }
 
         const tmpFile = getPdfTmpPath(`${key}.pdf`);
         const assertFile = getPdfAssertPath(`${key}.pdf`);

--- a/packages/generator/__tests__/integration2.test.ts
+++ b/packages/generator/__tests__/integration2.test.ts
@@ -4,6 +4,8 @@ import { barcode, business } from './assets/templates';
 import { text, image, barcodes } from '@pdfme/schemas';
 import { getFont, getPdf, getPdfTmpPath, getPdfAssertPath } from './utils';
 
+const PERFORMANCE_THRESHOLD = parseFloat(process.env.PERFORMANCE_THRESHOLD || '2.0');
+
 describe('generate integration test(barcode, business)', () => {
   describe.each([barcode, business])('%s', (templateData) => {
     const entries = Object.entries(templateData);
@@ -32,8 +34,10 @@ describe('generate integration test(barcode, business)', () => {
 
         const hrend = process.hrtime(hrstart);
         const execSeconds = hrend[0] + hrend[1] / 1000000000;
-        if (execSeconds >= 2) {
-          console.warn(`Warning: Execution time for ${key} is ${execSeconds} seconds, which is above the threshold.`);
+        if (process.env.CI) {
+          expect(execSeconds).toBeLessThan(PERFORMANCE_THRESHOLD);
+        } else if (execSeconds >= PERFORMANCE_THRESHOLD) {
+          console.warn(`Warning: Execution time for ${key} is ${execSeconds} seconds, which is above the threshold of ${PERFORMANCE_THRESHOLD} seconds.`);
         }
 
         const tmpFile = getPdfTmpPath(`${key}.pdf`);

--- a/packages/generator/__tests__/integration3.test.ts
+++ b/packages/generator/__tests__/integration3.test.ts
@@ -63,7 +63,9 @@ describe('generate integration test(other, shape)', () => {
 
         const hrend = process.hrtime(hrstart);
         const execSeconds = hrend[0] + hrend[1] / 1000000000;
-        expect(execSeconds).toBeLessThan(1.5);
+        if (execSeconds >= 1.5) {
+          console.warn(`Warning: Execution time for ${key} is ${execSeconds} seconds, which is above the threshold.`);
+        }
 
         const tmpFile = getPdfTmpPath(`${key}.pdf`);
         const assertFile = getPdfAssertPath(`${key}.pdf`);

--- a/packages/generator/__tests__/integration3.test.ts
+++ b/packages/generator/__tests__/integration3.test.ts
@@ -25,6 +25,8 @@ const signature = {
   },
 };
 
+const PERFORMANCE_THRESHOLD = parseFloat(process.env.PERFORMANCE_THRESHOLD || '1.5');
+
 describe('generate integration test(other, shape)', () => {
   describe.each([other, shape])('%s', (templateData) => {
     const entries = Object.entries(templateData);
@@ -63,8 +65,10 @@ describe('generate integration test(other, shape)', () => {
 
         const hrend = process.hrtime(hrstart);
         const execSeconds = hrend[0] + hrend[1] / 1000000000;
-        if (execSeconds >= 1.5) {
-          console.warn(`Warning: Execution time for ${key} is ${execSeconds} seconds, which is above the threshold.`);
+        if (process.env.CI) {
+          expect(execSeconds).toBeLessThan(PERFORMANCE_THRESHOLD);
+        } else if (execSeconds >= PERFORMANCE_THRESHOLD) {
+          console.warn(`Warning: Execution time for ${key} is ${execSeconds} seconds, which is above the threshold of ${PERFORMANCE_THRESHOLD} seconds.`);
         }
 
         const tmpFile = getPdfTmpPath(`${key}.pdf`);

--- a/packages/generator/__tests__/integration4.test.ts
+++ b/packages/generator/__tests__/integration4.test.ts
@@ -32,7 +32,9 @@ describe('generate integration test(slower)', () => {
 
         const hrend = process.hrtime(hrstart);
         const execSeconds = hrend[0] + hrend[1] / 1000000000;
-        expect(execSeconds).toBeLessThan(2.5);
+        if (execSeconds >= 2.5) {
+          console.warn(`Warning: Execution time for ${key} is ${execSeconds} seconds, which is above the threshold.`);
+        }
 
         const tmpFile = getPdfTmpPath(`${key}.pdf`);
         const assertFile = getPdfAssertPath(`${key}.pdf`);

--- a/packages/generator/__tests__/integration4.test.ts
+++ b/packages/generator/__tests__/integration4.test.ts
@@ -4,6 +4,8 @@ import { textType } from './assets/templates';
 import { text, image, barcodes } from '@pdfme/schemas';
 import { getFont, getPdf, getPdfTmpPath, getPdfAssertPath } from './utils';
 
+const PERFORMANCE_THRESHOLD = parseFloat(process.env.PERFORMANCE_THRESHOLD || '2.5');
+
 describe('generate integration test(slower)', () => {
   describe.each([textType])('%s', (templateData) => {
     const entries = Object.entries(templateData);
@@ -32,8 +34,10 @@ describe('generate integration test(slower)', () => {
 
         const hrend = process.hrtime(hrstart);
         const execSeconds = hrend[0] + hrend[1] / 1000000000;
-        if (execSeconds >= 2.5) {
-          console.warn(`Warning: Execution time for ${key} is ${execSeconds} seconds, which is above the threshold.`);
+        if (process.env.CI) {
+          expect(execSeconds).toBeLessThan(PERFORMANCE_THRESHOLD);
+        } else if (execSeconds >= PERFORMANCE_THRESHOLD) {
+          console.warn(`Warning: Execution time for ${key} is ${execSeconds} seconds, which is above the threshold of ${PERFORMANCE_THRESHOLD} seconds.`);
         }
 
         const tmpFile = getPdfTmpPath(`${key}.pdf`);


### PR DESCRIPTION
This pull request introduces different error handling of performance related tests for CI and non-CI.

When environment variable `CI` is set to `true` (i.e. in GH Actions `test` workflow), the test fails with an error in case the execution time constraints are violated. 
In other cases a constraint violation triggers a warning. 

The `PERFORMANCE_THRESHOLD` (in seconds) can be also set as environment variable.

Reference discussion: https://github.com/pdfme/pdfme/discussions/387#discussioncomment-7940652