### PR TITLE
Automatically replace PDFME_VERSION with the latest Git tag during the build process

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -33,6 +33,7 @@
   },
   "scripts": {
     "dev": "tsc -p tsconfig.esm.json -w",
+    "prebuild": "node replace-version.js",
     "build": "npm-run-all --parallel build:cjs build:esm",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json",

--- a/packages/common/replace-version.js
+++ b/packages/common/replace-version.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+try {
+  const gitTag = execSync('git describe --tags $(git rev-list --tags --max-count=1)', { encoding: 'utf8' }).trim();
+
+  const filePath = path.join(__dirname, 'src/constants.ts');
+
+  let content = fs.readFileSync(filePath, 'utf8');
+
+  content = content.replace(/export const PDFME_VERSION = '.*';/, `export const PDFME_VERSION = '${gitTag}';`);
+
+  fs.writeFileSync(filePath, content, 'utf8');
+
+  console.log(`Replaced PDFME_VERSION with '${gitTag}' in ${filePath}`);
+} catch (error) {
+  console.error('Error replacing PDFME_VERSION:', error);
+  process.exit(1);
+}

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -1,5 +1,5 @@
-// TODO: Automatically retrieve and apply the current git tag during the build process.
-export const PDFME_VERSION = '5.0.0';
+// This value is auto-replaced with the latest Git tag during the build, including npm releases, so no manual updates are needed.
+export const PDFME_VERSION = '5.2.4';
 export const PT_TO_PX_RATIO = 1.333;
 export const PT_TO_MM_RATIO = 0.3528;
 export const MM_TO_PT_RATIO = 2.8346; // https://www.ddc.co.jp/words/archives/20090701114500.html

--- a/packages/ui/src/helper.ts
+++ b/packages/ui/src/helper.ts
@@ -15,7 +15,7 @@ import {
 } from '@pdfme/common';
 import { RULER_HEIGHT } from './constants.js';
 
-GlobalWorkerOptions.workerSrc = `https://unpkg.com/pdfjs-dist@${version}/build/pdf.worker.min.mjs`;
+GlobalWorkerOptions.workerSrc = `https://cdn.jsdelivr.net/npm/pdfjs-dist@${version}/build/pdf.worker.min.mjs`;
 
 export const uuid = () =>
   'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {


### PR DESCRIPTION
ref: https://github.com/pdfme/pdfme/issues/543