### PR TITLE
Bump canvas version for Node 22 support

### DIFF
--- a/packages/converter/package.json
+++ b/packages/converter/package.json
@@ -51,10 +51,10 @@
   "devDependencies": {
     "@pdfme/generator": "*",
     "@types/estree": "^1.0.6",
-    "canvas": "^2.11.2"
+    "canvas": "^3.1.0"
   },
   "optionalDependencies": {
-    "canvas": "^2.11.0"
+    "canvas": "^3.1.0"
   },
   "jest": {
     "resolver": "ts-jest-resolver",


### PR DESCRIPTION
See https://github.com/Automattic/node-canvas/issues/2515 

Currently I'm needing to override this version for environments using node v22