### PR TITLE
Allow custom color conversion on pdf generator

### DIFF
--- a/packages/schemas/src/utils.ts
+++ b/packages/schemas/src/utils.ts
@@ -1,5 +1,5 @@
 import type * as CSS from 'csstype';
-import { cmyk, degrees, degreesToRadians, rgb } from '@pdfme/pdf-lib';
+import { cmyk, degrees, degreesToRadians, rgb, Color } from '@pdfme/pdf-lib';
 import { Schema, mm2pt, Mode, isHexValid, ColorType } from '@pdfme/common';
 import { IconNode } from 'lucide';
 import { getDynamicHeightsForTable as _getDynamicHeightsForTable } from './tables/dynamicTemplate.js';
@@ -146,10 +146,12 @@ const hex2CmykColor = (hexString: string | undefined) => {
   return undefined;
 };
 
-export const hex2PrintingColor = (hexString: string | undefined, colorType?: ColorType) => {
-  return colorType?.toLocaleLowerCase() == 'cmyk'
-    ? hex2CmykColor(hexString)
-    : hex2RgbColor(hexString);
+export const hex2PrintingColor = (color?: string | Color, colorType?: ColorType) => {
+  // if color is already CMYK, RGB or Grayscale, does not required to convert
+  if (typeof color === 'object') return color
+  return colorType?.toLowerCase() == 'cmyk'
+    ? hex2CmykColor(color)
+    : hex2RgbColor(color);
 };
 
 export const readFile = (input: File | FileList | null): Promise<string | ArrayBuffer> =>


### PR DESCRIPTION
We already have `hex` to `cmyk` or `rgb` conversion in this package.
But in some cases, we need to convert the color using icc profiles which provide a better result on color conversion. 

So I added a onColor option on generator. That will call when it is not null instead of existing `hex2PrintingColor()`.

```ts
const pdf = await generate({
  template,
  inputs,
  options: {
    onColor: (hexColor: string) => {
      // custom color conversion logic here 
      // and return cmyk or rgb
      return cmyk(0,0.78,0.51,1)
    },
    font,
    lang: options.lang,
    title: 'pdfme',
  },
  plugins: getPlugins(),
});
```