### PR TITLE
multiVariableText default schema sizes and text

### DIFF
--- a/packages/schemas/src/multiVariableText/propPanel.ts
+++ b/packages/schemas/src/multiVariableText/propPanel.ts
@@ -97,7 +97,9 @@ export const propPanel: PropPanel<MultiVariableTextSchema> = {
   defaultSchema: {
     ...parentPropPanel.defaultSchema,
     type: 'multiVariableText',
-    text: 'Type something...',
+    text: 'Add text here using {} for variables ',
+    width: 50,
+    height: 15,
     content: '{}',
     variables: [],
   },


### PR DESCRIPTION
After feedback from my team internally they felt that this change in default text would help users better understand how to use multi variable text (and made the field bigger to ensure the content fits with most fonts)