### PR TITLE
Multi-var text plugin (V4)

### DIFF
--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -1,3 +1,4 @@
+import multiVariableText from './multiVariableText/index.js'
 import text, { readOnlyText } from './text/index.js';
 import image, { readOnlyImage } from './graphics/image.js';
 import svg, { readOnlySvg } from './graphics/svg.js';
@@ -11,6 +12,7 @@ import { convertForPdfLayoutProps, rotatePoint } from './utils.js';
 const builtInPlugins = { Text: text };
 
 export {
+  multiVariableText,
   text,
   readOnlyText,
   image,

--- a/packages/schemas/src/multiVariableText/helper.ts
+++ b/packages/schemas/src/multiVariableText/helper.ts
@@ -1,0 +1,18 @@
+export const substituteVariables = (text: string, variablesStr: string): string => {
+  if (!text || !variablesStr) {
+    return text;
+  }
+
+  let substitutedText = text;
+
+  const variables: Record<string, string> = JSON.parse(variablesStr) || {}
+
+  Object.keys(variables).forEach((variableName) => {
+    const variableForRegex = variableName.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&');
+    const regex = new RegExp('{' + variableForRegex + '}', 'g');
+
+    substitutedText = substitutedText.replace(regex, variables[variableName]);
+  });
+
+  return substitutedText;
+};

--- a/packages/schemas/src/multiVariableText/index.ts
+++ b/packages/schemas/src/multiVariableText/index.ts
@@ -1,0 +1,8 @@
+import type { Plugin } from '@pdfme/common';
+import { pdfRender } from './pdfRender.js';
+import { propPanel } from './propPanel.js';
+import { uiRender } from './uiRender.js';
+import type { MultiVariableTextSchema } from './types';
+
+const schema: Plugin<MultiVariableTextSchema> = { pdf: pdfRender, ui: uiRender, propPanel };
+export default schema;

--- a/packages/schemas/src/multiVariableText/pdfRender.ts
+++ b/packages/schemas/src/multiVariableText/pdfRender.ts
@@ -6,10 +6,8 @@ import { substituteVariables } from './helper';
 export const pdfRender = async (arg: PDFRenderProps<MultiVariableTextSchema>) => {
   const { value, schema, ...rest } = arg;
 
-  const substitutedText = substituteVariables(schema.content || '', value);
-
   const renderArgs = {
-    value: substitutedText,
+    value:  substituteVariables(schema.text || '', value),
     schema,
     ...rest,
   };

--- a/packages/schemas/src/multiVariableText/pdfRender.ts
+++ b/packages/schemas/src/multiVariableText/pdfRender.ts
@@ -1,0 +1,18 @@
+import { PDFRenderProps } from '@pdfme/common';
+import { MultiVariableTextSchema } from './types';
+import { pdfRender as parentPdfRender } from '../text/pdfRender';
+import { substituteVariables } from './helper';
+
+export const pdfRender = async (arg: PDFRenderProps<MultiVariableTextSchema>) => {
+  const { value, schema, ...rest } = arg;
+
+  const substitutedText = substituteVariables(schema.content || '', value);
+
+  const renderArgs = {
+    value: substitutedText,
+    schema,
+    ...rest,
+  };
+
+  await parentPdfRender(renderArgs);
+};

--- a/packages/schemas/src/multiVariableText/propPanel.ts
+++ b/packages/schemas/src/multiVariableText/propPanel.ts
@@ -1,0 +1,127 @@
+import { propPanel as parentPropPanel } from '../text/propPanel';
+import { PropPanel, PropPanelWidgetProps } from '@pdfme/common';
+import { MultiVariableTextSchema } from './types';
+
+const mapDynamicVariables = (props: PropPanelWidgetProps) => {
+  const { rootElement, changeSchemas, activeSchema } = props;
+
+  const mvtSchema = (activeSchema as any);
+  const content = mvtSchema.content || '';
+  const variables = JSON.parse(mvtSchema.data) || {};
+
+  const variablesChanged = updateVariablesFromText(content, variables);
+  const varNames = Object.keys(variables);
+
+  if (variablesChanged) {
+    changeSchemas([
+        { key: 'data', value: JSON.stringify(variables), schemaId: activeSchema.id },
+        { key: 'variables', value: varNames, schemaId: activeSchema.id }
+    ]);
+  }
+
+  const placeholderRowEl = document.getElementById('placeholder-dynamic-var')?.closest('.ant-form-item') as HTMLElement;
+  if (!placeholderRowEl) {
+    console.error('Failed to find Ant form placeholder row to create dynamic variables inputs.');
+    return
+  }
+  placeholderRowEl.style.display = 'none';
+
+  // The wrapping form element has a display:flex which limits the width of the form fields, removing.
+  (rootElement.parentElement as HTMLElement).style.display = 'block';
+
+  const title = document.createElement('span');
+  title.innerHTML = 'Text Variables';
+  rootElement.appendChild(title);
+
+  if (varNames.length > 0) {
+    for (let variableName of varNames) {
+      const varRow = placeholderRowEl.cloneNode(true) as HTMLElement;
+
+      const textarea = varRow.querySelector('textarea') as HTMLTextAreaElement;
+      textarea.id = 'dynamic-var-' + variableName;
+      textarea.value = variables[variableName];
+      textarea.addEventListener('change', (e: Event) => {
+        variables[variableName] = (e.target as HTMLTextAreaElement).value;
+        changeSchemas([{ key: 'data', value: JSON.stringify(variables), schemaId: activeSchema.id }]);
+      });
+
+      const label = varRow.querySelector('label') as HTMLLabelElement
+      label.innerText = variableName;
+
+      varRow.style.display = 'block';
+      rootElement.appendChild(varRow);
+    }
+  } else {
+    const para = document.createElement('p');
+    para.innerHTML = 'Add variables by typing words surrounded by curly brackets, e.g. <code style="color:#168fe3; font-weight:bold;">{name}</code>';
+    rootElement.appendChild(para);
+  }
+};
+
+export const propPanel: PropPanel<MultiVariableTextSchema> = {
+  schema: (propPanelProps: Omit<PropPanelWidgetProps, 'rootElement'>) => {
+    if (typeof parentPropPanel.schema !== 'function') {
+      throw Error('Oops, is text schema no longer a function?');
+    }
+    return {
+      ...parentPropPanel.schema(propPanelProps),
+      '-------': { type: 'void', widget: 'Divider' },
+      dynamicVariables: { type: 'object', widget: 'mapDynamicVariables', bind: false, span: 24 },
+      placeholderDynamicVar: {
+        title: 'Placeholder Dynamic Variable',
+        type: 'string',
+        format: 'textarea',
+        props: {
+          id: 'placeholder-dynamic-var',
+          autoSize: {
+            minRows: 2,
+            maxRows: 5,
+          },
+        },
+        span: 24,
+      },
+    };
+  },
+  widgets: { ...parentPropPanel.widgets, mapDynamicVariables },
+  defaultValue: '{}',
+  defaultSchema: {
+    ...parentPropPanel.defaultSchema,
+    type: 'multiVariableText',
+    content: 'Type something...',
+    variables: [],
+  },
+};
+
+
+const updateVariablesFromText = (text: string, variables: any): boolean => {
+  const regex = /\{([^{}]+)}/g;
+  const matches = text.match(regex);
+  let changed = false;
+
+  if (matches) {
+    // Add any new variables
+    for (const match of matches) {
+      const variableName = match.replace('{', '').replace('}', '');
+      if (!variables[variableName]) {
+        // NOTE: We upper case the variable name as the default value
+        variables[variableName] = variableName.toUpperCase();
+        changed = true;
+      }
+    }
+    // Remove any that no longer exist
+    Object.keys(variables).forEach((variableName) => {
+      if (!matches.includes('{' + variableName + '}')) {
+        delete variables[variableName];
+        changed = true;
+      }
+    });
+  } else {
+    // No matches at all, so clear all variables
+    Object.keys(variables).forEach((variableName) => {
+      delete variables[variableName];
+      changed = true;
+    });
+  }
+
+  return changed;
+}

--- a/packages/schemas/src/multiVariableText/propPanel.ts
+++ b/packages/schemas/src/multiVariableText/propPanel.ts
@@ -6,15 +6,15 @@ const mapDynamicVariables = (props: PropPanelWidgetProps) => {
   const { rootElement, changeSchemas, activeSchema } = props;
 
   const mvtSchema = (activeSchema as any);
-  const content = mvtSchema.content || '';
-  const variables = JSON.parse(mvtSchema.data) || {};
+  const text = mvtSchema.text || '';
+  const variables = JSON.parse(mvtSchema.content) || {};
 
-  const variablesChanged = updateVariablesFromText(content, variables);
+  const variablesChanged = updateVariablesFromText(text, variables);
   const varNames = Object.keys(variables);
 
   if (variablesChanged) {
     changeSchemas([
-        { key: 'data', value: JSON.stringify(variables), schemaId: activeSchema.id },
+        { key: 'content', value: JSON.stringify(variables), schemaId: activeSchema.id },
         { key: 'variables', value: varNames, schemaId: activeSchema.id }
     ]);
   }
@@ -42,7 +42,7 @@ const mapDynamicVariables = (props: PropPanelWidgetProps) => {
       textarea.value = variables[variableName];
       textarea.addEventListener('change', (e: Event) => {
         variables[variableName] = (e.target as HTMLTextAreaElement).value;
-        changeSchemas([{ key: 'data', value: JSON.stringify(variables), schemaId: activeSchema.id }]);
+        changeSchemas([{ key: 'content', value: JSON.stringify(variables), schemaId: activeSchema.id }]);
       });
 
       const label = varRow.querySelector('label') as HTMLLabelElement
@@ -83,11 +83,11 @@ export const propPanel: PropPanel<MultiVariableTextSchema> = {
     };
   },
   widgets: { ...parentPropPanel.widgets, mapDynamicVariables },
-  defaultValue: '{}',
   defaultSchema: {
     ...parentPropPanel.defaultSchema,
     type: 'multiVariableText',
-    content: 'Type something...',
+    text: 'Type something...',
+    content: '{}',
     variables: [],
   },
 };

--- a/packages/schemas/src/multiVariableText/types.ts
+++ b/packages/schemas/src/multiVariableText/types.ts
@@ -1,6 +1,6 @@
 import type { TextSchema } from '../text/types';
 
 export interface MultiVariableTextSchema extends TextSchema {
-  content: string;
+  text: string;
   variables: string[];
 }

--- a/packages/schemas/src/multiVariableText/types.ts
+++ b/packages/schemas/src/multiVariableText/types.ts
@@ -1,0 +1,6 @@
+import type { TextSchema } from '../text/types';
+
+export interface MultiVariableTextSchema extends TextSchema {
+  content: string;
+  variables: string[];
+}

--- a/packages/schemas/src/multiVariableText/uiRender.ts
+++ b/packages/schemas/src/multiVariableText/uiRender.ts
@@ -1,0 +1,85 @@
+import { UIRenderProps } from '@pdfme/common';
+import { MultiVariableTextSchema } from './types';
+import { uiRender as parentUiRender } from '../text/uiRender';
+import { isEditable } from '../utils';
+import { substituteVariables } from './helper';
+
+export const uiRender = async (arg: UIRenderProps<MultiVariableTextSchema>) => {
+  const { value, schema, rootElement, mode, onChange, onSchemaAttributeChange, ...rest } = arg;
+
+  // This plugin currently does not support editing in form view, setting as read-only.
+  const mvtMode = mode == 'form' ? 'viewer' : mode;
+
+  let content = schema.content;
+  let numVariables = schema.variables.length;
+
+  const parentRenderArgs = {
+    value: isEditable(mvtMode, schema) ? content : substituteVariables(content, value),
+    schema,
+    mode: mvtMode,
+    rootElement,
+    onChange: (value: string) => {
+      if (onChange && onSchemaAttributeChange) onSchemaAttributeChange('content', value);
+    },
+    ...rest,
+  };
+
+  await parentUiRender(parentRenderArgs);
+
+  const textBlock = rootElement.querySelector('#text-' + schema.id) as HTMLDivElement;
+  if (textBlock) {
+    textBlock.addEventListener('keyup', (event: KeyboardEvent) => {
+      content = textBlock.textContent || '';
+      if (keyPressShouldBeChecked(event)) {
+        const newNumVariables = countUniqueVariableNames(content);
+        if (numVariables !== newNumVariables) {
+          // If variables were modified during this keypress, we trigger a change
+          if (onSchemaAttributeChange) {
+            onSchemaAttributeChange('content', content);
+          }
+          numVariables = newNumVariables;
+        }
+      }
+    });
+  } else {
+    throw new Error('Text block not found. Ensure the text block has an id of "text-" + schema.id');
+  }
+};
+
+const countUniqueVariableNames = (content: string) => {
+  const regex = /\{([^}]+)}/g;
+
+  const uniqueMatchesSet = new Set();
+  let match;
+  while ((match = regex.exec(content)) !== null) {
+    uniqueMatchesSet.add(match[1]);
+  }
+
+  return uniqueMatchesSet.size;
+};
+
+/**
+ * An optimisation to try to minimise jank while typing.
+ * Only check whether variables were modified based on certain key presses.
+ * Regex would otherwise be performed on every key press (which isn't terrible, but this code helps).
+ */
+const keyPressShouldBeChecked = (event: KeyboardEvent) => {
+  if (event.key == "ArrowUp" || event.key == "ArrowDown" || event.key == "ArrowLeft" || event.key == "ArrowRight") {
+    return false;
+  }
+
+  const selection = window.getSelection();
+  const contenteditable = event.target as HTMLDivElement;
+
+  const isCursorAtEnd = selection?.focusOffset === contenteditable?.textContent?.length;
+  if (isCursorAtEnd) {
+    return event.key === '}' || event.key === 'Backspace' || event.key === 'Delete';
+  }
+
+  const isCursorAtStart = selection?.anchorOffset === 0;
+  if (isCursorAtStart) {
+    return event.key === '{' || event.key === 'Backspace' || event.key === 'Delete';
+  }
+
+  return true;
+}

--- a/packages/schemas/src/text/uiRender.ts
+++ b/packages/schemas/src/text/uiRender.ts
@@ -115,6 +115,7 @@ export const uiRender = async (arg: UIRenderProps<TextSchema>) => {
     backgroundColor: 'transparent',
   };
   const textBlock = document.createElement('div');
+  textBlock.id = 'text-' + schema.id;
   Object.assign(textBlock.style, textBlockStyle);
 
   if (isEditable(mode, schema)) {

--- a/packages/ui/src/components/Designer/Canvas/index.tsx
+++ b/packages/ui/src/components/Designer/Canvas/index.tsx
@@ -449,6 +449,9 @@ const Canvas = (props: Props, ref: Ref<HTMLDivElement>) => {
               const args = Array.isArray(arg) ? arg : [arg];
               changeSchemas(args.map(({ key, value }) => ({ key, value, schemaId: schema.id })));
             }}
+            onSchemaAttributeChange={(key, value) => {
+              changeSchemas([{ key, value, schemaId: schema.id }]);
+            }}
             stopEditing={() => setEditing(false)}
             outline={`1px ${hoveringSchemaId === schema.id ? 'solid' : 'dashed'} ${schema.readOnly && hoveringSchemaId !== schema.id ? 'transparent' : token.colorPrimary
               }`}

--- a/packages/ui/src/components/Designer/Canvas/index.tsx
+++ b/packages/ui/src/components/Designer/Canvas/index.tsx
@@ -449,9 +449,6 @@ const Canvas = (props: Props, ref: Ref<HTMLDivElement>) => {
               const args = Array.isArray(arg) ? arg : [arg];
               changeSchemas(args.map(({ key, value }) => ({ key, value, schemaId: schema.id })));
             }}
-            onSchemaAttributeChange={(key, value) => {
-              changeSchemas([{ key, value, schemaId: schema.id }]);
-            }}
             stopEditing={() => setEditing(false)}
             outline={`1px ${hoveringSchemaId === schema.id ? 'solid' : 'dashed'} ${schema.readOnly && hoveringSchemaId !== schema.id ? 'transparent' : token.colorPrimary
               }`}

--- a/packages/ui/src/components/Renderer.tsx
+++ b/packages/ui/src/components/Renderer.tsx
@@ -57,6 +57,10 @@ const Renderer = (props: RendererProps) => {
   const ref = useRef<HTMLDivElement>(null);
   const _cache = useRef<Map<any, any>>(new Map());
 
+  // If this schema is actively being edited (e.g. typing into a field)
+  // then we don't want changes to that schema triggering a re-render
+  const schemaRerenderState = mode === 'form' || mode === 'designer' ? '' : JSON.stringify(schema);
+
   useEffect(() => {
     if (ref.current && schema.type) {
       const render = Object.values(pluginsRegistry).find(
@@ -95,6 +99,7 @@ Check this document: https://pdfme.com/docs/custom-schemas`);
       }
     };
   }, [value, JSON.stringify(schema), JSON.stringify(options), mode, scale]);
+// }, [mode, scale, schemaRerenderState, JSON.stringify(options)]);
 
   return (
     <Wrapper {...props}>

--- a/packages/ui/src/components/Renderer.tsx
+++ b/packages/ui/src/components/Renderer.tsx
@@ -58,7 +58,7 @@ const Renderer = (props: RendererProps) => {
   const _cache = useRef<Map<any, any>>(new Map());
 
   // If this schema is actively being edited (e.g. typing into a field)
-  // then we don't want changes to that schema triggering a re-render
+  // then we don't want changes to that schema made elsewhere to trigger a re-render and lose focus.
   const schemaRerenderState = mode === 'form' || mode === 'designer' ? '' : JSON.stringify(schema);
 
   useEffect(() => {
@@ -98,8 +98,7 @@ Check this document: https://pdfme.com/docs/custom-schemas`);
         ref.current.innerHTML = '';
       }
     };
-  }, [value, JSON.stringify(schema), JSON.stringify(options), mode, scale]);
-// }, [mode, scale, schemaRerenderState, JSON.stringify(options)]);
+}, [mode, scale, schemaRerenderState, JSON.stringify(options)]);
 
   return (
     <Wrapper {...props}>

--- a/playground/src/helper.ts
+++ b/playground/src/helper.ts
@@ -2,6 +2,7 @@ import { Template, Font, checkTemplate, getInputFromTemplate } from '@pdfme/comm
 import { Form, Viewer, Designer } from '@pdfme/ui';
 import { generate } from '@pdfme/generator';
 import {
+  multiVariableText,
   text,
   readOnlyText,
   barcodes,
@@ -104,6 +105,7 @@ ${e}`);
 
 export const getPlugins = () => {
   return {
+    'Advanced Text': multiVariableText,
     Text: text,
     ReadOnlyText: readOnlyText,
     Table: table,


### PR DESCRIPTION
This plugin is functionally ready for review.  The behaviour is shown below:

https://github.com/pdfme/pdfme/assets/7068515/84d5164e-da7b-47e6-be99-15006aba58bd

The idea is to store the variables as a JSON string in `content` and the typed input as `text`.

This plugin will allow n variables to be added to a single text field, where n can be >= 0 (so this will also achieve a read-only schema). These variables are automatically detected as you type, and done so in an optimally efficient way that is usable even with dynamic font sizing enabled, as shown in the video above.

This plugin does not support the Form mode. Some thought would be needed as to the UI but it would be doable if people were interested. It would probably need an overlay.

### TODO:

- [ ] Add tests where applicable
