### PR TITLE
feat: Text Schema Add border and padding

### DIFF
--- a/packages/schemas/src/text/propPanel.ts
+++ b/packages/schemas/src/text/propPanel.ts
@@ -153,6 +153,84 @@ export const propPanel: PropPanel<TextSchema> = {
           },
         ],
       },
+      borderWidth: {
+        title: i18n('schemas.borderWidth') || 'Border Width',
+        type: 'object',
+        widget: 'card',
+        column: 4,
+        properties: {
+          top: {
+            title: i18n('schemas.top') || 'Top',
+            type: 'number',
+            widget: 'inputNumber',
+            props: { min: 0, step: 0.1, precision: 1 },
+          },
+          right: {
+            title: i18n('schemas.right') || 'Right',
+            type: 'number',
+            widget: 'inputNumber',
+            props: { min: 0, step: 0.1, precision: 1 },
+          },
+          bottom: {
+            title: i18n('schemas.bottom') || 'Bottom',
+            type: 'number',
+            widget: 'inputNumber',
+            props: { min: 0, step: 0.1, precision: 1 },
+          },
+          left: {
+            title: i18n('schemas.left') || 'Left',
+            type: 'number',
+            widget: 'inputNumber',
+            props: { min: 0, step: 0.1, precision: 1 },
+          },
+        },
+      },
+      borderColor: {
+        title: i18n('schemas.borderColor') || 'Border Color',
+        type: 'string',
+        widget: 'color',
+        props: {
+          disabledAlpha: true,
+        },
+        rules: [
+          {
+            pattern: HEX_COLOR_PATTERN,
+            message: i18n('validation.hexColor'),
+          },
+        ],
+      },
+      padding: {
+        title: i18n('schemas.padding') || 'Padding',
+        type: 'object',
+        widget: 'card',
+        column: 4,
+        properties: {
+          top: {
+            title: i18n('schemas.top') || 'Top',
+            type: 'number',
+            widget: 'inputNumber',
+            props: { min: 0, step: 0.1, precision: 1 },
+          },
+          right: {
+            title: i18n('schemas.right') || 'Right',
+            type: 'number',
+            widget: 'inputNumber',
+            props: { min: 0, step: 0.1, precision: 1 },
+          },
+          bottom: {
+            title: i18n('schemas.bottom') || 'Bottom',
+            type: 'number',
+            widget: 'inputNumber',
+            props: { min: 0, step: 0.1, precision: 1 },
+          },
+          left: {
+            title: i18n('schemas.left') || 'Left',
+            type: 'number',
+            widget: 'inputNumber',
+            props: { min: 0, step: 0.1, precision: 1 },
+          },
+        },
+      },
     };
 
     return textSchema;
@@ -180,5 +258,8 @@ export const propPanel: PropPanel<TextSchema> = {
     opacity: DEFAULT_OPACITY,
     strikethrough: false,
     underline: false,
+    borderWidth: { top: 0, right: 0, bottom: 0, left: 0 },
+    borderColor: '#000000',
+    padding: { top: 0, right: 0, bottom: 0, left: 0 },
   },
 };

--- a/packages/schemas/src/text/types.ts
+++ b/packages/schemas/src/text/types.ts
@@ -5,6 +5,8 @@ export type ALIGNMENT = 'left' | 'center' | 'right' | 'justify';
 export type VERTICAL_ALIGNMENT = 'top' | 'middle' | 'bottom';
 export type DYNAMIC_FONT_SIZE_FIT = 'horizontal' | 'vertical';
 
+export type Spacing = { top: number; right: number; bottom: number; left: number };
+
 export type FontWidthCalcValues = {
   font: FontKitFont;
   fontSize: number;
@@ -27,4 +29,7 @@ export interface TextSchema extends Schema {
   };
   fontColor: string;
   backgroundColor: string;
+  borderWidth?: Spacing;
+  borderColor?: string;
+  padding?: Spacing;
 }

--- a/packages/schemas/src/text/uiRender.ts
+++ b/packages/schemas/src/text/uiRender.ts
@@ -191,16 +191,29 @@ export const buildStyledTextContainer = (
 
   const container = document.createElement('div');
 
+  // Get border and padding values
+  const borderWidth = schema.borderWidth || { top: 0, right: 0, bottom: 0, left: 0 };
+  const padding = schema.padding || { top: 0, right: 0, bottom: 0, left: 0 };
+
   const containerStyle: CSS.Properties = {
-    padding: 0,
+    padding: `${padding.top}mm ${padding.right}mm ${padding.bottom}mm ${padding.left}mm`,
     resize: 'none',
     backgroundColor: getBackgroundColor(value, schema),
-    border: 'none',
+    border: schema.borderWidth && schema.borderColor 
+      ? `${borderWidth.top}mm solid ${schema.borderColor}` 
+      : 'none',
+    borderTopWidth: `${borderWidth.top}mm`,
+    borderRightWidth: `${borderWidth.right}mm`,
+    borderBottomWidth: `${borderWidth.bottom}mm`,
+    borderLeftWidth: `${borderWidth.left}mm`,
+    borderColor: schema.borderColor || 'transparent',
+    borderStyle: 'solid',
     display: 'flex',
     flexDirection: 'column',
     justifyContent: mapVerticalAlignToFlex(schema.verticalAlignment),
     width: '100%',
     height: '100%',
+    boxSizing: 'border-box',
     cursor: isEditable(mode, schema) ? 'text' : 'default',
   };
   Object.assign(container.style, containerStyle);


### PR DESCRIPTION
## Add border and padding properties to text schema

Implements border and padding properties for text elements as requested in issue #851.

### Key Features
- Individual border width control for each side (top, right, bottom, left)
- Border color picker for unified border styling
- Individual padding control for each side
- Seamless integration with existing text properties
- Consistent UI/PDF rendering

### Changes
- Extended TextSchema type with `borderWidth`, `borderColor`, and `padding` properties
- Added `renderBorder` function in PDF rendering with proper coordinate calculations
- Updated UI rendering with CSS border and padding styles
- Enhanced property panel with new border and padding controls
- Maintains compatibility with existing text features

<img width="1279" alt="スクリーンショット 2025-05-30 23 56 10" src="https://github.com/user-attachments/assets/67c521ea-9af4-4a74-b572-181d76dd4e0a" />

<img width="619" alt="スクリーンショット 2025-05-31 0 01 25" src="https://github.com/user-attachments/assets/93a19ed7-a4ab-4b26-a1b8-1fb14c27b03a" />


Fixes #851

