### PR TITLE
contentEditable firefox fix

### DIFF
--- a/packages/schemas/src/text/helper.ts
+++ b/packages/schemas/src/text/helper.ts
@@ -318,3 +318,5 @@ export const calculateDynamicFontSize = async ({
 
   return dynamicFontSize;
 };
+
+export const isFirefox = () => navigator.userAgent.toLowerCase().indexOf('firefox') > -1;

--- a/packages/schemas/src/text/uiRender.ts
+++ b/packages/schemas/src/text/uiRender.ts
@@ -17,6 +17,7 @@ import {
   calculateDynamicFontSize,
   getFontKitFont,
   getBrowserVerticalFontAdjustments,
+  isFirefox,
 } from './helper.js';
 import { addAlphaToHex, isEditable } from '../utils.js';
 
@@ -118,11 +119,17 @@ export const uiRender = async (arg: UIRenderProps<TextSchema>) => {
   Object.assign(textBlock.style, textBlockStyle);
 
   if (isEditable(mode, schema)) {
-    try {
+    if (!isFirefox()) {
       textBlock.contentEditable = 'plaintext-only';
-    } catch (e) {
-      // Firefox hack to prevent rich text from being pasted.
+    } else {
       textBlock.contentEditable = 'true';
+      textBlock.addEventListener('keydown', (e: KeyboardEvent) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+          e.preventDefault();
+          document.execCommand('insertLineBreak', false, undefined);
+        }
+      });
+
       textBlock.addEventListener('paste', (e: ClipboardEvent) => {
         e.preventDefault();
         const paste = e.clipboardData?.getData('text');

--- a/packages/schemas/src/text/uiRender.ts
+++ b/packages/schemas/src/text/uiRender.ts
@@ -118,12 +118,21 @@ export const uiRender = async (arg: UIRenderProps<TextSchema>) => {
   Object.assign(textBlock.style, textBlockStyle);
 
   if (isEditable(mode, schema)) {
-    textBlock.contentEditable = 'plaintext-only';
+    textBlock.contentEditable = 'true';
     textBlock.tabIndex = tabIndex || 0;
     textBlock.innerText = value;
     textBlock.addEventListener('blur', (e: Event) => {
       onChange && onChange((e.target as HTMLDivElement).innerText);
       stopEditing && stopEditing();
+    });
+    textBlock.addEventListener('paste', (e: ClipboardEvent) => {
+      e.preventDefault();
+      const paste = e.clipboardData?.getData('text');
+      const selection = window.getSelection();
+      if (!selection?.rangeCount) return;
+      selection.deleteFromDocument();
+      selection.getRangeAt(0).insertNode(document.createTextNode(paste || ''));
+      selection.collapseToEnd();
     });
 
     if (schema.dynamicFontSize) {


### PR DESCRIPTION
As `contentEditable = 'plaintext-only'` doesn't work in firefox, this workaround fixes it and keeps 'plaintext-only' functionality (avoiding of styles be pasted)