### PR TITLE
Fix dynamic resizing additional newline

### DIFF
--- a/packages/schemas/src/multiVariableText/uiRender.ts
+++ b/packages/schemas/src/multiVariableText/uiRender.ts
@@ -89,7 +89,7 @@ const formUiRender = async (arg: UIRenderProps<MultiVariableTextSchema>) => {
       makeElementPlainTextContentEditable(span)
       span.textContent = variables[variableIndices[i]];
       span.addEventListener('blur', (e: Event) => {
-        const newValue = (e.target as HTMLSpanElement).innerText;
+        const newValue = (e.target as HTMLSpanElement).textContent || '';
         if (newValue !== variables[variableIndices[i]]) {
           variables[variableIndices[i]] = newValue;
           onChange && onChange({ key: 'content', value: JSON.stringify(variables) });

--- a/packages/schemas/src/text/uiRender.ts
+++ b/packages/schemas/src/text/uiRender.ts
@@ -55,7 +55,7 @@ export const uiRender = async (arg: UIRenderProps<TextSchema>) => {
   textBlock.tabIndex = tabIndex || 0;
   textBlock.innerText = value;
   textBlock.addEventListener('blur', (e: Event) => {
-    onChange && onChange({ key: 'content', value: (e.target as HTMLDivElement).innerText });
+    onChange && onChange({ key: 'content', value: (e.target as HTMLDivElement).textContent });
     stopEditing && stopEditing();
   });
 


### PR DESCRIPTION
`innerText` was returning the value with an additional `\n` on it. 

This was creating an extra line in read-only mode which was making the text shorter than the available space:

`textContent` does not have this additional `\n` on the end.

BEFORE:

https://github.com/user-attachments/assets/1a5cb676-a655-49f1-b214-9b5688efb374

