### PR TITLE
set readOnly when editing an MVT field based on whether there are variables

### DIFF
--- a/packages/schemas/src/multiVariableText/uiRender.ts
+++ b/packages/schemas/src/multiVariableText/uiRender.ts
@@ -26,7 +26,8 @@ export const uiRender = async (arg: UIRenderProps<MultiVariableTextSchema>) => {
     rootElement,
     onChange: (arg: { key: string; value: any; } | { key: string; value: any; }[]) => {
       if (!Array.isArray(arg)) {
-        onChange && onChange({key: 'text', value: arg.value});
+        const numVariables = countUniqueVariableNames(arg.value);
+        onChange && onChange([{key: 'text', value: arg.value}, {key: 'readOnly', value: numVariables == 0}]);
       } else {
         throw new Error('onChange is not an array, the parent text plugin has changed...');
       }
@@ -47,7 +48,7 @@ export const uiRender = async (arg: UIRenderProps<MultiVariableTextSchema>) => {
         if (numVariables !== newNumVariables) {
           // If variables were modified during this keypress, we trigger a change
           if (onChange) {
-            onChange({key: 'text', value: text});
+            onChange([{key: 'text', value: text}, {key: 'readOnly', value: newNumVariables == 0}]);
           }
           numVariables = newNumVariables;
         }


### PR DESCRIPTION
If you add a multiVariableText field without adding variables, and you make it required, and you do not pass an input for this schema it will currently throw an Error in generate. (We default all fields to `required=true` so this happens very easily for us)

By setting `readOnly` appropriately based on whether there are variables this prevents the following validation:

```
if (schema.required && !schema.readOnly && !inputs.some((input) => input[schema.name])) {
     throw new Error(`[@pdfme/generator] input for '${schema.name}' is required to generate this PDF`);
}
```

