### PR TITLE
[Text schema]: Add missing color type in get font prop

### DIFF
--- a/packages/schemas/src/text/pdfRender.ts
+++ b/packages/schemas/src/text/pdfRender.ts
@@ -97,7 +97,7 @@ export const pdfRender = async (arg: PDFRenderProps<TextSchema>) => {
   const [pdfFontObj, fontKitFont, fontProp] = await Promise.all([
     embedAndGetFontObj({ pdfDoc, font, _cache }),
     getFontKitFont(schema.fontName, font, _cache),
-    getFontProp({ value, font, schema, _cache }),
+    getFontProp({ value, font, schema, _cache, colorType }),
   ]);
 
   const { fontSize, color, alignment, verticalAlignment, lineHeight, characterSpacing } = fontProp;


### PR DESCRIPTION
Since color type was missing in `getFontProp` function, setting color type option was not working and always rendered as RGB in v4.