### PR TITLE
Refactor code and fix warning

### DIFF
--- a/packages/ui/src/components/Designer/RightSidebar/DetailView/index.tsx
+++ b/packages/ui/src/components/Designer/RightSidebar/DetailView/index.tsx
@@ -4,7 +4,7 @@ import type { ChangeSchemaItem, Dict, SchemaForUI, PropPanelWidgetProps, PropPan
 import type { SidebarProps } from '../../../../types';
 import { MenuOutlined } from '@ant-design/icons';
 import { I18nContext, PluginsRegistry, OptionsContext } from '../../../../contexts';
-import { getSidebarContentHeight, isEqual } from '../../../../helper';
+import { getSidebarContentHeight } from '../../../../helper';
 import { theme, Typography, Button, Divider } from 'antd';
 import AlignWidget from './AlignWidget';
 import WidgetRenderer from './WidgetRenderer';
@@ -43,7 +43,7 @@ const DetailView = (props: DetailViewProps) => {
   const handleWatch = (formSchema: any) => {
     const formAndSchemaValuesDiffer = (formValue: any, schemaValue: any): boolean => {
       if (typeof formValue === 'object') {
-        return !isEqual(formValue, schemaValue);
+        return JSON.stringify(formValue) !== JSON.stringify(schemaValue);
       }
       return formValue !== schemaValue;
     }
@@ -243,4 +243,9 @@ Check this document: https://pdfme.com/docs/custom-schemas`);
     </div>
   );
 };
-export default React.memo(DetailView, isEqual);
+
+const propsAreUnchanged = (prevProps: DetailViewProps, nextProps: DetailViewProps) => {
+  return JSON.stringify(prevProps.activeSchema) == JSON.stringify(nextProps.activeSchema)
+};
+
+export default React.memo(DetailView, propsAreUnchanged);

--- a/packages/ui/src/components/Designer/RightSidebar/DetailView/index.tsx
+++ b/packages/ui/src/components/Designer/RightSidebar/DetailView/index.tsx
@@ -30,7 +30,7 @@ const DetailView = (props: DetailViewProps) => {
   const options = useContext(OptionsContext);
 
   useEffect(() => {
-    const values = { ...activeSchema };
+    const values: any = { ...activeSchema };
     // [position] Change the nested position object into a flat, as a three-column layout is difficult to implement
     values.x = values.position.x;
     values.y = values.position.y;

--- a/packages/ui/src/components/Designer/index.tsx
+++ b/packages/ui/src/components/Designer/index.tsx
@@ -19,6 +19,7 @@ import { I18nContext, PluginsRegistry } from '../../contexts';
 import {
   schemasList2template,
   uuid,
+  round,
   cloneDeep,
   template2SchemasList,
   getPagesScrollTopByIndex,
@@ -51,7 +52,7 @@ const TemplateEditor = ({
   onSaveTemplate: (t: Template) => void;
   onChangeTemplate: (t: Template) => void;
 } & {
-  onChangeTemplate: (t: Template) => void 
+  onChangeTemplate: (t: Template) => void
   onPageCursorChange: (newPageCursor: number) => void
 }) => {
   const past = useRef<SchemaForUI[][]>([]);
@@ -253,7 +254,7 @@ const TemplateEditor = ({
           const moveY = (event.delta.y - canvasTopOffsetFromPageCorner) / scale;
           const moveX = (event.delta.x - canvasLeftOffsetFromPageCorner) / scale;
 
-          const position = { x: px2mm(Math.max(0, moveX)), y: px2mm(Math.max(0, moveY)) }
+          const position = { x: round(px2mm(Math.max(0, moveX)), 2), y: round(px2mm(Math.max(0, moveY)), 2) }
 
           addSchema({ ...(active.data.current as Schema), position });
         }}

--- a/packages/ui/src/helper.ts
+++ b/packages/ui/src/helper.ts
@@ -490,28 +490,3 @@ export const changeSchemas = (args: {
   }, cloneDeep(schemas));
   commitSchemas(newSchemas);
 };
-
-export const isEqual = <T extends Record<string, unknown>>(obj1: T, obj2: T): boolean => {
-  if (obj1 === obj2) return true;
-  if (typeof obj1 !== 'object' || typeof obj2 !== 'object' || obj1 == null || obj2 == null) return false;
-
-  const keys1 = Object.keys(obj1);
-  const keys2 = Object.keys(obj2);
-
-  if (keys1.length !== keys2.length) return false;
-
-  for (const key of keys1) {
-    if (!keys2.includes(key)) return false;
-    
-    const val1 = obj1[key];
-    const val2 = obj2[key];
-    
-    if (typeof val1 === 'object' && val1 !== null && typeof val2 === 'object' && val2 !== null) {
-      if (!isEqual(val1 as Record<string, unknown>, val2 as Record<string, unknown>)) return false;
-    } else if (val1 !== val2) {
-      return false;
-    }
-  }
-
-  return true;
-};

--- a/packages/ui/src/helper.ts
+++ b/packages/ui/src/helper.ts
@@ -490,3 +490,28 @@ export const changeSchemas = (args: {
   }, cloneDeep(schemas));
   commitSchemas(newSchemas);
 };
+
+export const isEqual = <T extends Record<string, unknown>>(obj1: T, obj2: T): boolean => {
+  if (obj1 === obj2) return true;
+  if (typeof obj1 !== 'object' || typeof obj2 !== 'object' || obj1 == null || obj2 == null) return false;
+
+  const keys1 = Object.keys(obj1);
+  const keys2 = Object.keys(obj2);
+
+  if (keys1.length !== keys2.length) return false;
+
+  for (const key of keys1) {
+    if (!keys2.includes(key)) return false;
+    
+    const val1 = obj1[key];
+    const val2 = obj2[key];
+    
+    if (typeof val1 === 'object' && val1 !== null && typeof val2 === 'object' && val2 !== null) {
+      if (!isEqual(val1 as Record<string, unknown>, val2 as Record<string, unknown>)) return false;
+    } else if (val1 !== val2) {
+      return false;
+    }
+  }
+
+  return true;
+};


### PR DESCRIPTION
I fixed the error that was occurring when changing the schema in the development build.

![CleanShot 2024-07-27 at 10 57 09](https://github.com/user-attachments/assets/cc1dee76-fa03-40eb-8c32-c9bcc5d408c7)

<details>
<summary>console log</summary>


```
Warning: Cannot update a component (`InternalFormItem`) while rendering a different component (`DetailView`). To locate the bad setState() call inside `DetailView`, follow the stack trace as described in https://fb.me/setstate-in-render
    in DetailView
    in DetailView (created by Sidebar)
    in div (created by Sidebar)
    in div (created by Sidebar)
    in div (created by Sidebar)
    in div (created by Sidebar)
    in Sidebar (created by TemplateEditor)
    in DndContext2 (created by TemplateEditor)
    in div (created by ForwardRef(Root))
    in div (created by ForwardRef(Root))
    in ForwardRef(Root) (created by TemplateEditor)
    in TemplateEditor
    in MotionWrapper (created by ProviderChildren)
    in ProviderChildren (created by ConfigProvider)
    in ConfigProvider (created by AppContextProvider)
    in AppContextProvider
overrideMethod @ console.js:273
printWarning @ index.es.js?t=1722045372620:2523
error2 @ index.es.js?t=1722045372620:2505
warnAboutRenderPhaseUpdatesInDEV @ index.es.js?t=1722045372620:18657
scheduleUpdateOnFiber @ index.es.js?t=1722045372620:17315
dispatchAction @ index.es.js?t=1722045372620:13445
safeSetState @ index.es.js?t=1722045372620:183781
onMetaChange @ index.es.js?t=1722045372620:224449
(anonymous) @ index.es.js?t=1722045372620:191910
(anonymous) @ index.es.js?t=1722045372620:191930
(anonymous) @ index.es.js?t=1722045372620:193026
(anonymous) @ index.es.js?t=1722045372620:193024
(anonymous) @ index.es.js?t=1722045372620:193067
xform.setValues @ index.es.js?t=1722045372620:258615
DetailView @ index.es.js?t=1722045372620:259624
renderWithHooks @ index.es.js?t=1722045372620:12833
updateFunctionComponent @ index.es.js?t=1722045372620:14601
beginWork @ index.es.js?t=1722045372620:15650
beginWork$1 @ index.es.js?t=1722045372620:18618
performUnitOfWork @ index.es.js?t=1722045372620:17954
workLoopSync @ index.es.js?t=1722045372620:17939
performSyncWorkOnRoot @ index.es.js?t=1722045372620:17676
(anonymous) @ index.es.js?t=1722045372620:10222
unstable_runWithPriority @ index.es.js?t=1722045372620:2000
runWithPriority$1 @ index.es.js?t=1722045372620:10183
flushSyncCallbackQueueImpl @ index.es.js?t=1722045372620:10218
flushSyncCallbackQueue @ index.es.js?t=1722045372620:10209
scheduleUpdateOnFiber @ index.es.js?t=1722045372620:17336
dispatchAction @ index.es.js?t=1722045372620:13445
(anonymous) @ index.es.js?t=1722045372620:275060
changeSchemas @ index.es.js?t=1722045372620:139125
(anonymous) @ index.es.js?t=1722045372620:275074
onDragEnd @ index.es.js?t=1722045372620:274585
__proto.triggerEvent @ index.es.js?t=1722045372620:273090
triggerEvent @ index.es.js?t=1722045372620:265884
dragEnd @ index.es.js?t=1722045372620:269163
(anonymous) @ index.es.js?t=1722045372620:272640
triggerAble @ index.es.js?t=1722045372620:272633
(anonymous) @ index.es.js?t=1722045372620:272711
(anonymous) @ index.es.js?t=1722045372620:260658
__proto.emit @ index.es.js?t=1722045372620:260657
Gesto2._this.onDragEnd @ index.es.js?t=1722045372620:261076
Show 1 more frame
Show less
index.es.js?t=1722045372620:2523 Warning: Cannot update during an existing state transition (such as within `render`). Render methods should be a pure function of props and state.
    in DetailView
    in DetailView (created by Sidebar)
    in div (created by Sidebar)
    in div (created by Sidebar)
    in div (created by Sidebar)
    in div (created by Sidebar)
    in Sidebar (created by TemplateEditor)
    in DndContext2 (created by TemplateEditor)
    in div (created by ForwardRef(Root))
    in div (created by ForwardRef(Root))
    in ForwardRef(Root) (created by TemplateEditor)
    in TemplateEditor
    in MotionWrapper (created by ProviderChildren)
    in ProviderChildren (created by ConfigProvider)
    in ConfigProvider (created by AppContextProvider)
    in AppContextProvider
```

</details>