### PR TITLE
fix "clear" text signature from ja to universal emoji

### DIFF
--- a/playground/src/FormAndViewer.tsx
+++ b/playground/src/FormAndViewer.tsx
@@ -59,7 +59,7 @@ function FormAndViewerApp() {
         options: {
           font: getFontsData(),
           lang: 'ja',
-          labels: { 'clear': '消去' },
+          labels: { 'clear': '🗑️' },
           theme: {
             token: {
               colorPrimary: '#25c2a0',


### PR DESCRIPTION
Update clear text "消去" to "🗑️" emoji to make it consistent like Designer signature clear