### PR TITLE
Short-term improvement to Form flicker between fields 

### DIFF
--- a/packages/ui/src/components/Preview.tsx
+++ b/packages/ui/src/components/Preview.tsx
@@ -137,8 +137,8 @@ const Preview = ({
                       const oldValue = (input?.[key] as string) || '';
                       if (newValue === oldValue) return;
                       handleChangeInput({ key, value: newValue });
-                      // TODO Set to true only if the execution of getDynamicTemplate, such as for a table, is required.
-                      isNeedInit = true;
+                      // TODO Improve this to allow schema types to determine whether the execution of getDynamicTemplate is required.
+                      if (schema.type === 'table') isNeedInit = true;
                     } else {
                       const targetSchema = schemasList[pageCursor].find(
                         (s) => s.id === schema.id


### PR DESCRIPTION
This is due to tables needing refresh. 

I'm not addressing the underlying design issue, just a small improvement on the editor experience for now

see #492 