### PR TITLE
Update Japanese text to English where language configured as 'en'

### DIFF
--- a/playground/src/routes/FormAndViewer.tsx
+++ b/playground/src/routes/FormAndViewer.tsx
@@ -65,7 +65,7 @@ function FormAndViewerApp() {
         options: {
           font: getFontsData(),
           lang: 'en',
-          labels: { 'signature.clear': '消去' },
+          labels: { 'signature.clear': 'Clear' },
           theme: {
             token: {
               colorPrimary: '#25c2a0',


### PR DESCRIPTION
Hey mate,

Thanks for this library! I just noticed there was a label marked with `lang: 'en'` that had Japanese text in it - this fixes that.

Cheers ✌️