### PR TITLE
Fix pdf text render overlap by avoiding line breaks in pdflib

### DIFF
--- a/packages/schemas/src/text/pdfRender.ts
+++ b/packages/schemas/src/text/pdfRender.ts
@@ -126,7 +126,7 @@ export const pdfRender = async (arg: PDFRenderProps<TextSchema>) => {
   };
 
   let lines: string[] = [];
-  value.split(/\r\n|\r|\n/g).forEach((line: string) => {
+  value.split(/\r\n|\r|\n|\f|\u000B/g).forEach((line: string) => {
     lines = lines.concat(getSplittedLines(line, fontWidthCalcValues));
   });
 
@@ -175,9 +175,7 @@ export const pdfRender = async (arg: PDFRenderProps<TextSchema>) => {
       size: fontSize,
       color,
       lineHeight: lineHeight * fontSize,
-      maxWidth: width,
       font: pdfFontValue,
-      wordBreaks: [''],
       opacity,
     });
   });


### PR DESCRIPTION
fixes #398 

Pdfme calculates how lines should be split and renders them individually. It does this for a number of reasons including alignment, dynamic font size calculation and rotation. 

Pdflib has it's own line breaking which, in theory, shouldn't happen if calculations between the 2 libraries match up. However, pdflib appears to be calculating the width of a line of some fonts differently (incorrectly) compared to pdfme. Regardless of what and why this difference is (it wasn't immediately obvious to me), we don't need pdflib to split lines because we've already done it.

You cannot tell pdflib not to split lines, but we can make it impossible through this change.

pdflib `drawText()` function does the following:

```
    const lines =
      options.maxWidth === undefined
        ? lineSplit(cleanText(text))
        : breakTextIntoLines(text, wordBreaks, options.maxWidth, textWidth);
```

Previously we pass the `maxWidth` option which will result in `breakTextIntoLines()` being called. This is a more intelligent line breaking algorithm which is very similar to what pdfme does (although comes up with a different result).

By not passing maxWidth, we instead will call `lineSplit()`, which is simply the following:

```
export const lineSplit = (text: string) => text.split(/[\n\f\r\u000B]/);
```

By updating our split regex to include `\f` (form feed) and `u000B` ([line tabulation](https://codepoints.net/U+000B?lang=en)) we can ensure that no splitting will happen in pdf rendering, even if those characters are unlikely in the input.

BEFORE with text overlapping using Cairo font:
![Screenshot 2024-01-31 at 07 05 26](https://github.com/pdfme/pdfme/assets/7068515/068e8814-71c8-4a68-97a8-be820a0d15ee)

AFTER with no overlap:
![Screenshot 2024-01-31 at 07 05 48](https://github.com/pdfme/pdfme/assets/7068515/1e6e2786-f0d7-432e-a14f-0d30ed2d3ba8)






