### PR TITLE
promote includetext from  bwipjs arg that is always set to true to schema option (same as textColor)

### DIFF
--- a/packages/common/src/schema.ts
+++ b/packages/common/src/schema.ts
@@ -54,6 +54,7 @@ export const Dict = z.object({
   'schemas.text.dynamicFontSize': z.string(),
 
   'schemas.barcodes.barColor': z.string(),
+  'schemas.barcodes.includetext': z.string(),
 });
 export const Mode = z.enum(['viewer', 'form', 'designer']);
 

--- a/packages/schemas/src/barcodes/constants.ts
+++ b/packages/schemas/src/barcodes/constants.ts
@@ -15,3 +15,5 @@ export const BARCODE_TYPES = [
 export const DEFAULT_BARCODE_BG_COLOR = '#ffffff';
 
 export const DEFAULT_BARCODE_COLOR = '#000000';
+
+export const DEFAULT_BARCODE_INCLUDETEXT = true;

--- a/packages/schemas/src/barcodes/helper.ts
+++ b/packages/schemas/src/barcodes/helper.ts
@@ -1,7 +1,7 @@
 import { b64toUint8Array } from '@pdfme/common';
 import bwipjs, { RenderOptions } from 'bwip-js';
 import { Buffer } from 'buffer';
-import { BARCODE_TYPES } from './constants.js';
+import { BARCODE_TYPES, DEFAULT_BARCODE_INCLUDETEXT } from './constants.js';
 import { BarcodeTypes } from './types';
 
 // GTIN-13, GTIN-8, GTIN-12, GTIN-14
@@ -143,7 +143,7 @@ export const createBarCode = async (arg: {
     backgroundColor,
     barColor,
     textColor,
-    includetext = true,
+    includetext = DEFAULT_BARCODE_INCLUDETEXT,
   } = arg;
 
   const bcid = barCodeType2Bcid(type);

--- a/packages/schemas/src/barcodes/helper.ts
+++ b/packages/schemas/src/barcodes/helper.ts
@@ -133,11 +133,11 @@ export const createBarCode = async (arg: {
   backgroundColor?: string;
   barColor?: string;
   textColor?: string;
+  includetext?: boolean;
 }): Promise<Buffer> => {
-  const { type, input, width, height, backgroundColor, barColor, textColor } = arg;
+  const { type, input, width, height, backgroundColor, barColor, textColor, includetext } = arg;
 
   const bcid = barCodeType2Bcid(type);
-  const includetext = true;
   const scale = 5;
   const bwipjsArg: RenderOptions = { bcid, text: input, width, height, scale, includetext };
 

--- a/packages/schemas/src/barcodes/helper.ts
+++ b/packages/schemas/src/barcodes/helper.ts
@@ -135,7 +135,16 @@ export const createBarCode = async (arg: {
   textColor?: string;
   includetext?: boolean;
 }): Promise<Buffer> => {
-  const { type, input, width, height, backgroundColor, barColor, textColor, includetext } = arg;
+  const {
+    type,
+    input,
+    width,
+    height,
+    backgroundColor,
+    barColor,
+    textColor,
+    includetext = true,
+  } = arg;
 
   const bcid = barCodeType2Bcid(type);
   const scale = 5;

--- a/packages/schemas/src/barcodes/pdfRender.ts
+++ b/packages/schemas/src/barcodes/pdfRender.ts
@@ -4,7 +4,7 @@ import type { BarcodeSchema } from './types';
 import { createBarCode, validateBarcodeInput } from './helper.js';
 
 const getBarcodeCacheKey = (schema: BarcodeSchema, value: string) => {
-  return `${schema.type}${schema.backgroundColor}${schema.barColor}${schema.textColor}${value}`;
+  return `${schema.type}${schema.backgroundColor}${schema.barColor}${schema.textColor}${value}${schema.includetext}`;
 };
 
 export const pdfRender = async (arg: PDFRenderProps<BarcodeSchema>) => {

--- a/packages/schemas/src/barcodes/propPanel.ts
+++ b/packages/schemas/src/barcodes/propPanel.ts
@@ -193,7 +193,7 @@ export const getPropPanelByBarcodeType = (barcodeType: string): PropPanel<Barcod
       ...(barcodeHasText
         ? { 
           textColor: { title: i18n('schemas.textColor'), type: 'string', widget: 'color' },
-          includetext: { title: i18n('schemas.includetext'), type: 'boolean' },
+          includetext: { title: i18n('schemas.barcodes.includetext'), type: 'boolean' },
          }
         : {}),
     }),

--- a/packages/schemas/src/barcodes/propPanel.ts
+++ b/packages/schemas/src/barcodes/propPanel.ts
@@ -1,6 +1,6 @@
 import type { PropPanel } from '@pdfme/common';
 import type { BarcodeSchema } from './types';
-import { DEFAULT_BARCODE_COLOR, DEFAULT_BARCODE_BG_COLOR } from './constants.js';
+import { DEFAULT_BARCODE_COLOR, DEFAULT_BARCODE_BG_COLOR, DEFAULT_BARCODE_INCLUDETEXT } from './constants.js';
 import { DEFAULT_OPACITY, HEX_COLOR_PATTERN } from '../constants.js';
 
 const defaultColors = {
@@ -8,6 +8,7 @@ const defaultColors = {
   barColor: DEFAULT_BARCODE_COLOR,
 };
 const defaultTextColors = { textColor: DEFAULT_BARCODE_COLOR };
+const defaultIncludetext = { includetext: DEFAULT_BARCODE_INCLUDETEXT };
 const position = { x: 0, y: 0 };
 const default40x20 = { width: 40, height: 20 };
 
@@ -31,6 +32,7 @@ const barcodeDefaults: { defaultValue: string; defaultSchema: BarcodeSchema }[] 
       position,
       ...defaultColors,
       ...defaultTextColors,
+      ...defaultIncludetext,
       width: 80,
       height: 7.2,
       rotate: 0,
@@ -44,6 +46,7 @@ const barcodeDefaults: { defaultValue: string; defaultSchema: BarcodeSchema }[] 
       position,
       ...defaultColors,
       ...defaultTextColors,
+      ...defaultIncludetext,
       ...default40x20,
       height: 16,
       rotate: 0,
@@ -57,6 +60,7 @@ const barcodeDefaults: { defaultValue: string; defaultSchema: BarcodeSchema }[] 
       position,
       ...defaultColors,
       ...defaultTextColors,
+      ...defaultIncludetext,
       ...default40x20,
       rotate: 0,
       opacity: DEFAULT_OPACITY,
@@ -69,6 +73,7 @@ const barcodeDefaults: { defaultValue: string; defaultSchema: BarcodeSchema }[] 
       position,
       ...defaultColors,
       ...defaultTextColors,
+      ...defaultIncludetext,
       ...default40x20,
       opacity: DEFAULT_OPACITY,
     },
@@ -80,6 +85,7 @@ const barcodeDefaults: { defaultValue: string; defaultSchema: BarcodeSchema }[] 
       position,
       ...defaultColors,
       ...defaultTextColors,
+      ...defaultIncludetext,
       ...default40x20,
       rotate: 0,
       opacity: DEFAULT_OPACITY,
@@ -92,6 +98,7 @@ const barcodeDefaults: { defaultValue: string; defaultSchema: BarcodeSchema }[] 
       position,
       ...defaultColors,
       ...defaultTextColors,
+      ...defaultIncludetext,
       ...default40x20,
       rotate: 0,
       opacity: DEFAULT_OPACITY,
@@ -104,6 +111,7 @@ const barcodeDefaults: { defaultValue: string; defaultSchema: BarcodeSchema }[] 
       position,
       ...defaultColors,
       ...defaultTextColors,
+      ...defaultIncludetext,
       ...default40x20,
       height: 12,
       rotate: 0,
@@ -117,6 +125,7 @@ const barcodeDefaults: { defaultValue: string; defaultSchema: BarcodeSchema }[] 
       position,
       ...defaultColors,
       ...defaultTextColors,
+      ...defaultIncludetext,
       ...default40x20,
       height: 16,
       rotate: 0,
@@ -130,6 +139,7 @@ const barcodeDefaults: { defaultValue: string; defaultSchema: BarcodeSchema }[] 
       position,
       ...defaultColors,
       ...defaultTextColors,
+      ...defaultIncludetext,
       ...default40x20,
       rotate: 0,
       opacity: DEFAULT_OPACITY,
@@ -181,7 +191,10 @@ export const getPropPanelByBarcodeType = (barcodeType: string): PropPanel<Barcod
         ],
       },
       ...(barcodeHasText
-        ? { textColor: { title: i18n('schemas.textColor'), type: 'string', widget: 'color' } }
+        ? { 
+          textColor: { title: i18n('schemas.textColor'), type: 'string', widget: 'color' },
+          includetext: { title: i18n('schemas.includetext'), type: 'boolean' },
+         }
         : {}),
     }),
     ...defaults,

--- a/packages/schemas/src/barcodes/propPanel.ts
+++ b/packages/schemas/src/barcodes/propPanel.ts
@@ -1,6 +1,10 @@
 import type { PropPanel } from '@pdfme/common';
 import type { BarcodeSchema } from './types';
-import { DEFAULT_BARCODE_COLOR, DEFAULT_BARCODE_BG_COLOR, DEFAULT_BARCODE_INCLUDETEXT } from './constants.js';
+import {
+  DEFAULT_BARCODE_COLOR,
+  DEFAULT_BARCODE_BG_COLOR,
+  DEFAULT_BARCODE_INCLUDETEXT,
+} from './constants.js';
 import { DEFAULT_OPACITY, HEX_COLOR_PATTERN } from '../constants.js';
 
 const defaultColors = {
@@ -164,7 +168,8 @@ export const getPropPanelByBarcodeType = (barcodeType: string): PropPanel<Barcod
 
   const defaults = barcodeDefaults.find(({ defaultSchema }) => defaultSchema.type === barcodeType);
 
-  if (!defaults) throw new Error(`[@pdfme/schemas/barcodes] No default for barcode type ${barcodeType}`);
+  if (!defaults)
+    throw new Error(`[@pdfme/schemas/barcodes] No default for barcode type ${barcodeType}`);
 
   return {
     schema: ({ i18n }) => ({
@@ -191,10 +196,14 @@ export const getPropPanelByBarcodeType = (barcodeType: string): PropPanel<Barcod
         ],
       },
       ...(barcodeHasText
-        ? { 
-          textColor: { title: i18n('schemas.textColor'), type: 'string', widget: 'color' },
-          includetext: { title: i18n('schemas.barcodes.includetext'), type: 'boolean' },
-         }
+        ? {
+            textColor: { title: i18n('schemas.textColor'), type: 'string', widget: 'color' },
+            includetext: {
+              title: i18n('schemas.barcodes.includetext'),
+              type: 'boolean',
+              widget: 'switch',
+            },
+          }
         : {}),
     }),
     ...defaults,

--- a/packages/schemas/src/barcodes/types.ts
+++ b/packages/schemas/src/barcodes/types.ts
@@ -6,7 +6,7 @@ export interface BarcodeSchema extends Schema {
   backgroundColor: string;
   barColor: string;
   textColor?: string;
-  includetext: boolean;
+  includetext?: boolean;
 }
 
 export type BarcodeTypes = (typeof BARCODE_TYPES)[number];

--- a/packages/schemas/src/barcodes/types.ts
+++ b/packages/schemas/src/barcodes/types.ts
@@ -6,6 +6,7 @@ export interface BarcodeSchema extends Schema {
   backgroundColor: string;
   barColor: string;
   textColor?: string;
+  includetext: boolean;
 }
 
 export type BarcodeTypes = (typeof BARCODE_TYPES)[number];

--- a/packages/ui/src/components/Designer/Canvas/index.tsx
+++ b/packages/ui/src/components/Designer/Canvas/index.tsx
@@ -382,7 +382,9 @@ const Canvas = (props: Props, ref: Ref<HTMLDivElement>) => {
               changeSchemas([{ key: 'data', value, schemaId: schema.id }]);
             }}
             stopEditing={() => setEditing(false)}
-            outline={`1px ${hoveringSchemaId === schema.id ? 'solid' : 'dashed'} ${schema.readOnly ? 'transparent' : token.colorPrimary}`}
+            outline={`1px ${hoveringSchemaId === schema.id ? 'solid' : 'dashed'} ${
+              schema.readOnly ? 'transparent' : token.colorPrimary
+            }`}
             scale={scale}
           />
         )}

--- a/packages/ui/src/components/Designer/index.tsx
+++ b/packages/ui/src/components/Designer/index.tsx
@@ -97,7 +97,7 @@ const TemplateEditor = ({
   const changeSchemas: ChangeSchemas = useCallback(
     (objs) => {
       const newSchemas = objs.reduce((acc, { key, value, schemaId }) => {
-        const tgt = acc.find((s) => s.id === schemaId)! as SchemaForUI;        
+        const tgt = acc.find((s) => s.id === schemaId)! as SchemaForUI;
         // Assign to reference
         set(tgt, key, value);
 

--- a/packages/ui/src/i18n.ts
+++ b/packages/ui/src/i18n.ts
@@ -99,6 +99,7 @@ const dictJa: { [key in keyof Dict]: string } = {
   'schemas.text.fit': 'フィット',
   'schemas.text.dynamicFontSize': '動的フォントサイズ',
   'schemas.barcodes.barColor': 'バーの色',
+  'schemas.barcodes.includetext': 'テキストを含める',
 };
 
 const dictAr: { [key in keyof Dict]: string } = {
@@ -148,6 +149,7 @@ const dictAr: { [key in keyof Dict]: string } = {
   'schemas.text.fit': 'ملاءمة',
   'schemas.text.dynamicFontSize': 'حجم الخط الديناميكي',
   'schemas.barcodes.barColor': 'لون الشريط',
+  'schemas.barcodes.includetext': 'تضمين النص',
 };
 
 const dictTh: { [key in keyof Dict]: string } = {
@@ -197,6 +199,7 @@ const dictTh: { [key in keyof Dict]: string } = {
   'schemas.text.fit': 'พอดี',
   'schemas.text.dynamicFontSize': 'ขนาดตัวอักษรแบบไดนามิก',
   'schemas.barcodes.barColor': 'สีบาร์',
+  'schemas.barcodes.includetext': 'รวมข้อความ',
 };
 
 const dictIt: { [key in keyof Dict]: string } = {
@@ -247,6 +250,7 @@ const dictIt: { [key in keyof Dict]: string } = {
   'schemas.text.fit': 'Adatta',
   'schemas.text.dynamicFontSize': 'Dimensione font dinamica',
   'schemas.barcodes.barColor': 'Colore barra',
+  'schemas.barcodes.includetext': 'Includi testo',
 };
 
 const dictPl: { [key in keyof Dict]: string } = {
@@ -296,6 +300,7 @@ const dictPl: { [key in keyof Dict]: string } = {
   'schemas.text.fit': 'Dopasowanie',
   'schemas.text.dynamicFontSize': 'Dynamiczny rozmiar czcionki',
   'schemas.barcodes.barColor': 'Kolor paska',
+  'schemas.barcodes.includetext': 'Dołącz tekst',
 };
 
 const dictDe: { [key in keyof Dict]: string } = {

--- a/packages/ui/src/i18n.ts
+++ b/packages/ui/src/i18n.ts
@@ -49,6 +49,7 @@ const dictEn: { [key in keyof Dict]: string } = {
   'schemas.text.fit': 'Fit',
   'schemas.text.dynamicFontSize': 'Dynamic Font Size',
   'schemas.barcodes.barColor': 'Bar Color',
+  'schemas.barcodes.includetext': 'Include Text',
 };
 
 const dictJa: { [key in keyof Dict]: string } = {
@@ -345,6 +346,7 @@ const dictDe: { [key in keyof Dict]: string } = {
   'schemas.text.fit': 'Anpassen',
   'schemas.text.dynamicFontSize': 'Dynamische Schriftgröße',
   'schemas.barcodes.barColor': 'Strichcodefarbe',
+  'schemas.barcodes.includetext': 'Text anzeigen',
 };
 
 const dictionaries: { [key in Lang]: Dict } = {


### PR DESCRIPTION
I'm pretty sure I implemented the bwipjs arg includetext at all the necessary spots, the only missing thing should be the new label in i18n.
This PR is also currently untested, I should be able to test it tomorrow.

fixes #23