### PR TITLE
MultiVariableText minor fixes

### DIFF
--- a/packages/schemas/src/multiVariableText/helper.ts
+++ b/packages/schemas/src/multiVariableText/helper.ts
@@ -14,5 +14,8 @@ export const substituteVariables = (text: string, variablesIn: string | Record<s
     substitutedText = substitutedText.replace(regex, variables[variableName]);
   });
 
+  // Remove any variables that were not substituted from inputs
+  substitutedText.replace(/{[^{}]+}/g, '');
+
   return substitutedText;
 };

--- a/packages/schemas/src/multiVariableText/helper.ts
+++ b/packages/schemas/src/multiVariableText/helper.ts
@@ -1,21 +1,23 @@
 export const substituteVariables = (text: string, variablesIn: string | Record<string, string>): string => {
-  if (!text || !variablesIn) {
-    return text;
+  if (!text) {
+    return "";
   }
 
   let substitutedText = text;
 
-  const variables: Record<string, string> = (typeof variablesIn === "string") ? JSON.parse(variablesIn) || {} : variablesIn;
+  if (variablesIn) {
+    const variables: Record<string, string> = (typeof variablesIn === "string") ? JSON.parse(variablesIn) || {} : variablesIn;
 
-  Object.keys(variables).forEach((variableName) => {
-    // handle special characters in variable name
-    const variableForRegex = variableName.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&');
-    const regex = new RegExp('{' + variableForRegex + '}', 'g');
-    substitutedText = substitutedText.replace(regex, variables[variableName]);
-  });
+    Object.keys(variables).forEach((variableName) => {
+      // handle special characters in variable name
+      const variableForRegex = variableName.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&');
+      const regex = new RegExp('{' + variableForRegex + '}', 'g');
+      substitutedText = substitutedText.replace(regex, variables[variableName]);
+    });
+  }
 
   // Remove any variables that were not substituted from inputs
-  substitutedText.replace(/{[^{}]+}/g, '');
+  substitutedText = substitutedText.replace(/{[^{}]+}/g, '');
 
   return substitutedText;
 };

--- a/packages/schemas/src/multiVariableText/propPanel.ts
+++ b/packages/schemas/src/multiVariableText/propPanel.ts
@@ -115,7 +115,7 @@ const updateVariablesFromText = (text: string, variables: any): boolean => {
     // Add any new variables
     for (const match of matches) {
       const variableName = match.replace('{', '').replace('}', '');
-      if (!variables[variableName]) {
+      if (!(variableName in variables)) {
         // NOTE: We upper case the variable name as the default value
         variables[variableName] = variableName.toUpperCase();
         changed = true;


### PR DESCRIPTION
1. Remove any raw variables that were missing from provided input if not intended for rendering.
2. Allow variables to be set to empty in the propPanel - only prepopulate them when first created