### PR TITLE
A fix for rectangle rotation

### DIFF
--- a/packages/schemas/src/shapes/rectAndEllipse.ts
+++ b/packages/schemas/src/shapes/rectAndEllipse.ts
@@ -1,7 +1,7 @@
 import { Plugin, Schema, mm2pt } from '@pdfme/common';
 import { HEX_COLOR_PATTERN } from '../constants.js';
 import { hex2PrintingColor, convertForPdfLayoutProps, createSvgStr } from '../utils.js';
-import { toDegrees, toRadians } from '@pdfme/pdf-lib';
+import { toRadians } from '@pdfme/pdf-lib';
 import { Circle, Square } from 'lucide';
 
 interface ShapeSchema extends Schema {
@@ -35,11 +35,6 @@ const shape: Plugin<ShapeSchema> = {
     const pageHeight = page.getHeight();
     const cArg = { schema, pageHeight };
     const { position, width, height, rotate, opacity } = convertForPdfLayoutProps(cArg);
-    const rotateDegrees = toDegrees(rotate);
-    const rotateRadians = toRadians(rotate);
-    const tanFactor = Math.tan(rotateRadians);
-    const adjustedTan = Math.abs(tanFactor) > 1 ? tanFactor / Math.PI : tanFactor;
-    const degreeOctant = Math.floor(rotateDegrees / 45);
     const {
       position: { x: x4Ellipse, y: y4Ellipse },
     } = convertForPdfLayoutProps({ ...cArg, applyRotateTranslate: false });
@@ -63,8 +58,8 @@ const shape: Plugin<ShapeSchema> = {
       });
     } else if (schema.type === 'rectangle') {
       page.drawRectangle({
-        x: position.x + borderWidth * ((1 / 2) - (Math.sin(rotateRadians) / 3)) + adjustedTan * (Math.PI ** 2) - (Math.PI * degreeOctant),
-        y: position.y + borderWidth * ((1 / 2) + (Math.sin(rotateRadians) / 3)) + adjustedTan * (Math.PI ** 2) - (Math.PI * 6 * degreeOctant),
+        x: position.x + borderWidth * ((1 / 2) - (Math.sin(toRadians(rotate)) / 3)) + Math.tan(toRadians(rotate)) * (Math.PI ** 2),
+        y: position.y + borderWidth * ((1 / 2) + (Math.sin(toRadians(rotate)) / 3)) + Math.tan(toRadians(rotate)) * (Math.PI ** 2),
         width: width - borderWidth,
         height: height - borderWidth,
         ...drawOptions,

--- a/packages/schemas/src/shapes/rectAndEllipse.ts
+++ b/packages/schemas/src/shapes/rectAndEllipse.ts
@@ -58,8 +58,8 @@ const shape: Plugin<ShapeSchema> = {
       });
     } else if (schema.type === 'rectangle') {
       page.drawRectangle({
-        x: position.x + borderWidth * ((1 / 2) - (Math.sin(toRadians(rotate)) / 3)) + Math.tan(toRadians(rotate)) * (Math.PI ** 2),
-        y: position.y + borderWidth * ((1 / 2) + (Math.sin(toRadians(rotate)) / 3)) + Math.tan(toRadians(rotate)) * (Math.PI ** 2),
+        x: position.x + borderWidth * ((1 - Math.sin(toRadians(rotate))) / 2) + Math.tan(toRadians(rotate)) * (Math.PI ** 2),
+        y: position.y + borderWidth * ((1 + Math.sin(toRadians(rotate))) / 2) + Math.tan(toRadians(rotate)) * (Math.PI ** 2),
         width: width - borderWidth,
         height: height - borderWidth,
         ...drawOptions,


### PR DESCRIPTION
The values for the formula in the file changes are obtained by trial and error and then joining the curve on the graph based on the trial outcomes. But the rendered pdf is near accurate to the playground maybe due to decimals in pi value or some other factor.

Findings:
For 0-45 degrees:
```ts
page.drawRectangle({
  x: position.x + borderWidth * ((1 / 2) - (Math.sin(fixedRadians) / 3)) + adjustedTan * (Math.PI ** 2),
  y: position.y + borderWidth * ((1 / 2) + (Math.sin(fixedRadians) / 3)) + adjustedTan * (Math.PI ** 2),
  width: width - borderWidth,
  height: height - borderWidth,
  ...drawOptions,
});
```

For above 45 degrees the x and y values are variable by some factor

For 46-90 degrees:
```ts
page.drawRectangle({
  x: position.x + borderWidth * ((1 / 2) - (Math.sin(fixedRadians) / 3)) + adjustedTan * (Math.PI ** 2) - (Math.PI),
  y: position.y + borderWidth * ((1 / 2) + (Math.sin(fixedRadians) / 3)) + adjustedTan * (Math.PI ** 2) - (Math.PI * 6),
  width: width - borderWidth,
  height: height - borderWidth,
  ...drawOptions,
});
```

It gets more wilder above 90 degrees!

For 130 degrees:
```ts
page.drawRectangle({
  x: position.x + borderWidth * ((1 / 2) - (Math.sin(fixedRadians) / 3)) + adjustedTan * (Math.PI ** 2) - (Math.PI * 15),
  y: position.y + borderWidth * ((1 / 2) + (Math.sin(fixedRadians) / 3)) + adjustedTan * (Math.PI ** 2) - (Math.PI * 24),
  width: width - borderWidth,
  height: height - borderWidth,
  ...drawOptions,
});
```

For 140 degrees:
```ts
page.drawRectangle({
  x: position.x + borderWidth * ((1 / 2) - (Math.sin(fixedRadians) / 3)) + adjustedTan * (Math.PI ** 2) - (Math.PI * 20),
  y: position.y + borderWidth * ((1 / 2) + (Math.sin(fixedRadians) / 3)) + adjustedTan * (Math.PI ** 2) - (Math.PI * 25),
  width: width - borderWidth,
  height: height - borderWidth,
  ...drawOptions,
});
```

For 150 degrees:
```ts
page.drawRectangle({
  x: position.x + borderWidth * ((1 / 2) - (Math.sin(fixedRadians) / 3)) + adjustedTan * (Math.PI ** 2) - (Math.PI * 19),
  y: position.y + borderWidth * ((1 / 2) + (Math.sin(fixedRadians) / 3)) + adjustedTan * (Math.PI ** 2) - (Math.PI * 24),
  width: width - borderWidth,
  height: height - borderWidth,
  ...drawOptions,
});
```

For 170 degrees:
```ts
page.drawRectangle({
  x: position.x + borderWidth * ((1 / 2) - (Math.sin(fixedRadians) / 3)) + adjustedTan * (Math.PI ** 2) - (Math.PI * 18),
  y: position.y + borderWidth * ((1 / 2) + (Math.sin(fixedRadians) / 3)) + adjustedTan * (Math.PI ** 2) - (Math.PI * 23),
  width: width - borderWidth,
  height: height - borderWidth,
  ...drawOptions,
});
```

For 200 degrees:
```ts
page.drawRectangle({
  x: position.x + borderWidth * ((1 / 2) - (Math.sin(fixedRadians) / 3)) + adjustedTan * (Math.PI ** 2) - (Math.PI * 22),
  y: position.y + borderWidth * ((1 / 2) + (Math.sin(fixedRadians) / 3)) + adjustedTan * (Math.PI ** 2) - (Math.PI * 19.5),
  width: width - borderWidth,
  height: height - borderWidth,
  ...drawOptions,
});
```

Limitations:
Please limit the values upto 90 degrees for rectangle and move the position of the rectangle to make up for the rotation above 90 degrees.

As I am no math genius I can't find a common relation b/w all findings but I am sure it becomes a complex formula of sine, cos and tan angles (also I didn't test above 200 degrees)

Note: The tests are done using the template provided in https://github.com/pdfme/pdfme/issues/382 issue.