### PR TITLE
fix import for index.js to support esm without importing errors

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -6,7 +6,7 @@ import {
   BLANK_PDF,
   ZOOM,
   DEFAULT_FONT_NAME,
-} from './constants.js';
+} from './constants';
 import type {
   ChangeSchemaItem,
   ChangeSchemas,
@@ -36,7 +36,7 @@ import type {
   UIProps,
   PreviewProps,
   DesignerProps,
-} from './types.js';
+} from './types';
 import {
   cloneDeep,
   getFallbackFontName,
@@ -59,7 +59,7 @@ import {
   getInputFromTemplate,
   isBlankPdf,
   getDynamicTemplate,
-} from './helper.js';
+} from './helper';
 
 export {
   PDFME_VERSION,

--- a/packages/generator/src/index.ts
+++ b/packages/generator/src/index.ts
@@ -1,3 +1,3 @@
-import generate from './generate.js';
+import generate from './generate';
 
 export { generate };

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -1,15 +1,15 @@
-import multiVariableText from './multiVariableText/index.js';
-import text from './text/index.js';
-import image from './graphics/image.js';
-import svg from './graphics/svg.js';
-import barcodes from './barcodes/index.js';
-import line from './shapes/line.js';
-import table from './tables/index.js';
-import { rectangle, ellipse } from './shapes/rectAndEllipse.js';
-import dateTime from './date/dateTime.js';
-import date from './date/date.js';
-import time from './date/time.js';
-import select from './select/index.js';
+import multiVariableText from './multiVariableText/index';
+import text from './text/index';
+import image from './graphics/image';
+import svg from './graphics/svg';
+import barcodes from './barcodes/index';
+import line from './shapes/line';
+import table from './tables/index';
+import { rectangle, ellipse } from './shapes/rectAndEllipse';
+import dateTime from './date/dateTime';
+import date from './date/date';
+import time from './date/time';
+import select from './select/index';
 
 const builtInPlugins = { Text: text };
 


### PR DESCRIPTION
For other frontend frameworks like astrology oder sevelt was a import problem with esm.

This fix the issue, so other framework can use this lib too.