### PR TITLE
Restore NotoSerifJP and NotoSansJP in Playground Font Settings

### DIFF
--- a/playground/src/helper.ts
+++ b/playground/src/helper.ts
@@ -12,14 +12,14 @@ export function fromKebabCase(str: string): string {
 
 export const getFontsData = (): Font => ({
   ...getDefaultFont(),
-  // NotoSerifJP: {
-  //   fallback: false,
-  //   data: 'https://fonts.gstatic.com/s/notoserifjp/v30/xn71YHs72GKoTvER4Gn3b5eMRtWGkp6o7MjQ2bwxOubAILO5wBCU.ttf',
-  // },
-  // NotoSansJP: {
-  //   fallback: false,
-  //   data: 'https://fonts.gstatic.com/s/notosansjp/v53/-F6jfjtqLzI2JPCgQBnw7HFyzSD-AsregP8VFBEj75vY0rw-oME.ttf',
-  // },
+  NotoSerifJP: {
+    fallback: false,
+    data: 'https://fonts.gstatic.com/s/notoserifjp/v30/xn71YHs72GKoTvER4Gn3b5eMRtWGkp6o7MjQ2bwxOubAILO5wBCU.ttf',
+  },
+  NotoSansJP: {
+    fallback: false,
+    data: 'https://fonts.gstatic.com/s/notosansjp/v53/-F6jfjtqLzI2JPCgQBnw7HFyzSD-AsregP8VFBEj75vY0rw-oME.ttf',
+  },
   'PinyonScript-Regular': {
     fallback: false,
     data: 'https://fonts.gstatic.com/s/pinyonscript/v22/6xKpdSJbL9-e9LuoeQiDRQR8aOLQO4bhiDY.ttf',

--- a/playground/src/helper.ts
+++ b/playground/src/helper.ts
@@ -12,6 +12,10 @@ export function fromKebabCase(str: string): string {
 
 export const getFontsData = (): Font => ({
   ...getDefaultFont(),
+  'PinyonScript-Regular': {
+    fallback: false,
+    data: 'https://fonts.gstatic.com/s/pinyonscript/v22/6xKpdSJbL9-e9LuoeQiDRQR8aOLQO4bhiDY.ttf',
+  },
   NotoSerifJP: {
     fallback: false,
     data: 'https://fonts.gstatic.com/s/notoserifjp/v30/xn71YHs72GKoTvER4Gn3b5eMRtWGkp6o7MjQ2bwxOubAILO5wBCU.ttf',
@@ -19,11 +23,7 @@ export const getFontsData = (): Font => ({
   NotoSansJP: {
     fallback: false,
     data: 'https://fonts.gstatic.com/s/notosansjp/v53/-F6jfjtqLzI2JPCgQBnw7HFyzSD-AsregP8VFBEj75vY0rw-oME.ttf',
-  },
-  'PinyonScript-Regular': {
-    fallback: false,
-    data: 'https://fonts.gstatic.com/s/pinyonscript/v22/6xKpdSJbL9-e9LuoeQiDRQR8aOLQO4bhiDY.ttf',
-  },
+  }
 });
 
 export const readFile = (file: File | null, type: 'text' | 'dataURL' | 'arrayBuffer') => {


### PR DESCRIPTION
### Summary  
This PR restores **NotoSerifJP** and **NotoSansJP** in the font settings of the playground by uncommenting their values.  

### Related Discussion  
This issue was discussed in [GitHub Discussions #845](https://github.com/pdfme/pdfme/discussions/845).  

### Why This Change Is Important  
Restoring Japanese fonts makes it easier to confirm that **pdfme supports non-English fonts**, which is valuable for library selection.  
In my case, I used the playground to **demonstrate pdfme’s usability** to our sales team.  
After deciding to adopt pdfme and starting development, we noticed that Japanese fonts were missing, which caused confusion.  

### What I Did  
- Uncommented **NotoSerifJP** and **NotoSansJP** in the playground’s font settings.  

### Verification  
- Confirmed that this change **does not affect e2e tests**.  

This is a simple fix, but it improves usability for users who need **multilingual PDF support**.  
Thank you for your time and consideration! 😊  
