### PR TITLE
Make Designer class initial state configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,6 @@
 dist
 coverage/
 
-**/repomix-output.txt
+**/repomix-output.{txt,xml}
 
 **/__diff_output__/**

--- a/packages/common/src/schema.ts
+++ b/packages/common/src/schema.ts
@@ -202,7 +202,6 @@ export const UIOptions = CommonOptions.extend({
   icons: z.record(z.string(), z.string()).optional(),
   requiredByDefault: z.boolean().optional(),
   maxZoom: z.number().optional(),
-  pageCursor: z.number().optional(),
   sidebarOpen: z.boolean().optional(),
   zoomLevel: z.number().optional(),
 });

--- a/packages/common/src/schema.ts
+++ b/packages/common/src/schema.ts
@@ -202,6 +202,9 @@ export const UIOptions = CommonOptions.extend({
   icons: z.record(z.string(), z.string()).optional(),
   requiredByDefault: z.boolean().optional(),
   maxZoom: z.number().optional(),
+  pageCursor: z.number().optional(),
+  sidebarOpen: z.boolean().optional(),
+  zoomLevel: z.number().optional(),
 });
 
 const HTMLElementSchema: z.ZodSchema<HTMLElement> = z.any().refine((v) => v instanceof HTMLElement);

--- a/packages/ui/src/Designer.tsx
+++ b/packages/ui/src/Designer.tsx
@@ -16,15 +16,11 @@ import AppContextProvider from './components/AppContextProvider.js';
 class Designer extends BaseUIClass {
   private onSaveTemplateCallback?: (template: Template) => void;
   private onChangeTemplateCallback?: (template: Template) => void;
-  private pageCursor = 0;
+  private pageCursor: number = 0;
 
   constructor(props: DesignerProps) {
     super(props);
     checkDesignerProps(props);
-
-    if (typeof props.options?.pageCursor === 'number') {
-      this.pageCursor = props.options.pageCursor;
-    }
   }
 
   public saveTemplate() {

--- a/packages/ui/src/Designer.tsx
+++ b/packages/ui/src/Designer.tsx
@@ -16,11 +16,15 @@ import AppContextProvider from './components/AppContextProvider.js';
 class Designer extends BaseUIClass {
   private onSaveTemplateCallback?: (template: Template) => void;
   private onChangeTemplateCallback?: (template: Template) => void;
-  private pageCursor: number = 0;
+  private pageCursor = 0;
 
   constructor(props: DesignerProps) {
     super(props);
     checkDesignerProps(props);
+
+    if (typeof props.options?.pageCursor === 'number') {
+      this.pageCursor = props.options.pageCursor;
+    }
   }
 
   public saveTemplate() {

--- a/packages/ui/src/components/Designer/index.tsx
+++ b/packages/ui/src/components/Designer/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useContext, useCallback } from 'react';
+import React, { useRef, useState, useContext, useCallback, useEffect } from 'react';
 import {
   cloneDeep,
   ZOOM,
@@ -69,9 +69,9 @@ const TemplateEditor = ({
   const [hoveringSchemaId, setHoveringSchemaId] = useState<string | null>(null);
   const [activeElements, setActiveElements] = useState<HTMLElement[]>([]);
   const [schemasList, setSchemasList] = useState<SchemaForUI[][]>([[]] as SchemaForUI[][]);
-  const [pageCursor, setPageCursor] = useState(0);
-  const [zoomLevel, setZoomLevel] = useState(1);
-  const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [pageCursor, setPageCursor] = useState(options.pageCursor ?? 0);
+  const [zoomLevel, setZoomLevel] = useState(options.zoomLevel ?? 1);
+  const [sidebarOpen, setSidebarOpen] = useState(options.sidebarOpen ?? true);
   const [prevTemplate, setPrevTemplate] = useState<Template | null>(null);
 
   const { backgrounds, pageSizes, scale, error, refresh } = useUIPreProcessor({
@@ -90,6 +90,22 @@ const TemplateEditor = ({
     setActiveElements([]);
     setHoveringSchemaId(null);
   };
+
+  // Update component state only when _options_ changes
+  // Ignore exhaustive useEffect dependency warnings here
+  useEffect(() => {
+    if (typeof options.pageCursor === 'number' && options.pageCursor !== pageCursor) {
+      setPageCursor(options.pageCursor);
+      onPageCursorChange(options.pageCursor);
+    }
+    if (typeof options.zoomLevel === 'number' && options.zoomLevel !== zoomLevel) {
+      setZoomLevel(options.zoomLevel);
+    }
+    if (typeof options.sidebarOpen === 'boolean' && options.sidebarOpen !== sidebarOpen) {
+      setSidebarOpen(options.sidebarOpen);
+    }
+    // eslint-disable-next-line
+  }, [options, onPageCursorChange]);
 
   useScrollPageCursor({
     ref: canvasRef,

--- a/packages/ui/src/components/Designer/index.tsx
+++ b/packages/ui/src/components/Designer/index.tsx
@@ -101,7 +101,7 @@ const TemplateEditor = ({
       setSidebarOpen(options.sidebarOpen);
     }
     // eslint-disable-next-line
-  }, [options, onPageCursorChange]);
+  }, [options]);
 
   useScrollPageCursor({
     ref: canvasRef,

--- a/packages/ui/src/components/Designer/index.tsx
+++ b/packages/ui/src/components/Designer/index.tsx
@@ -69,7 +69,7 @@ const TemplateEditor = ({
   const [hoveringSchemaId, setHoveringSchemaId] = useState<string | null>(null);
   const [activeElements, setActiveElements] = useState<HTMLElement[]>([]);
   const [schemasList, setSchemasList] = useState<SchemaForUI[][]>([[]] as SchemaForUI[][]);
-  const [pageCursor, setPageCursor] = useState(options.pageCursor ?? 0);
+  const [pageCursor, setPageCursor] = useState(0);
   const [zoomLevel, setZoomLevel] = useState(options.zoomLevel ?? 1);
   const [sidebarOpen, setSidebarOpen] = useState(options.sidebarOpen ?? true);
   const [prevTemplate, setPrevTemplate] = useState<Template | null>(null);
@@ -94,10 +94,6 @@ const TemplateEditor = ({
   // Update component state only when _options_ changes
   // Ignore exhaustive useEffect dependency warnings here
   useEffect(() => {
-    if (typeof options.pageCursor === 'number' && options.pageCursor !== pageCursor) {
-      setPageCursor(options.pageCursor);
-      onPageCursorChange(options.pageCursor);
-    }
     if (typeof options.zoomLevel === 'number' && options.zoomLevel !== zoomLevel) {
       setZoomLevel(options.zoomLevel);
     }

--- a/packages/ui/src/components/Preview.tsx
+++ b/packages/ui/src/components/Preview.tsx
@@ -41,7 +41,7 @@ const Preview = ({
   const paperRefs = useRef<HTMLDivElement[]>([]);
 
   const [unitCursor, setUnitCursor] = useState(0);
-  const [pageCursor, setPageCursor] = useState(options.pageCursor ?? 0);
+  const [pageCursor, setPageCursor] = useState(0);
   const [zoomLevel, setZoomLevel] = useState(options.zoomLevel ?? 1);
   const [schemasList, setSchemasList] = useState<SchemaForUI[][]>([[]] as SchemaForUI[][]);
 
@@ -83,9 +83,6 @@ const Preview = ({
   // Update component state only when _options_ changes
   // Ignore exhaustive useEffect dependency warnings here
   useEffect(() => {
-    if (typeof options.pageCursor === 'number' && options.pageCursor !== pageCursor) {
-      setPageCursor(options.pageCursor);
-    }
     if (typeof options.zoomLevel === 'number' && options.zoomLevel !== zoomLevel) {
       setZoomLevel(options.zoomLevel);
     }

--- a/packages/ui/src/components/Preview.tsx
+++ b/packages/ui/src/components/Preview.tsx
@@ -16,7 +16,7 @@ import CtlBar from './CtlBar.js';
 import Paper from './Paper.js';
 import Renderer from './Renderer.js';
 import { useUIPreProcessor, useScrollPageCursor } from '../hooks.js';
-import { FontContext } from '../contexts.js';
+import { FontContext, OptionsContext } from '../contexts.js';
 import { template2SchemasList, getPagesScrollTopByIndex, useMaxZoom } from '../helper.js';
 import { theme } from 'antd';
 
@@ -34,14 +34,15 @@ const Preview = ({
   const { token } = theme.useToken();
 
   const font = useContext(FontContext);
+  const options = useContext(OptionsContext);
   const maxZoom = useMaxZoom();
 
   const containerRef = useRef<HTMLDivElement>(null);
   const paperRefs = useRef<HTMLDivElement[]>([]);
 
   const [unitCursor, setUnitCursor] = useState(0);
-  const [pageCursor, setPageCursor] = useState(0);
-  const [zoomLevel, setZoomLevel] = useState(1);
+  const [pageCursor, setPageCursor] = useState(options.pageCursor ?? 0);
+  const [zoomLevel, setZoomLevel] = useState(options.zoomLevel ?? 1);
   const [schemasList, setSchemasList] = useState<SchemaForUI[][]>([[]] as SchemaForUI[][]);
 
   const { backgrounds, pageSizes, scale, error, refresh } = useUIPreProcessor({
@@ -78,6 +79,18 @@ const Preview = ({
       })
       .catch((err) => console.error(`[@pdfme/ui] `, err));
   };
+
+  // Update component state only when _options_ changes
+  // Ignore exhaustive useEffect dependency warnings here
+  useEffect(() => {
+    if (typeof options.pageCursor === 'number' && options.pageCursor !== pageCursor) {
+      setPageCursor(options.pageCursor);
+    }
+    if (typeof options.zoomLevel === 'number' && options.zoomLevel !== zoomLevel) {
+      setZoomLevel(options.zoomLevel);
+    }
+    // eslint-disable-next-line
+  }, [options]);
 
   useEffect(() => {
     if (unitCursor > inputs.length - 1) {

--- a/website/docs/custom-ui.md
+++ b/website/docs/custom-ui.md
@@ -76,3 +76,26 @@ new Designer({
   },
 });
 ```
+
+## UI Options
+
+You can control aspects of the UI state by passing options:
+
+```javascript
+// Initialize with specific states (also works for Form and Viewer):
+const designer = new Designer({
+  domContainer,
+  template,
+  options: {
+    zoomLevel: 1.5,
+    pageCursor: 0,
+    sidebarOpen: false,  // (Designer only)
+  }
+});
+
+// Update states after initialization:
+designer.updateOptions({
+  zoomLevel: 2,
+  sidebarOpen: true
+});
+```

--- a/website/docs/custom-ui.md
+++ b/website/docs/custom-ui.md
@@ -88,7 +88,6 @@ const designer = new Designer({
   template,
   options: {
     zoomLevel: 1.5,
-    pageCursor: 0,
     sidebarOpen: false,  // (Designer only)
   }
 });

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -258,7 +258,14 @@ const template: Template = {
   // skip...　Check the Template section.
 };
 
-const designer = new Designer({ domContainer, template });
+// configure some or all of the UI state (optional, defaults shown below)
+ const options = {
+   pageCursor: 0,
+   zoomLevel: 1,
+   sidebarOpen: true
+ };
+
+const designer = new Designer({ domContainer, template, options });
 ```
 
 The Designer class is instantiated as shown above, and the template designer is displayed in the `domContainer`.  

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -260,7 +260,6 @@ const template: Template = {
 
 // configure some or all of the UI state (optional, defaults shown below)
  const options = {
-   pageCursor: 0,
    zoomLevel: 1,
    sidebarOpen: true
  };

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/custom-ui.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/custom-ui.md
@@ -76,3 +76,25 @@ new Designer({
   },
 });
 ```
+
+## UIオプション
+
+UIの状態をオプションで制御できます。
+
+```javascript
+// 特定の状態で初期化（FormやViewerでも同様に使えます）:
+const designer = new Designer({
+  domContainer,
+  template,
+  options: {
+    zoomLevel: 1.5,
+    sidebarOpen: false,  // （Designerのみ）
+  }
+});
+
+// 初期化後に状態を更新:
+designer.updateOptions({
+  zoomLevel: 2,
+  sidebarOpen: true
+});
+```

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/getting-started.md
@@ -275,6 +275,18 @@ const designer = new Designer({ domContainer, template });
 - `onSaveTemplate`
 - `destroy`
 
+UIの状態は `options` で制御できます（省略時は下記のデフォルト値です）。
+
+```js
+// UIの状態を一部またはすべて設定（省略時のデフォルト値を例示）
+const options = {
+  zoomLevel: 1,
+  sidebarOpen: true
+};
+
+const designer = new Designer({ domContainer, template, options });
+```
+
 ### フォーム
 
 テンプレートを使用してフォームとPDFビューワーを作成できます。


### PR DESCRIPTION
Hey again,

I'm hoping you might be open to making this change such that things like whether or not the sidebar is open on first load is configurable in the Designer constructor.

~Raising this as a draft for now as I haven't had a chance to properly test it locally yet - I'll update this description and the PR status when I do.~

EDIT: I've now tested this locally using the playground and updated my initial changes accordingly - all seems to be working nicely. I've set it up so `sidebarOpen` and `zoomLevel` ~and `pageCursor`~ are all configurable by passing an object with one or more of those fields as `initialState` to the Designer class constructor or component. Any fields omitted from an incoming `initialState` object will fallback to the default as originally designed.

Let me know if you have any feedback or suggestions :)