### PR TITLE
Align the mouse cursor with the X coordinate of the table column(#430)

### DIFF
--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -74,6 +74,7 @@ export interface PDFRenderProps<T extends Schema> {
  * @property {UIOptions} options - Options object passed from the Viewer, Form, or Designer.
  * @property {ThemeConfig} theme - An object that merges the 'theme' passed as an options with the default theme.
  * @property {(key: keyof Dict | string) => string} i18n - An object merged based on the options 'lang' and 'labels'.
+ * @property {number} scale - The scale of the UI.
  * @property {Map<string | number, unknown>} _cache - Cache shared only during the execution of the render function (useful for caching images, etc. if needed).
  */
 export type UIRenderProps<T extends Schema> = {
@@ -89,6 +90,7 @@ export type UIRenderProps<T extends Schema> = {
   options: UIOptions;
   theme: GlobalToken;
   i18n: (key: string) => string;
+  scale: number;
   _cache: Map<string | number, unknown>;
 };
 

--- a/packages/ui/src/components/Renderer.tsx
+++ b/packages/ui/src/components/Renderer.tsx
@@ -139,6 +139,7 @@ const Renderer = (props: RendererProps) => {
       options,
       theme,
       i18n,
+      scale,
       _cache,
     });
 


### PR DESCRIPTION
## Context
- https://github.com/pdfme/pdfme/issues/430

## Overview

Fixed the coordinate calculation logic when changing table column widths to make it more intuitive depending on the zoom level of the preview.

## Problems before the change

Previously, the drag operation to change table column widths did not include the UI display magnification (zoom level) in the calculation.
As a result, when users zoomed in and out of the UI, the distance the mouse traveled did not match the distance the table borders moved, significantly reducing operability.

## Changes

To solve this problem, we introduced a coordinate conversion logic that takes into account the display magnification (scale) of the UI.

The absolute coordinate at the start of the drag (`e.clientX`) is used as a reference, and the difference from the current mouse coordinate (`deltaX`) is calculated. This difference is divided by the current UI scale and a fixed px-mm conversion factor (`ZOOM`) to calculate an accurate scale-independent movement in mm.

```typescript 
// Before 
let moveX = e.movementX; // in px 
const currentLeft = Number(handle.style.left.replace('mm', '')); // in mm 
let newLeft = startLeft + moveX; //!!! <- mm and px are mixed

// After 
const deltaX = e.clientX - startClientX; // calculate absolute difference from drag start position 
const moveX = (deltaX / ZOOM) / scale; // convert difference in px units to mm units considering scale 
let newLeft = startLeft + moveX; // compute new coordinates in mm //! 
```

### Why this approach: 
The goal was to be consistent with the approach adopted in the move/resize process for other UI elements such as text boxes and images (`packages/ui/src/components/Designer/Canvas/index.tsx`) .

## What I have visually confirmed.
- ✅ Verified that mouse movement and column border movement track 1:1 at all zoom levels
- ✅ Verified that columns do not fall below minimum width
- ✅ Verified that columns do not cross adjacent columns
- ✅ Verified that uiRender and pdfRender are equivalent in appearance