### PR TITLE
Upgrade Canvas

### DIFF
--- a/packages/converter/package.json
+++ b/packages/converter/package.json
@@ -45,7 +45,9 @@
   },
   "dependencies": {
     "@pdfme/common": "*",
-    "pdfjs-dist": "^3.11.174",
+    "pdfjs-dist": "^3.11.174"
+  },
+  "optionalDependencies": {
     "canvas": "^3.1.0"
   },
   "devDependencies": {

--- a/packages/converter/package.json
+++ b/packages/converter/package.json
@@ -45,14 +45,12 @@
   },
   "dependencies": {
     "@pdfme/common": "*",
-    "pdfjs-dist": "^3.11.174"
+    "pdfjs-dist": "^3.11.174",
+    "canvas": "^3.1.0"
   },
   "devDependencies": {
     "@pdfme/generator": "file:../generator",
     "@types/estree": "^1.0.6"
-  },
-  "optionalDependencies": {
-    "canvas": "^2.11.0"
   },
   "jest": {
     "resolver": "ts-jest-resolver",

--- a/playground/package.json
+++ b/playground/package.json
@@ -19,7 +19,7 @@
     "@pdfme/generator": "file:../packages/generator/dist",
     "@pdfme/schemas": "file:../packages/schemas/dist",
     "@pdfme/ui": "file:../packages/ui/dist",
-    "canvas": "^2.11.2",
+    "canvas": "^3.1.0",
     "esbuild": "^0.19.10",
     "lucide-react": "^0.475.0",
     "react": "^18.2.0",


### PR DESCRIPTION
When trying to contribute I got the following error:
```
src/index.node.ts:1:30 - error TS2307: Cannot find module 'canvas' or its corresponding type declarations.

1 import { createCanvas } from 'canvas';
                               ~~~~~~~~
```

The issue when installing canvas
```
npm error node-pre-gyp http GET https://github.com/Automattic/node-canvas/releases/download/v2.11.2/canvas-v2.11.2-node-v127-darwin-unknown-arm64.tar.gz
npm error node-pre-gyp ERR! install response status 404 Not Found on https://github.com/Automattic/node-canvas/releases/download/v2.11.2/canvas-v2.11.2-node-v127-darwin-unknown-arm64.tar.gz 
npm error node-pre-gyp WARN Pre-built binaries not installable for canvas@2.11.2 and node@22.4.1 (node-v127 ABI, unknown) (falling back to source compile with node-gyp) 
npm error node-pre-gyp WARN Hit error response status 404 Not Found on https://github.com/Automattic/node-canvas/releases/download/v2.11.2/canvas-v2.11.2-node-v127-darwin-unknown-arm64.tar.gz 
np
```

I upgraded canvas and could run successfully all tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated dependency management by adding a new optional version of the `canvas` package and removing the older version for improved stability.
  - Upgraded the `canvas` package version in the playground for enhanced features and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->