### PR TITLE
Enforce validation: Do not apply schema changes from right sidebar if they are invalid

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_FONT_NAME,
 } from './constants.js';
 import type {
+  ChangeSchemaItem,
   ChangeSchemas,
   PropPanel,
   PropPanelSchema,
@@ -107,6 +108,7 @@ export type {
   UIProps,
   PreviewProps,
   DesignerProps,
+  ChangeSchemaItem,
   ChangeSchemas,
   PropPanel,
   PropPanelSchema,

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -26,7 +26,12 @@ import {
 } from './schema.js';
 
 export type PropPanelSchema = _PropPanelSchema;
-export type ChangeSchemas = (objs: { key: string; value: any; schemaId: string }[]) => void;
+export type ChangeSchemaItem = {
+  key: string,
+  value: any,
+  schemaId: string
+};
+export type ChangeSchemas = (objs: ChangeSchemaItem[]) => void;
 
 /**
  * Properties used for PDF rendering.

--- a/packages/schemas/src/constants.ts
+++ b/packages/schemas/src/constants.ts
@@ -1,2 +1,2 @@
 export const DEFAULT_OPACITY = 1;
-export const HEX_COLOR_PATTERN = '^#(?:[A-Fa-f0-9]{3,4}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$';
+export const HEX_COLOR_PATTERN = '^#(?:[A-Fa-f0-9]{6})$';


### PR DESCRIPTION
I think this is a decent solution to #354. Originally I was thinking of trying to validate a schema fully on-demand, but I think this approach is a good start and perhaps enough.

In my company, we have problems where users enter and save invalid colors and the rendering fails from their schema. This change prevents invalid attribute values from getting into the schema in the first place, and the most likely cause of these errors is from human input via the designer. 

BEFORE:
You edit a value, change to another field, come back to the previous field and it doesn't show up as invalid.

https://github.com/user-attachments/assets/a4fd6558-8875-4738-a12d-ad35c2564b17

AFTER:

https://github.com/user-attachments/assets/432bb01c-c8aa-4e8b-a3b9-78b032f1b68d


NOTE: There are 2 caveats:
1. When you hover over another schema in the designer it appears to trigger a rerender of the right-hand sidebar and the value is therefore reset. I don't think this is a problem, perhaps a minor bug to look at in the designer.
2. Not every form field will map exactly to the schema keys, but I think in nearly every case it does. 

