### PR TITLE
Potential fix for code scanning alert no. 16: Incomplete string escaping or encoding

### DIFF
--- a/packages/ui/src/helper.ts
+++ b/packages/ui/src/helper.ts
@@ -49,7 +49,7 @@ export const uuid = () =>
   });
 
 const set = <T extends object>(obj: T, path: string | string[], value: unknown) => {
-  path = Array.isArray(path) ? path : path.replace('[', '.').replace(']', '').split('.');
+  path = Array.isArray(path) ? path : path.replace(/\[/g, '.').replace(/\]/g, '').split('.');
   let src: Record<string, unknown> = obj as Record<string, unknown>;
   path.forEach((key, index, array) => {
     if (index == path.length - 1) {


### PR DESCRIPTION
Potential fix for [https://github.com/pdfme/pdfme/security/code-scanning/16](https://github.com/pdfme/pdfme/security/code-scanning/16)

To fix this problem, all occurrences of `'['` and `']'` in the given `path` string should be replaced, not just the first. This can be achieved by using regular expressions with the global (`g`) flag in the calls to `replace`. Specifically, `.replace(/\[/g, '.')` and `.replace(/\]/g, '')` should be used rather than `.replace('[', '.')` and `.replace(']', '')`. This change should be made directly in the line shown, inside the `set` function in `packages/ui/src/helper.ts`. No external dependencies are needed. No additional methods or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
