### PR TITLE
Default fontName to fallback font for all newly created schemas in UI

### DIFF
--- a/packages/ui/__tests__/helper.test.ts
+++ b/packages/ui/__tests__/helper.test.ts
@@ -1,5 +1,5 @@
 import { SchemaForUI, Schema, Template, BLANK_PDF, BasePdf, pluginRegistry } from '@pdfme/common';
-import { uuid, getUniqueSchemaName, schemasList2template, changeSchemas } from '../src/helper';
+import { uuid, getUniqueSchemaName, schemasList2template, changeSchemas, setFontNameRecursively } from '../src/helper';
 import { text, image } from '@pdfme/schemas';
 
 const getSchema = (): Schema => ({
@@ -519,5 +519,67 @@ describe('changeSchemas test', () => {
         height: 100,
       },
     ]);
+  });
+});
+
+describe('setFontNameRecursively', () => {
+  it('sets fontName in object with undefined fontName property', () => {
+    const obj = { fontName: undefined, content: 'test' };
+    setFontNameRecursively(obj, 'Arial');
+    expect(obj.fontName).toEqual('Arial');
+  });
+
+  it('does not modify existing fontName values', () => {
+    const obj = { fontName: 'Helvetica', content: 'test' };
+    setFontNameRecursively(obj, 'Arial');
+    expect(obj.fontName).toEqual('Helvetica');
+  });
+
+  it('recursively sets fontName in nested objects', () => {
+    const obj = {
+      outer: {
+        fontName: undefined,
+        inner: {
+          fontName: undefined,
+          content: 'test'
+        }
+      }
+    };
+    setFontNameRecursively(obj, 'Arial');
+    expect(obj.outer.fontName).toEqual('Arial');
+    expect(obj.outer.inner.fontName).toEqual('Arial');
+  });
+
+  it('handles arrays of objects', () => {
+    const obj = {
+      items: [
+        { fontName: undefined, content: 'item1' },
+        { fontName: undefined, content: 'item2' }
+      ]
+    };
+    setFontNameRecursively(obj, 'Arial');
+    expect(obj.items[0].fontName).toEqual('Arial');
+    expect(obj.items[1].fontName).toEqual('Arial');
+  });
+
+  it('ignores null values', () => {
+    const obj = { fontName: undefined, nullProp: null };
+    setFontNameRecursively(obj, 'Arial');
+    expect(obj.fontName).toEqual('Arial');
+    expect(obj.nullProp).toBeNull();
+  });
+
+  it('handles empty objects', () => {
+    const obj = {};
+    setFontNameRecursively(obj, 'Arial');
+    expect(obj).toEqual({});
+  });
+
+  it('returns early for null input', () => {
+    expect(() => setFontNameRecursively(null as any, 'Arial')).not.toThrow();
+  });
+
+  it('returns early for undefined input', () => {
+    expect(() => setFontNameRecursively(undefined as any, 'Arial')).not.toThrow();
   });
 });

--- a/packages/ui/__tests__/helper.test.ts
+++ b/packages/ui/__tests__/helper.test.ts
@@ -535,19 +535,24 @@ describe('setFontNameRecursively', () => {
     expect(obj.fontName).toEqual('Helvetica');
   });
 
-  it('recursively sets fontName in nested objects', () => {
+  it('recursively sets fontName in nested objects and preserves other properties', () => {
     const obj = {
       outer: {
         fontName: undefined,
+        otherProp: 'unchanged',
         inner: {
           fontName: undefined,
-          content: 'test'
+          content: 'test',
+          style: { color: 'red' }
         }
       }
     };
     setFontNameRecursively(obj, 'Arial');
     expect(obj.outer.fontName).toEqual('Arial');
+    expect(obj.outer.otherProp).toEqual('unchanged');
     expect(obj.outer.inner.fontName).toEqual('Arial');
+    expect(obj.outer.inner.content).toEqual('test');
+    expect(obj.outer.inner.style.color).toEqual('red');
   });
 
   it('handles arrays of objects', () => {
@@ -575,11 +580,8 @@ describe('setFontNameRecursively', () => {
     expect(obj).toEqual({});
   });
 
-  it('returns early for null input', () => {
+  it('returns early for null input or undefined input', () => {
     expect(() => setFontNameRecursively(null as any, 'Arial')).not.toThrow();
-  });
-
-  it('returns early for undefined input', () => {
     expect(() => setFontNameRecursively(undefined as any, 'Arial')).not.toThrow();
   });
 });

--- a/packages/ui/src/components/Designer/LeftSidebar.tsx
+++ b/packages/ui/src/components/Designer/LeftSidebar.tsx
@@ -1,11 +1,12 @@
 import React, { useContext, useState, useEffect } from 'react';
-import { Schema, Plugin, BasePdf } from '@pdfme/common';
+import { Schema, Plugin, BasePdf, getFallbackFontName } from '@pdfme/common';
 import { theme, Button } from 'antd';
 import { useDraggable } from '@dnd-kit/core';
 import { CSS } from '@dnd-kit/utilities';
 import Renderer from '../Renderer.js';
 import { LEFT_SIDEBAR_WIDTH } from '../../constants.js';
-import { PluginsRegistry } from '../../contexts.js';
+import { setFontNameRecursively } from '../../helper';
+import { OptionsContext, PluginsRegistry } from '../../contexts.js';
 import PluginIcon from './PluginIcon.js';
 
 const Draggable = (props: {
@@ -16,7 +17,12 @@ const Draggable = (props: {
 }) => {
   const { scale, basePdf, plugin } = props;
   const { token } = theme.useToken();
+  const options = useContext(OptionsContext);
   const defaultSchema = plugin.propPanel.defaultSchema;
+  if (options.font) {
+    const fontName = getFallbackFontName(options.font);
+    setFontNameRecursively(defaultSchema, fontName);
+  }
   const draggable = useDraggable({ id: defaultSchema.type, data: defaultSchema });
   const { listeners, setNodeRef, attributes, transform, isDragging } = draggable;
   const style = { transform: CSS.Translate.toString(transform) };

--- a/packages/ui/src/helper.ts
+++ b/packages/ui/src/helper.ts
@@ -516,3 +516,15 @@ export const useMaxZoom = () => {
 
   return options.maxZoom ? options.maxZoom / 100 : DEFAULT_MAX_ZOOM;
 };
+
+export const setFontNameRecursively = (obj: Record<string, unknown>, fontName: string): void => {
+  if (!obj || typeof obj !== 'object') return;
+
+  for (const key in obj) {
+    if (key === 'fontName' && obj[key] === undefined) {
+      obj[key] = fontName;
+    } else if (typeof obj[key] === 'object' && obj[key] !== null) {
+      setFontNameRecursively(obj[key] as Record<string, unknown>, fontName);
+    }
+  }
+};

--- a/packages/ui/src/helper.ts
+++ b/packages/ui/src/helper.ts
@@ -10,7 +10,7 @@ import {
   SchemaForUI,
   Size,
   isBlankPdf,
-  PluginRegistry
+  PluginRegistry,
 } from '@pdfme/common';
 import { pdf2size } from '@pdfme/converter';
 import { DEFAULT_MAX_ZOOM, RULER_HEIGHT } from './constants.js';
@@ -517,14 +517,19 @@ export const useMaxZoom = () => {
   return options.maxZoom ? options.maxZoom / 100 : DEFAULT_MAX_ZOOM;
 };
 
-export const setFontNameRecursively = (obj: Record<string, unknown>, fontName: string): void => {
-  if (!obj || typeof obj !== 'object') return;
+export const setFontNameRecursively = (
+  obj: Record<string, unknown>,
+  fontName: string,
+  seen = new WeakSet(),
+): void => {
+  if (!obj || typeof obj !== 'object' || seen.has(obj)) return;
+  seen.add(obj);
 
   for (const key in obj) {
-    if (key === 'fontName' && obj[key] === undefined) {
+    if (key === 'fontName' && Object.prototype.hasOwnProperty.call(obj, key) && obj[key] === undefined) {
       obj[key] = fontName;
     } else if (typeof obj[key] === 'object' && obj[key] !== null) {
-      setFontNameRecursively(obj[key] as Record<string, unknown>, fontName);
+      setFontNameRecursively(obj[key] as Record<string, unknown>, fontName, seen);
     }
   }
 };


### PR DESCRIPTION
fixes #953

This is the simplest solution that I can think of. It's not perfect if people use a different key from `fontName` in their schemas, but it works for all current use cases, including nested text within tables.