### PR TITLE
fix: Update getDocument calls to include data and isEvalSupported options

### DIFF
--- a/packages/converter/src/index.browser.ts
+++ b/packages/converter/src/index.browser.ts
@@ -29,7 +29,7 @@ export const pdf2img = async (
   options: Pdf2ImgOptions = {},
 ): Promise<ArrayBuffer[]> =>
   _pdf2img(pdf, options, {
-    getDocument: (pdf) => pdfjsLib.getDocument(pdf).promise,
+    getDocument: (pdf) => pdfjsLib.getDocument({ data: pdf, isEvalSupported: false }).promise,
     createCanvas: (width, height) => {
       const canvas = document.createElement('canvas');
       canvas.width = width;
@@ -45,7 +45,7 @@ export const pdf2img = async (
 
 export const pdf2size = async (pdf: ArrayBuffer | Uint8Array, options: Pdf2SizeOptions = {}) =>
   _pdf2size(pdf, options, {
-    getDocument: (pdf) => pdfjsLib.getDocument(pdf).promise,
+    getDocument: (pdf) => pdfjsLib.getDocument({ data: pdf, isEvalSupported: false }).promise,
   });
 
 export { img2pdf } from './img2pdf.js';

--- a/packages/converter/src/index.node.ts
+++ b/packages/converter/src/index.node.ts
@@ -12,7 +12,7 @@ export const pdf2img = async (
   options: Pdf2ImgOptions = {},
 ): Promise<ArrayBuffer[]> =>
   _pdf2img(pdf, options, {
-    getDocument: (pdf) => pdfjsLib.getDocument(pdf).promise,
+    getDocument: (pdf) => pdfjsLib.getDocument({ data: pdf, isEvalSupported: false }).promise,
     createCanvas: (width, height) => createCanvas(width, height) as unknown as HTMLCanvasElement,
     canvasToArrayBuffer: (canvas) => {
       // Using a more specific type for the canvas from the 'canvas' package
@@ -27,7 +27,7 @@ export const pdf2img = async (
 
 export const pdf2size = async (pdf: ArrayBuffer | Uint8Array, options: Pdf2SizeOptions = {}) =>
   _pdf2size(pdf, options, {
-    getDocument: (pdf) => pdfjsLib.getDocument(pdf).promise,
+    getDocument: (pdf) => pdfjsLib.getDocument({ data: pdf, isEvalSupported: false }).promise,
   });
 
 export { img2pdf } from './img2pdf.js';


### PR DESCRIPTION
CVE-2024-4367 temporary workaround

---

The identified library pdf.js, version 3.11.174 is vulnerable.
CVE-2024-4367
https://bugzilla.mozilla.org/show_bug.cgi?id=1893645
https://github.com/mozilla/pdf.js/commit/85e64b5c16c9aaef738f421733c12911a441cec6
https://github.com/mozilla/pdf.js/pull/18015
https://github.com/mozilla/pdf.js/security/advisories/GHSA-wgrm-67xf-hhpq
https://github.com/mozilla/pdf.js
https://github.com/advisories/GHSA-wgrm-67xf-hhpq
