### PR TITLE
check file selected or not

### DIFF
--- a/playground/src/Designer.tsx
+++ b/playground/src/Designer.tsx
@@ -73,7 +73,7 @@ function DesignerApp() {
   }, []);
 
   const onChangeBasePDF = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target && e.target.files) {
+    if (e.target && e.target.files && e.target.files[0]) {
       readFile(e.target.files[0], "dataURL").then(async (basePdf) => {
         if (designer.current) {
           designer.current.updateTemplate(

--- a/playground/src/helper.ts
+++ b/playground/src/helper.ts
@@ -85,7 +85,7 @@ export const handleLoadTemplate = (
   e: React.ChangeEvent<HTMLInputElement>,
   currentRef: Designer | Form | Viewer | null
 ) => {
-  if (e.target && e.target.files) {
+  if (e.target && e.target.files && e.target.files[0]) {
     getTemplateFromJsonFile(e.target.files[0])
       .then((t) => {
         if (!currentRef) return;


### PR DESCRIPTION
If users click the "cancel" button on the file selector for the first time, the `change` event is not triggered. However, if the `input` element has a previous selection, the event is triggered but the `e.target.files` array is empty, which cause an error in  the subsequent `readFile`.
