### PR TITLE
fix innerText and strip ending newline

### DIFF
--- a/packages/schemas/src/text/uiRender.ts
+++ b/packages/schemas/src/text/uiRender.ts
@@ -34,6 +34,14 @@ export const uiRender = async (arg: UIRenderProps<TextSchema>) => {
     _cache,
   } = arg;
   const usePlaceholder = isEditable(mode, schema) && placeholder && !value;
+  const getText = (element: HTMLDivElement) => {
+    let text = element.innerText;
+    if (text.endsWith('\n')) {
+      // contenteditable adds additional newline char retrieved with innerText
+      text = text.slice(0, -1);
+    }
+    return text;
+  };
 
   const textBlock = await buildStyledTextContainer(arg, usePlaceholder ? placeholder : value);
 
@@ -55,7 +63,7 @@ export const uiRender = async (arg: UIRenderProps<TextSchema>) => {
   textBlock.tabIndex = tabIndex || 0;
   textBlock.innerText = value;
   textBlock.addEventListener('blur', (e: Event) => {
-    onChange && onChange({ key: 'content', value: (e.target as HTMLDivElement).textContent });
+    onChange && onChange({ key: 'content', value: getText(e.target as HTMLDivElement) });
     stopEditing && stopEditing();
   });
 
@@ -71,7 +79,7 @@ export const uiRender = async (arg: UIRenderProps<TextSchema>) => {
           dynamicFontSize = await calculateDynamicFontSize({
             textSchema: schema,
             font,
-            value: textBlock.textContent,
+            value: getText(textBlock),
             startingFontSize: dynamicFontSize,
             _cache,
           });


### PR DESCRIPTION
I recently [tried to fix an issue with dynamic resizing](https://github.com/pdfme/pdfme/pull/510/files), but `textContent` doesn't just strip the last newline but **all** newlines 🙄 

This fix reverts to using `innerText` but strips any trailing `\n`.

BEFORE:

https://github.com/user-attachments/assets/9235e641-3842-45a5-910a-13d12fcf4d73


AFTER:

https://github.com/user-attachments/assets/4cee9635-8a44-47dc-8811-e6e014c18696

