### PR TITLE
onChange should be fired only if the schema is in the current page

### DIFF
--- a/packages/ui/src/components/Designer/Canvas/index.tsx
+++ b/packages/ui/src/components/Designer/Canvas/index.tsx
@@ -506,6 +506,18 @@ const Canvas = (props: Props, ref: Ref<HTMLDivElement>) => {
             value = replacePlaceholders({ content, variables, schemas: schemasList });
           }
 
+          const onChange =
+            schemasList[pageCursor].filter((s) => s.id === schema.id).length > 0
+              ? (arg) => {
+                  // Use type assertion to safely handle the argument
+                  type ChangeArg = { key: string; value: unknown };
+                  const args = Array.isArray(arg) ? (arg as ChangeArg[]) : [arg as ChangeArg];
+                  changeSchemas(
+                    args.map(({ key, value }) => ({ key, value, schemaId: schema.id })),
+                  );
+                }
+              : undefined;
+
           return (
             <Renderer
               key={schema.id}
@@ -514,12 +526,7 @@ const Canvas = (props: Props, ref: Ref<HTMLDivElement>) => {
               value={value}
               onChangeHoveringSchemaId={onChangeHoveringSchemaId}
               mode={mode}
-              onChange={(arg) => {
-                // Use type assertion to safely handle the argument
-                type ChangeArg = { key: string; value: unknown };
-                const args = Array.isArray(arg) ? (arg as ChangeArg[]) : [arg as ChangeArg];
-                changeSchemas(args.map(({ key, value }) => ({ key, value, schemaId: schema.id })));
-              }}
+              onChange={onChange}
               stopEditing={() => setEditing(false)}
               outline={`1px ${hoveringSchemaId === schema.id ? 'solid' : 'dashed'} ${
                 schema.readOnly && hoveringSchemaId !== schema.id

--- a/packages/ui/src/components/Designer/Canvas/index.tsx
+++ b/packages/ui/src/components/Designer/Canvas/index.tsx
@@ -507,7 +507,7 @@ const Canvas = (props: Props, ref: Ref<HTMLDivElement>) => {
           }
 
           const onChange =
-            schemasList[pageCursor].filter((s) => s.id === schema.id).length > 0
+            schemasList[pageCursor].some((s) => s.id === schema.id)
               ? (arg) => {
                   // Use type assertion to safely handle the argument
                   type ChangeArg = { key: string; value: unknown };

--- a/packages/ui/src/components/Designer/Canvas/index.tsx
+++ b/packages/ui/src/components/Designer/Canvas/index.tsx
@@ -506,18 +506,6 @@ const Canvas = (props: Props, ref: Ref<HTMLDivElement>) => {
             value = replacePlaceholders({ content, variables, schemas: schemasList });
           }
 
-          const onChange =
-            schemasList[pageCursor].some((s) => s.id === schema.id)
-              ? (arg) => {
-                  // Use type assertion to safely handle the argument
-                  type ChangeArg = { key: string; value: unknown };
-                  const args = Array.isArray(arg) ? (arg as ChangeArg[]) : [arg as ChangeArg];
-                  changeSchemas(
-                    args.map(({ key, value }) => ({ key, value, schemaId: schema.id })),
-                  );
-                }
-              : undefined;
-
           return (
             <Renderer
               key={schema.id}
@@ -526,7 +514,18 @@ const Canvas = (props: Props, ref: Ref<HTMLDivElement>) => {
               value={value}
               onChangeHoveringSchemaId={onChangeHoveringSchemaId}
               mode={mode}
-              onChange={onChange}
+              onChange={
+                schemasList[pageCursor].some((s) => s.id === schema.id)
+                  ? (arg) => {
+                      // Use type assertion to safely handle the argument
+                      type ChangeArg = { key: string; value: unknown };
+                      const args = Array.isArray(arg) ? (arg as ChangeArg[]) : [arg as ChangeArg];
+                      changeSchemas(
+                        args.map(({ key, value }) => ({ key, value, schemaId: schema.id })),
+                      );
+                    }
+                  : undefined
+              }
               stopEditing={() => setEditing(false)}
               outline={`1px ${hoveringSchemaId === schema.id ? 'solid' : 'dashed'} ${
                 schema.readOnly && hoveringSchemaId !== schema.id


### PR DESCRIPTION
This is a workaround with my random thought, but it fixes #964. 

If the `schema.height` differs from the calculated `tableHeight`, `onChange` will be triggered at the following code:

https://github.com/pdfme/pdfme/blob/34e9f4956912c65a16bc5c7b7f7e921f58281206/packages/schemas/src/tables/uiRender.ts#L431-L434

which will be handled by the follwoing function:

https://github.com/pdfme/pdfme/blob/34e9f4956912c65a16bc5c7b7f7e921f58281206/packages/ui/src/helper.ts#L567-L591

In this code, on the initial load,`tgt` will be undefined if the schema is not on the first page, since the passed `schemas` argument references the `SchemaForUI`  array of the page zero. This prevents updating `schema.height` and casuses an infinite loop.

My idea is simply to stop passing `onChange` function if the schema is not on the current page at the `Canvas` level. 

