### PR TITLE
alwasy include text render in preprocessing

### DIFF
--- a/packages/generator/src/helper.ts
+++ b/packages/generator/src/helper.ts
@@ -82,7 +82,10 @@ export const preprocessing = async (arg: { template: Template; userPlugins: Plug
       : Object.values(builtInPlugins)
   ) as Plugin<Schema>[];
 
-  const schemaTypes = schemas.flatMap(schemaPage => schemaPage.map((schema) => schema.type));
+  let schemaTypes = schemas.flatMap(schemaPage => schemaPage.map((schema) => schema.type));
+  if (schemaTypes.indexOf('text') == -1) {
+    schemaTypes.push('text');
+  }
 
   const renderObj = schemaTypes.reduce((acc, type) => {
     const render = pluginValues.find((pv) => pv.propPanel.defaultSchema.type === type);
@@ -129,8 +132,8 @@ export const insertPage = (arg: {
   const { basePage, embedPdfBox, pdfDoc } = arg;
   const size = basePage instanceof PDFEmbeddedPage ? basePage.size() : basePage.getSize();
   const insertedPage = basePage instanceof PDFEmbeddedPage
-      ? pdfDoc.addPage([size.width, size.height])
-      : pdfDoc.addPage(basePage);
+    ? pdfDoc.addPage([size.width, size.height])
+    : pdfDoc.addPage(basePage);
 
   if (basePage instanceof PDFEmbeddedPage) {
     insertedPage.drawPage(basePage);


### PR DESCRIPTION
If a schema is missing the `text` schema, the `staticSchemas`, which include the header and footer, are not rendered properly. The reason is that the `preprocessing` function skips preparing the renderer for the `text` schema. To fix this bug, the renderer for the `text` schema should always be included in `preprocessing` function. This pull request resolves this issue. 