### PR TITLE
Ensure unique schema names when working in the designer

### DIFF
--- a/packages/ui/src/components/Designer/RightSidebar/DetailView/index.tsx
+++ b/packages/ui/src/components/Designer/RightSidebar/DetailView/index.tsx
@@ -14,7 +14,7 @@ import { InternalNamePath, ValidateErrorEntity } from "rc-field-form/es/interfac
 const { Text } = Typography;
 
 type DetailViewProps = Pick<SidebarProps,
-  'size' | 'schemas' | 'pageSize' | 'changeSchemas' | 'activeElements' | 'deselectSchema'
+  'size' | 'schemas' | 'schemasList' | 'pageSize' | 'changeSchemas' | 'activeElements' | 'deselectSchema'
 > & {
   activeSchema: SchemaForUI;
 };
@@ -22,7 +22,7 @@ type DetailViewProps = Pick<SidebarProps,
 const DetailView = (props: DetailViewProps) => {
   const { token } = theme.useToken();
 
-  const { size, schemas, changeSchemas, deselectSchema, activeSchema } = props;
+  const { size, schemasList, changeSchemas, deselectSchema, activeSchema } = props;
   const form = useForm();
 
   const i18n = useContext(I18nContext);
@@ -74,14 +74,16 @@ const DetailView = (props: DetailViewProps) => {
 
   useEffect(() => {
     uniqueSchemaKey.current = (value: string): boolean => {
-      for (const s of Object.values(schemas)) {
-        if (s.key === value && s.id !== activeSchema.id) {
-          return false;
+      for (const page of schemasList) {
+        for (const s of Object.values(page)) {
+          if (s.key === value && s.id !== activeSchema.id) {
+            return false;
+          }
         }
       }
       return true;
     };
-  }, [schemas, activeSchema]);
+  }, [schemasList, activeSchema]);
 
   const uniqueSchemaKey = useRef((value: string): boolean => true);
 
@@ -218,9 +220,11 @@ Check this document: https://pdfme.com/docs/custom-schemas`);
   };
 
   if (typeof activePropPanelSchema === 'function') {
+    const { schemasList: _, ...propPanelProps } = props;
+
     const apps =
       activePropPanelSchema({
-        ...props,
+        ...propPanelProps,
         options,
         theme: token,
         i18n: i18n as (key: keyof Dict | string) => string,

--- a/packages/ui/src/components/Designer/index.tsx
+++ b/packages/ui/src/components/Designer/index.tsx
@@ -163,9 +163,9 @@ const TemplateEditor = ({
     const pageSize = pageSizes[pageCursor];
 
     const newSchemaKey = (prefix: string) => {
-      let keyNum = schemasList[pageCursor].length + 1;
+      let keyNum = schemasList.reduce((acc, page) => acc + page.length, 0);
       let newKey = prefix + keyNum;
-      while (schemasList[pageCursor].find((s) => s.key === newKey)) {
+      while (schemasList.some(page => page.find((s) => s.key === newKey))) {
         keyNum++;
         newKey = prefix + keyNum;
       }
@@ -298,6 +298,7 @@ const TemplateEditor = ({
           size={size}
           pageSize={pageSizes[pageCursor] ?? []}
           activeElements={activeElements}
+          schemasList={schemasList}
           schemas={schemasList[pageCursor] ?? []}
           changeSchemas={changeSchemas}
           onSortEnd={onSortEnd}

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -8,6 +8,7 @@ export type SidebarProps = {
   pageSize: Size;
   activeElements: HTMLElement[];
   schemas: SchemaForUI[];
+  schemasList: SchemaForUI[][];
   onSortEnd: (sortedSchemas: SchemaForUI[]) => void;
   onEdit: (id: string) => void;
   onEditEnd: () => void;


### PR DESCRIPTION
Fixes #549 #490 (although only in the designer, it doesn't check that field names are unique on loaded templates)

When adding a new schema, ensure the name is unique across all pages:

https://github.com/user-attachments/assets/06f713f2-861f-4bf4-9af3-5a6163b87df6


When changing a key validate it across all schemas:

https://github.com/user-attachments/assets/4053a840-5f49-4d3e-9f9e-7d83bd4fce4c

