### PR TITLE
Issue 567 Dark mode icon color fix

### DIFF
--- a/packages/ui/src/components/Designer/RightSidebar/DetailView/ButtonGroupWidget.tsx
+++ b/packages/ui/src/components/Designer/RightSidebar/DetailView/ButtonGroupWidget.tsx
@@ -1,7 +1,6 @@
-import { Button, Form } from 'antd';
+import { Button, Form, theme } from 'antd';
 import React from 'react';
 import type { PropPanelWidgetProps, SchemaForUI } from '@pdfme/common';
-
 interface ButtonConfig {
   key: string;
   icon: string;
@@ -11,6 +10,7 @@ interface ButtonConfig {
 
 const ButtonGroupWidget = (props: PropPanelWidgetProps) => {
   const { activeElements, changeSchemas, schemas, schema } = props;
+  const { token } = theme.useToken();
 
   const apply = (btn: ButtonConfig) => {
     const key = btn.key;
@@ -38,8 +38,13 @@ const ButtonGroupWidget = (props: PropPanelWidgetProps) => {
     return active;
   };
 
+  const replaceCurrentColor = (svgString: string, color?: string) =>
+    color ? svgString.replace(/="currentColor"/g, `="${color}"`) : svgString;
+
   const svgIcon = (svgString: string) => {
-    const svgDataUrl = `data:image/svg+xml;utf8,${encodeURIComponent(svgString)}`;
+    const svgDataUrl = `data:image/svg+xml;utf8,${encodeURIComponent(
+      replaceCurrentColor(svgString, token.colorText)
+    )}`;
     return <img width={17} height={17} src={svgDataUrl} />;
   };
 


### PR DESCRIPTION
Issue: https://github.com/pdfme/pdfme/issues/567

Fix:
In dark mode, the format widget icons were found to be invisible. Upon investigation, it was determined that the issue occurred due to currentColor being used as the stroke property. To address this, the SVG rendering logic has been updated.

Screenshot
![image](https://github.com/user-attachments/assets/ded33f33-3000-4f38-abc7-274956e671e9)

@peteward @hand-dot