### PR TITLE
Fix: do not throw an error in a debounced function if an instance was destroyed

### DIFF
--- a/packages/ui/src/class.ts
+++ b/packages/ui/src/class.ts
@@ -23,7 +23,7 @@ import { builtInPlugins } from '@pdfme/schemas';
 export abstract class BaseUIClass {
   protected domContainer!: HTMLElement | null;
 
-  protected _isDestroyed!: boolean = false;
+  protected _isDestroyed: boolean = false;
 
   protected template!: Template;
 


### PR DESCRIPTION
The error is thrown in a debounced function which makes it impossible to catch and is useless. If an instance is already destroyed and you have a delayed action scheduled, then either cancel it or ignore the action if the instance is not valid anymore.