### PR TITLE
fix(ui): correct element position clamping in template2SchemasList

### DIFF
--- a/packages/ui/src/helper.ts
+++ b/packages/ui/src/helper.ts
@@ -308,13 +308,11 @@ export const template2SchemasList = async (_template: Template) => {
       const { width, height } = pageSizes[i];
       const xEdge = value.position.x + value.width;
       const yEdge = value.position.y + value.height;
-      if (width < xEdge) {
-        const diff = xEdge - width;
-        value.position.x += diff;
+      if (xEdge > width) {
+        value.position.x = Math.max(0, width - value.width);
       }
-      if (height < yEdge) {
-        const diff = yEdge - height;
-        value.position.y += diff;
+      if (yEdge > height) {
+        value.position.y = Math.max(0, height - value.height);
       }
     });
 


### PR DESCRIPTION
Fixes the incorrect position adjustment in `template2SchemasList()` where elements exceeding page boundaries were pushed further out of bounds.

This resolves the bug described in #1220.

Changes:
- Replace `+= diff` with proper clamping using `Math.max(0, pageDim - elementDim)`
- Ensure elements stay within page bounds without going negative

Tested locally with sample templates containing out-of-bounds elements.