### PR TITLE
Add autocomplete=off to the name key/field to avoid lastpass breaking forms

### DIFF
--- a/packages/ui/src/components/Designer/RightSidebar/DetailView/index.tsx
+++ b/packages/ui/src/components/Designer/RightSidebar/DetailView/index.tsx
@@ -152,7 +152,7 @@ Check this document: https://pdfme.com/docs/custom-schemas`);
         required: true,
         span: 12,
       },
-      key: { title: i18n('fieldName'), type: 'string', required: true, span: 12 },
+      key: { title: i18n('fieldName'), type: 'string', required: true, span: 12, props: { autocomplete: "off"} },
       required: { title: i18n('required'), type: 'boolean', span: 8, hidden: defaultSchema?.readOnly },
       '-': { type: 'void', widget: 'Divider' },
       align: { title: i18n('align'), type: 'void', widget: 'AlignWidget' },


### PR DESCRIPTION
I appreciate this is a workaround for a specific tool that I'm using, but I couldn't find any other working solution, and Lastpass is popular.

This is because the field is named `key` and so is considered a possible password field by password managers. Disabling autocomplete prevents their interference.

BEFORE:

![Screenshot 2024-08-01 at 08 50 48](https://github.com/user-attachments/assets/2d25a006-12f0-4862-b267-2d135742909e)

AFTER:

![Screenshot 2024-08-01 at 08 51 08](https://github.com/user-attachments/assets/9f4311b9-fbca-49b9-b60a-68681d74aaab)

