### PR TITLE
Export blob2Base64Pdf function

### DIFF
--- a/packages/common/src/helper.ts
+++ b/packages/common/src/helper.ts
@@ -70,7 +70,7 @@ export const px2mm = (px: number): number => {
   return parseFloat(String(px)) * ratio;
 };
 
-const blob2Base64Pdf = (blob: Blob) => {
+export const blob2Base64Pdf = (blob: Blob) => {
   return new Promise<string>((resolve, reject) => {
     const reader = new FileReader();
     reader.onloadend = () => {


### PR DESCRIPTION
Hey again, this is a very handy function and I noticed I couldn't import it from `@pdfme/common` - reckon we can export it?