### PR TITLE
fix(playground): fix Windows path resolution in template scripts

### DIFF
--- a/playground/scripts/generate-templates-list-json.mjs
+++ b/playground/scripts/generate-templates-list-json.mjs
@@ -1,12 +1,21 @@
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const templatesDir = path.join(__dirname, '..', 'public', 'template-assets');
 const indexFilePath = path.join(templatesDir, 'index.json');
 
-const featuredTemplates = ['invoice', 'quotes','pedigree', 'certificate-black', 'a4-blank', 'QR-lines'];
+const featuredTemplates = [
+  'invoice',
+  'quotes',
+  'pedigree',
+  'certificate-black',
+  'a4-blank',
+  'QR-lines',
+];
 
 function generateTemplatesListJson() {
   const items = fs.readdirSync(templatesDir, { withFileTypes: true });
@@ -23,7 +32,7 @@ function generateTemplatesListJson() {
       const templateJson = JSON.parse(fs.readFileSync(templateJsonPath, 'utf8'));
       return {
         name: item.name,
-        author: templateJson.author || 'pdfme'
+        author: templateJson.author || 'pdfme',
       };
     })
     .sort((a, b) => {
@@ -40,7 +49,7 @@ function generateTemplatesListJson() {
     });
 
   fs.writeFileSync(indexFilePath, JSON.stringify(result, null, 2));
-  console.log(`Generated index.json with templates: ${result.map(t => t.name).join(', ')}`);
+  console.log(`Generated index.json with templates: ${result.map((t) => t.name).join(', ')}`);
 }
 
 generateTemplatesListJson();

--- a/playground/scripts/generate-templates-thumbnail.mjs
+++ b/playground/scripts/generate-templates-thumbnail.mjs
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import crypto from 'crypto';
 import pLimit from 'p-limit';
 import { generate } from '@pdfme/generator/cjs/src/index.js';
@@ -23,7 +24,8 @@ import {
   radioGroup,
 } from '@pdfme/schemas/cjs/src/index.js';
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const plugins = {
   multiVariableText,
@@ -45,7 +47,7 @@ const plugins = {
   checkbox,
   radioGroup,
   signature: {
-    ui: async () => { },
+    ui: async () => {},
     pdf: image.pdf,
     propPanel: {
       schema: {},
@@ -74,7 +76,7 @@ const font = {
   NotoSansJP: {
     fallback: false,
     data: 'https://fonts.gstatic.com/s/notosansjp/v53/-F6jfjtqLzI2JPCgQBnw7HFyzSD-AsregP8VFBEj75vY0rw-oME.ttf',
-  }
+  },
 };
 
 const limit = pLimit(4);
@@ -82,7 +84,6 @@ const limit = pLimit(4);
 function calcHash(content) {
   return crypto.createHash('md5').update(content, 'utf8').digest('hex');
 }
-
 
 async function createThumbnailFromTemplate(templatePath, thumbnailPath) {
   try {


### PR DESCRIPTION
Fixes #1231

Summary
This PR fixes the playground dev script on Windows. When running `npm run dev` in `playground`, the scripts that read `public/template-assets` fail with ENOENT because the resolved path starts with `\\C:\...` on Windows.

Changes
- Use `fileURLToPath(import.meta.url)` to compute `__dirname` in:
  - `playground/scripts/generate-templates-list-json.mjs`
  - `playground/scripts/generate-templates-thumbnail.mjs`
- The resulting paths now resolve correctly on Windows while keeping existing behavior on other platforms.

Testing
- `npm run build` in repo root
- `npm run dev` in `playground` on Windows 10 with Node v18.20.4
- Verified that the dev server starts and the playground loads templates without errors