### PR TITLE
`plugin` should be checked before its usage

### DIFF
--- a/packages/ui/src/components/Renderer.tsx
+++ b/packages/ui/src/components/Renderer.tsx
@@ -95,20 +95,26 @@ const Renderer = (props: RendererProps) => {
   const i18n = useContext(I18nContext) as (key: keyof Dict | string) => string;
   const { token: theme } = antdTheme.useToken();
 
-
+  
   const ref = useRef<HTMLDivElement>(null);
   const _cache = useRef<Map<any, any>>(new Map());
   const plugin = Object.values(pluginsRegistry).find(
     (plugin) => plugin?.propPanel.defaultSchema.type === schema.type
   ) as Plugin<any>;
 
-  const reRenderDependencies = useRerenderDependencies({ plugin, value, mode, scale, schema, options });
-
   if (!plugin || !plugin.ui) {
     console.error(`[@pdfme/ui] Renderer for type ${schema.type} not found. 
 Check this document: https://pdfme.com/docs/custom-schemas`);
     return <></>;
   }
+  const reRenderDependencies = useRerenderDependencies({
+    plugin,
+    value,
+    mode,
+    scale,
+    schema,
+    options,
+  });
 
   useEffect(() => {
     if (ref.current && schema.type) {


### PR DESCRIPTION
With the playground, it fails to open the the following template, since the `ean8` barcode plugin is not installed. That's okay but we should inform users what is wrong instead of cryptic error messages.

https://github.com/pdfme/pdfme/blob/main/packages/generator/__tests__/assets/templates/Aone72230JAN%E3%82%B3%E3%83%BC%E3%83%89%E7%9F%AD%E7%B8%AE.json