### PR TITLE
Add separate build for node

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -26,7 +26,10 @@
   "types": "dist/types/src/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/esm/src/index.js",
+      "import": {
+        "node": "./dist/node/src/index.js",
+        "default": "./dist/esm/src/index.js"
+      },
       "require": "./dist/cjs/src/index.js",
       "types": "./dist/types/src/index.d.ts"
     }
@@ -34,9 +37,10 @@
   "scripts": {
     "dev": "node set-version.js && tsc -p tsconfig.esm.json -w",
     "prebuild": "node set-version.js",
-    "build": "npm-run-all --parallel build:cjs build:esm",
+    "build": "npm-run-all --parallel build:cjs build:esm build:node",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json",
+    "build:node": "tsc -p tsconfig.node.json",
     "clean": "rimraf dist",
     "lint": "eslint --ext .ts src",
     "test": "jest",

--- a/packages/common/tsconfig.node.json
+++ b/packages/common/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "outDir": "./dist/node",
+    "declaration": true,
+    "declarationDir": "dist/types",
+    "skipLibCheck": true
+  }
+}

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -26,16 +26,20 @@
   "types": "dist/types/src/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/esm/src/index.js",
+      "import": {
+        "node": "./dist/node/src/index.js",
+        "default": "./dist/esm/src/index.js"
+      },
       "require": "./dist/cjs/src/index.js",
       "types": "./dist/types/src/index.d.ts"
     }
   },
   "scripts": {
     "dev": "tsc -p tsconfig.esm.json -w",
-    "build": "npm-run-all --parallel build:cjs build:esm",
+    "build": "npm-run-all --parallel build:cjs build:esm build:node",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json",
+    "build:node": "tsc -p tsconfig.node.json",
     "clean": "rimraf dist",
     "lint": "eslint --ext .ts src",
     "test": "jest",

--- a/packages/generator/tsconfig.node.json
+++ b/packages/generator/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "outDir": "./dist/node",
+    "declaration": true,
+    "declarationDir": "dist/types",
+    "skipLibCheck": true
+  }
+}

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -26,21 +26,28 @@
   "types": "dist/types/src/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/esm/src/index.js",
+      "import": {
+        "node": "./dist/node/src/index.js",
+        "default": "./dist/esm/src/index.js"
+      },
       "require": "./dist/cjs/src/index.js",
       "types": "./dist/types/src/index.d.ts"
     },
     "./utils": {
-      "import": "./dist/esm/src/utils.js",
+      "import": {
+        "node": "./dist/node/src/utils.js",
+        "default": "./dist/esm/src/utils.js"
+      },
       "require": "./dist/cjs/src/utils.js",
       "types": "./dist/types/src/utils.d.ts"
     }
   },
   "scripts": {
     "dev": "tsc -p tsconfig.esm.json -w",
-    "build": "npm-run-all --parallel build:cjs build:esm",
+    "build": "npm-run-all --parallel build:cjs build:esm build:node",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json",
+    "build:node": "tsc -p tsconfig.node.json",
     "clean": "rimraf dist",
     "lint": "eslint --ext .ts src",
     "test": "jest",

--- a/packages/schemas/tsconfig.node.json
+++ b/packages/schemas/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "outDir": "./dist/node",
+    "declaration": true,
+    "declarationDir": "dist/types",
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
For the Node.js framework utilizing the NodeNext module, our package encounters the following error:
 
`yntaxError: The requested module '@pdfme/generator' does not provide an export named 'generate'`

To address this issue, I have added a dedicated build script specifically for Node.js applications using the NodeNext module. Typically, Node.js applications require the generator, common, and schema packages. Therefore, I have included these three packages in the build script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced module resolution with dedicated entry points for both Node.js and standard environments.
  - Expanded the build process to include a Node.js-specific step running in parallel with existing builds.
  - Introduced tailored build configurations that optimize TypeScript compilation for Node.js compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->