### PR TITLE
Improve UI font caching and simplify fontKitFont use

### DIFF
--- a/packages/schemas/__tests__/text.test.ts
+++ b/packages/schemas/__tests__/text.test.ts
@@ -154,12 +154,15 @@ describe('getSplittedLines test with real font width calculations', () => {
 });
 
 describe('calculateDynamicFontSize with Default font', () => {
-  const font = getDefaultFont();
-  const _cache = new Map();
+  let fontKitFont: FontKitFont;
+
+  beforeAll(async () => {
+    fontKitFont = await getFontKitFont('SauceHanSansJP', getDefaultFont(), new Map());
+  });
 
   it('should return default font size when dynamicFontSizeSetting is not provided', async () => {
     const textSchema = getTextSchema();
-    const result = await calculateDynamicFontSize({ textSchema, font, value: 'test', _cache });
+    const result = calculateDynamicFontSize({ textSchema, fontKitFont, value: 'test' });
 
     expect(result).toBe(14);
   });
@@ -167,7 +170,7 @@ describe('calculateDynamicFontSize with Default font', () => {
   it('should return default font size when dynamicFontSizeSetting max is less than min', async () => {
     const textSchema = getTextSchema();
     textSchema.dynamicFontSize = { min: 11, max: 10, fit: 'vertical' };
-    const result = await calculateDynamicFontSize({ textSchema, font, value: 'test', _cache });
+    const result = calculateDynamicFontSize({ textSchema, fontKitFont, value: 'test' });
 
     expect(result).toBe(14);
   });
@@ -176,7 +179,7 @@ describe('calculateDynamicFontSize with Default font', () => {
     const textSchema = getTextSchema();
     textSchema.dynamicFontSize = { min: 10, max: 30, fit: 'vertical' };
     const value = 'test with a length string\n and a new line';
-    const result = await calculateDynamicFontSize({ textSchema, font, value, _cache });
+    const result = calculateDynamicFontSize({ textSchema, fontKitFont, value });
 
     expect(result).toBe(19.25);
   });
@@ -185,7 +188,7 @@ describe('calculateDynamicFontSize with Default font', () => {
     const textSchema = getTextSchema();
     textSchema.dynamicFontSize = { min: 10, max: 30, fit: 'horizontal' };
     const value = 'test with a length string\n and a new line';
-    const result = await calculateDynamicFontSize({ textSchema, font, value, _cache });
+    const result = calculateDynamicFontSize({ textSchema, fontKitFont, value });
 
     expect(result).toBe(11.25);
   });
@@ -195,12 +198,12 @@ describe('calculateDynamicFontSize with Default font', () => {
     textSchema.fontSize = 2;
     textSchema.dynamicFontSize = { min: 10, max: 30, fit: 'vertical' };
     const value = 'test with a length string\n and a new line';
-    let result = await calculateDynamicFontSize({ textSchema, font, value, _cache });
+    let result = calculateDynamicFontSize({ textSchema, fontKitFont, value });
 
     expect(result).toBe(19.25);
 
     textSchema.fontSize = 40;
-    result = await calculateDynamicFontSize({ textSchema, font, value, _cache });
+    result = calculateDynamicFontSize({ textSchema, fontKitFont, value });
 
     expect(result).toBe(19.25);
   });
@@ -210,7 +213,7 @@ describe('calculateDynamicFontSize with Default font', () => {
     textSchema.width = 10;
     textSchema.dynamicFontSize = { min: 10, max: 30, fit: 'vertical' };
     const value = 'test with a length string\n and a new line';
-    const result = await calculateDynamicFontSize({ textSchema, font, value, _cache });
+    const result = calculateDynamicFontSize({ textSchema, fontKitFont, value });
 
     expect(result).toBe(10);
   });
@@ -221,7 +224,7 @@ describe('calculateDynamicFontSize with Default font', () => {
     textSchema.height = 200;
     textSchema.dynamicFontSize = { min: 10, max: 30, fit: 'vertical' };
     const value = 'test with a length string\n and a new line';
-    const result = await calculateDynamicFontSize({ textSchema, font, value, _cache });
+    const result = calculateDynamicFontSize({ textSchema, fontKitFont, value });
 
     expect(result).toBe(30);
   });
@@ -232,7 +235,7 @@ describe('calculateDynamicFontSize with Default font', () => {
     textSchema.width = 4;
     textSchema.height = 1;
     const value = 'a very \nlong \nmulti-line \nstring\nto';
-    const result = await calculateDynamicFontSize({ textSchema, font, value, _cache });
+    const result = calculateDynamicFontSize({ textSchema, fontKitFont, value });
 
     expect(result).toBeGreaterThan(0);
   });
@@ -242,13 +245,7 @@ describe('calculateDynamicFontSize with Default font', () => {
     textSchema.dynamicFontSize = { min: 10, max: 30, fit: 'vertical' };
     const value = 'test with a length string\n and a new line';
     const startingFontSize = 18;
-    const result = await calculateDynamicFontSize({
-      textSchema,
-      font,
-      value,
-      startingFontSize,
-      _cache,
-    });
+    const result = calculateDynamicFontSize({textSchema, fontKitFont, value, startingFontSize});
 
     expect(result).toBe(19.25);
   });
@@ -258,13 +255,7 @@ describe('calculateDynamicFontSize with Default font', () => {
     textSchema.dynamicFontSize = { min: 10, max: 30, fit: 'horizontal' };
     const value = 'test with a length string\n and a new line';
     const startingFontSize = 36;
-    const result = await calculateDynamicFontSize({
-      textSchema,
-      font,
-      value,
-      startingFontSize,
-      _cache,
-    });
+    const result = calculateDynamicFontSize({textSchema, fontKitFont, value, startingFontSize});
 
     expect(result).toBe(11.25);
   });
@@ -273,62 +264,61 @@ describe('calculateDynamicFontSize with Default font', () => {
     const textSchema = getTextSchema();
     textSchema.dynamicFontSize = { min: 10, max: 30, fit: 'vertical' };
     const value = 'test with a length string\n and a new line';
-    const result = await calculateDynamicFontSize({ textSchema, font, value, _cache });
+    const result = calculateDynamicFontSize({ textSchema, fontKitFont, value });
 
     expect(result).toBe(19.25);
   });
 });
 
 describe('calculateDynamicFontSize with Custom font', () => {
-  const font = getSampleFont();
+  let fontKitFont: FontKitFont;
+  beforeAll(async () => {
+    fontKitFont = await getFontKitFont('SauceHanSansJP',  getSampleFont(), new Map());
+  });
+
 
   it('should return smaller font size when dynamicFontSizeSetting is provided with horizontal fit', async () => {
     const textSchema = getTextSchema();
-    const _cache = new Map();
     textSchema.dynamicFontSize = { min: 10, max: 30, fit: 'horizontal' };
     const value = 'あいうあいうあい';
     
-    const result = await calculateDynamicFontSize({ textSchema, font, value, _cache });
+    const result = calculateDynamicFontSize({ textSchema, fontKitFont, value });
 
     expect(result).toBe(16.75);
   });
 
   it('should return smaller font size when dynamicFontSizeSetting is provided with vertical fit', async () => {
     const textSchema = getTextSchema();
-    const _cache = new Map();
     textSchema.dynamicFontSize = { min: 10, max: 30, fit: 'vertical' };
     const value = 'あいうあいうあい';
-    const result = await calculateDynamicFontSize({ textSchema, font, value, _cache });
+    const result = calculateDynamicFontSize({ textSchema, fontKitFont, value });
 
     expect(result).toBe(26);
   });
 
   it('should return min font size when content is too big to fit given constraints', async () => {
     const textSchema = getTextSchema();
-    const _cache = new Map();
     textSchema.dynamicFontSize = { min: 20, max: 30, fit: 'vertical' };
     const value = 'あいうあいうあいうあいうあいうあいうあいうあいうあいう';
-    const result = await calculateDynamicFontSize({ textSchema, font, value, _cache });
+    const result = await calculateDynamicFontSize({ textSchema, fontKitFont, value });
 
     expect(result).toBe(20);
   });
 
   it('should return max font size when content is too small to fit given constraints', async () => {
     const textSchema = getTextSchema();
-    const _cache = new Map();
     textSchema.dynamicFontSize = { min: 10, max: 30, fit: 'vertical' };
     const value = 'あ';
-    const result = await calculateDynamicFontSize({ textSchema, font, value, _cache });
+    const result = await calculateDynamicFontSize({ textSchema, fontKitFont, value });
 
     expect(result).toBe(30);
   });
 
   it('should return min font size when content is multi-line with too many lines for the container', async () => {
     const textSchema = getTextSchema();
-    const _cache = new Map();
     textSchema.dynamicFontSize = { min: 5, max: 20, fit: 'vertical' };
     const value = 'あ\nいう\nあ\nいう\nあ\nいう\nあ\nいう\nあ\nいう\nあ\nいう';
-    const result = await calculateDynamicFontSize({ textSchema, font, value, _cache });
+    const result = await calculateDynamicFontSize({ textSchema, fontKitFont, value });
 
     expect(result).toBe(5);
   });

--- a/packages/schemas/src/multiVariableText/uiRender.ts
+++ b/packages/schemas/src/multiVariableText/uiRender.ts
@@ -1,4 +1,4 @@
-import { UIRenderProps } from '@pdfme/common';
+import { getDefaultFont, UIRenderProps } from '@pdfme/common';
 import { MultiVariableTextSchema } from './types';
 import {
   uiRender as parentUiRender,
@@ -6,6 +6,7 @@ import {
   makeElementPlainTextContentEditable
 } from '../text/uiRender';
 import { isEditable } from '../utils';
+import { getFontKitFont } from '../text/helper';
 import { substituteVariables } from './helper';
 
 export const uiRender = async (arg: UIRenderProps<MultiVariableTextSchema>) => {
@@ -65,6 +66,8 @@ const formUiRender = async (arg: UIRenderProps<MultiVariableTextSchema>) => {
     onChange,
     stopEditing,
     theme,
+    _cache,
+    options,
   } = arg;
   const rawText = schema.text;
 
@@ -76,8 +79,10 @@ const formUiRender = async (arg: UIRenderProps<MultiVariableTextSchema>) => {
   const variables: Record<string, string> = JSON.parse(value) || {}
   const variableIndices = getVariableIndices(rawText);
   const substitutedText = substituteVariables(rawText, variables);
+  const font = options?.font || getDefaultFont();
+  const fontKitFont = await getFontKitFont(schema.fontName, font, _cache);
 
-  const textBlock = await buildStyledTextContainer(arg, substitutedText);
+  const textBlock = buildStyledTextContainer(arg, fontKitFont, substitutedText);
 
   // Construct content-editable spans for each variable within the string
   let inVarString = false;

--- a/packages/schemas/src/text/helper.ts
+++ b/packages/schemas/src/text/helper.ts
@@ -221,18 +221,16 @@ export const getSplittedLines = (textLine: string, calcValues: FontWidthCalcValu
  * Calculating space usage involves splitting lines where they exceed
  * the box width based on the proposed size.
  */
-export const calculateDynamicFontSize = async ({
+export const calculateDynamicFontSize = ({
   textSchema,
-  font,
+  fontKitFont,
   value,
   startingFontSize,
-  _cache,
 }: {
   textSchema: TextSchema;
-  font: Font;
+  fontKitFont: FontKitFont;
   value: string;
   startingFontSize?: number | undefined;
-  _cache: Map<any, any>;
 }) => {
   const {
     fontSize: schemaFontSize,
@@ -247,7 +245,6 @@ export const calculateDynamicFontSize = async ({
   if (dynamicFontSizeSetting.max < dynamicFontSizeSetting.min) return fontSize;
 
   const characterSpacing = schemaCharacterSpacing ?? DEFAULT_CHARACTER_SPACING;
-  const fontKitFont = await getFontKitFont(textSchema.fontName, font, _cache);
   const paragraphs = value.split('\n');
 
   let dynamicFontSize = fontSize;

--- a/packages/schemas/src/text/pdfRender.ts
+++ b/packages/schemas/src/text/pdfRender.ts
@@ -1,4 +1,5 @@
 import { PDFFont, PDFDocument } from '@pdfme/pdf-lib';
+import type { Font as FontKitFont } from 'fontkit';
 import type { TextSchema } from './types';
 import {
   PDFRenderProps,
@@ -60,21 +61,19 @@ const embedAndGetFontObj = async (arg: {
   return fontObj;
 };
 
-const getFontProp = async ({
+const getFontProp = ({
   value,
-  font,
+  fontKitFont,
   schema,
   colorType,
-  _cache,
 }: {
   value: string;
-  font: Font;
+  fontKitFont: FontKitFont;
   colorType?: ColorType;
   schema: TextSchema;
-  _cache: Map<any, any>;
 }) => {
   const fontSize = schema.dynamicFontSize
-    ? await calculateDynamicFontSize({ textSchema: schema, font, value, _cache })
+    ? calculateDynamicFontSize({ textSchema: schema, fontKitFont, value })
     : schema.fontSize ?? DEFAULT_FONT_SIZE;
   const color = hex2PrintingColor(schema.fontColor || DEFAULT_FONT_COLOR, colorType);
 
@@ -94,11 +93,11 @@ export const pdfRender = async (arg: PDFRenderProps<TextSchema>) => {
 
   const { font = getDefaultFont(), colorType } = options;
 
-  const [pdfFontObj, fontKitFont, fontProp] = await Promise.all([
+  const [pdfFontObj, fontKitFont] = await Promise.all([
     embedAndGetFontObj({ pdfDoc, font, _cache }),
     getFontKitFont(schema.fontName, font, _cache),
-    getFontProp({ value, font, schema, _cache, colorType }),
   ]);
+  const fontProp = getFontProp({ value, fontKitFont, schema, colorType });
 
   const { fontSize, color, alignment, verticalAlignment, lineHeight, characterSpacing } = fontProp;
 

--- a/packages/ui/src/components/Designer/index.tsx
+++ b/packages/ui/src/components/Designer/index.tsx
@@ -24,6 +24,7 @@ import {
   template2SchemasList,
   getPagesScrollTopByIndex,
   changeSchemas as _changeSchemas,
+  getMaxZoom,
 } from '../../helper';
 import { useUIPreProcessor, useScrollPageCursor, useInitEvents } from '../../hooks';
 import Root from '../Root';
@@ -63,6 +64,7 @@ const TemplateEditor = ({
   const i18n = useContext(I18nContext);
   const pluginsRegistry = useContext(PluginsRegistry);
   const options = useContext(OptionsContext);
+  const maxZoom = getMaxZoom();
 
   const [hoveringSchemaId, setHoveringSchemaId] = useState<string | null>(null);
   const [activeElements, setActiveElements] = useState<HTMLElement[]>([]);
@@ -73,7 +75,7 @@ const TemplateEditor = ({
   const [prevTemplate, setPrevTemplate] = useState<Template | null>(null);
 
   const { backgrounds, pageSizes, scale, error, refresh } =
-    useUIPreProcessor({ template, size, zoomLevel });
+    useUIPreProcessor({ template, size, zoomLevel, maxZoom });
 
   const onEdit = (targets: HTMLElement[]) => {
     setActiveElements(targets);

--- a/packages/ui/src/components/Preview.tsx
+++ b/packages/ui/src/components/Preview.tsx
@@ -10,7 +10,7 @@ import Paper from './Paper';
 import Renderer from './Renderer';
 import { useUIPreProcessor, useScrollPageCursor } from '../hooks';
 import { FontContext } from '../contexts';
-import { template2SchemasList, getPagesScrollTopByIndex } from '../helper';
+import { template2SchemasList, getPagesScrollTopByIndex, getMaxZoom } from '../helper';
 import { theme } from 'antd';
 
 const _cache = new Map();
@@ -27,6 +27,7 @@ const Preview = ({
   const { token } = theme.useToken();
 
   const font = useContext(FontContext);
+  const maxZoom = getMaxZoom();
 
   const containerRef = useRef<HTMLDivElement>(null);
   const paperRefs = useRef<HTMLDivElement[]>([]);
@@ -37,7 +38,7 @@ const Preview = ({
   const [schemasList, setSchemasList] = useState<SchemaForUI[][]>([[]] as SchemaForUI[][]);
 
   const { backgrounds, pageSizes, scale, error, refresh } =
-    useUIPreProcessor({ template, size, zoomLevel });
+    useUIPreProcessor({ template, size, zoomLevel, maxZoom });
 
   const isForm = Boolean(onChangeInput);
 

--- a/packages/ui/src/components/Renderer.tsx
+++ b/packages/ui/src/components/Renderer.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useContext, ReactNode, useRef, useMemo } from 'react'
 import { Dict, Mode, ZOOM, UIRenderProps, SchemaForUI, BasePdf, Schema, Plugin, UIOptions, cloneDeep } from '@pdfme/common';
 import { theme as antdTheme } from 'antd';
 import { SELECTABLE_CLASSNAME } from '../constants';
-import { PluginsRegistry, OptionsContext, I18nContext } from '../contexts';
+import { PluginsRegistry, OptionsContext, I18nContext, CacheContext } from '../contexts';
 
 type RendererProps = Omit<
   UIRenderProps<Schema>,
@@ -96,7 +96,7 @@ const Renderer = (props: RendererProps) => {
 
   
   const ref = useRef<HTMLDivElement>(null);
-  const _cache = useRef<Map<any, any>>(new Map());
+  const _cache = useContext(CacheContext);
   const plugin = Object.values(pluginsRegistry).find(
     (plugin) => plugin?.propPanel.defaultSchema.type === schema.type
   ) as Plugin<any>;
@@ -133,7 +133,7 @@ Check this document: https://pdfme.com/docs/custom-schemas`);
         options,
         theme,
         i18n,
-        _cache: _cache.current,
+        _cache,
       });
     }
     return () => {

--- a/packages/ui/src/contexts.ts
+++ b/packages/ui/src/contexts.ts
@@ -10,3 +10,5 @@ export const FontContext = createContext(getDefaultFont());
 export const PluginsRegistry = createContext<Plugins>(builtInPlugins);
 
 export const OptionsContext = createContext<UIOptions>({});
+
+export const CacheContext = createContext<Map<any, any>>(new Map());

--- a/packages/ui/src/hooks.ts
+++ b/packages/ui/src/hooks.ts
@@ -36,9 +36,9 @@ export const usePrevious = <T>(value: T) => {
 const getScale = (n: number, paper: number) =>
   Math.floor((n / paper > 1 ? 1 : n / paper) * 100) / 100;
 
-type UIPreProcessorProps = { template: Template; size: Size; zoomLevel: number };
+type UIPreProcessorProps = { template: Template; size: Size; zoomLevel: number; maxZoom: number };
 
-export const useUIPreProcessor = ({ template, size, zoomLevel }: UIPreProcessorProps) => {
+export const useUIPreProcessor = ({ template, size, zoomLevel, maxZoom }: UIPreProcessorProps) => {
   const [backgrounds, setBackgrounds] = useState<string[]>([]);
   const [pageSizes, setPageSizes] = useState<Size[]>([]);
   const [scale, setScale] = useState(0);
@@ -69,7 +69,7 @@ export const useUIPreProcessor = ({ template, size, zoomLevel }: UIPreProcessorP
 
       const [_pages, imgBuffers] = await Promise.all([
         pdf2size(b64toUint8Array(_basePdf)),
-        pdf2img(b64toUint8Array(_basePdf), { scale: getMaxZoom() }),
+        pdf2img(b64toUint8Array(_basePdf), { scale: maxZoom }),
       ]);
 
       _pageSizes = _pages;

--- a/packages/ui/src/hooks.ts
+++ b/packages/ui/src/hooks.ts
@@ -19,8 +19,7 @@ import {
   moveCommandToChangeSchemasArg,
   arrayBufferToBase64,
   initShortCuts,
-  destroyShortCuts,
-  getMaxZoom,
+  destroyShortCuts
 } from './helper.js';
 import { RULER_HEIGHT } from './constants.js';
 


### PR DESCRIPTION
fixes #693 

Having a `CacheContext` means the cache remains global, not just one cache per schema that is sometimes lost on browser resize.

Also reduced the number of calls to `getFontKitFont()` by pulling it higher up, which means less arguments need passing and less async functions. This is hopefully a bit cleaner.