### PR TITLE
Center align text on barcodes

### DIFF
--- a/packages/schemas/src/barcodes/helper.ts
+++ b/packages/schemas/src/barcodes/helper.ts
@@ -148,7 +148,7 @@ export const createBarCode = async (arg: {
 
   const bcid = barCodeType2Bcid(type);
   const scale = 5;
-  const bwipjsArg: RenderOptions = { bcid, text: input, width, height, scale, includetext };
+  const bwipjsArg: RenderOptions = { bcid, text: input, width, height, scale, includetext, textxalign: 'center' };
 
   if (backgroundColor) bwipjsArg.backgroundcolor = mapHexColorForBwipJsLib(backgroundColor);
   if (barColor) bwipjsArg.barcolor = mapHexColorForBwipJsLib(barColor);


### PR DESCRIPTION
ref #553 

This does not 'fix' the issue reported above for Code128 barcode, but I think it does improve the layout of some barcodes with text. The [docs](https://github.com/metafloor/bwip-js) suggest that it is 'Always good to set this'.

BEFORE:

![Screenshot 2024-08-10 at 06 54 17](https://github.com/user-attachments/assets/375f06f5-3dcd-49d6-9b01-a1f5932d1186)


AFTER:

![Screenshot 2024-08-10 at 06 51 54](https://github.com/user-attachments/assets/594afa8c-dc54-4416-a181-bbcf32955df3)
