### PR TITLE
fix: make line elements draggable when height is very small

### DIFF
--- a/packages/schemas/src/shapes/line.ts
+++ b/packages/schemas/src/shapes/line.ts
@@ -9,6 +9,7 @@ import { HEX_COLOR_PATTERN } from '../constants.js';
 import { Minus } from 'lucide';
 
 const DEFAULT_LINE_COLOR = '#000000';
+const HIT_POINT_HEIGHT = 16;
 
 interface LineSchema extends Schema {
   color: string;
@@ -38,11 +39,30 @@ const lineSchema: Plugin<LineSchema> = {
   },
   ui: (arg) => {
     const { schema, rootElement } = arg;
+    Object.assign(rootElement.style, { position: 'relative', overflow: 'visible' });
+
+    const baseStyles = {
+      position: 'absolute',
+      top: '50%',
+      left: '0',
+      transform: 'translateY(-50%)',
+      width: '100%',
+    } as const;
+
+    const hitArea = document.createElement('div');
+    Object.assign(hitArea.style, baseStyles, {
+      height: `${HIT_POINT_HEIGHT}px`,
+      backgroundColor: 'transparent',
+    });
+
     const div = document.createElement('div');
-    div.style.backgroundColor = schema.color ?? 'transparent';
-    div.style.width = '100%';
-    div.style.height = '100%';
-    rootElement.appendChild(div);
+    Object.assign(div.style, baseStyles, {
+      height: '100%',
+      backgroundColor: schema.color ?? 'transparent',
+      pointerEvents: 'none',
+    });
+
+    rootElement.append(hitArea, div);
   },
   propPanel: {
     schema: ({ i18n }) => ({


### PR DESCRIPTION
## Description
This PR significantly improves the usability of the line schema in the UI by making thin lines easier to select and drag.

## The Problem
Previously, lines with a small height (e.g., 0.5) were extremely difficult to grab and move with the mouse, as their clickable target area was too small. This resulted in a frustrating user experience, especially for users who need precise layouts.

## The Solution
A transparent "hit area" has been introduced over the visible line element. This invisible area is larger than the line itself, providing a generous target for mouse interactions without altering the visual appearance of the line.

- Adds a dedicated `hitArea` element for mouse events.
- The visible line element now ignores pointer events (`pointer-events: none`).
- This change **only affects the UI rendering**; the PDF output remains completely unchanged.

## Demo
Here are videos comparing the behavior before and after the change:

**Before:**

https://github.com/user-attachments/assets/e4cf7aa8-0b20-444f-9999-2b07458ece7a



**After:**

https://github.com/user-attachments/assets/051a852f-6f4c-4d93-bd51-b03e75534977



Fixes #1006