### PR TITLE
fix to ensure first field starts as `field1`

### DIFF
--- a/packages/ui/src/components/Designer/index.tsx
+++ b/packages/ui/src/components/Designer/index.tsx
@@ -163,7 +163,7 @@ const TemplateEditor = ({
     const pageSize = pageSizes[pageCursor];
 
     const newSchemaKey = (prefix: string) => {
-      let keyNum = schemasList.reduce((acc, page) => acc + page.length, 0);
+      let keyNum = schemasList.reduce((acc, page) => acc + page.length, 1);
       let newKey = prefix + keyNum;
       while (schemasList.some(page => page.find((s) => s.key === newKey))) {
         keyNum++;


### PR DESCRIPTION
Currently starting at `field0` 🤦 