### PR TITLE
Fix playground height, fix spacing of text prop panel items

### DIFF
--- a/packages/schemas/src/text/extraFormatter.ts
+++ b/packages/schemas/src/text/extraFormatter.ts
@@ -72,6 +72,6 @@ export function getExtraFormatterSchema(
     title: i18n('schemas.text.format'),
     widget: 'ButtonGroup',
     buttons,
-    span: 16,
+    span: 17,
   };
 }

--- a/packages/schemas/src/text/propPanel.ts
+++ b/packages/schemas/src/text/propPanel.ts
@@ -83,7 +83,7 @@ export const propPanel: PropPanel<TextSchema> = {
         type: 'number',
         widget: 'inputNumber',
         props: { step: 0.1, min: 0 },
-        span: 8,
+        span: 7,
       },
       useDynamicFontSize: { type: 'boolean', widget: 'UseDynamicFontSize', bind: false, span: 16 },
       dynamicFontSize: {

--- a/playground/src/Designer.tsx
+++ b/playground/src/Designer.tsx
@@ -13,7 +13,7 @@ import {
   downloadJsonFile,
 } from "./helper";
 
-const headerHeight = 65;
+const headerHeight = 80;
 
 const initialTemplatePresetKey = "invoice"
 const customTemplatePresetKey = "custom";


### PR DESCRIPTION
Playground was causing the designer to scroll because the height wasn't set correctly.

Improve the spacing around the toolbars:

before:
![Screenshot 2024-07-18 at 11 35 25](https://github.com/user-attachments/assets/efea5990-d03c-4506-aca7-d49aeb566dea)

after:
![Screenshot 2024-07-18 at 11 33 32](https://github.com/user-attachments/assets/ff1c0938-38b0-4557-b036-a2dd4c2f6f14)
