### PR TITLE
fix(schemas:text): align text background rotation with text

### DIFF
--- a/packages/schemas/src/text/pdfRender.ts
+++ b/packages/schemas/src/text/pdfRender.ts
@@ -119,9 +119,17 @@ export const pdfRender = async (arg: PDFRenderProps<TextSchema>) => {
     opacity,
   } = convertForPdfLayoutProps({ schema, pageHeight, applyRotateTranslate: false });
 
+  const pivotPoint = { x: x + width / 2, y: pageHeight - mm2pt(schema.position.y) - height / 2 };
+
   if (schema.backgroundColor) {
     const color = hex2PrintingColor(schema.backgroundColor, colorType);
-    page.drawRectangle({ x, y, width, height, rotate, color });
+    if (rotate.angle !== 0) {
+      // Apply the same rotation logic as text rendering to match UI behavior
+      const rotatedPoint = rotatePoint({ x, y }, pivotPoint, rotate.angle);
+      page.drawRectangle({ x: rotatedPoint.x, y: rotatedPoint.y, width, height, rotate, color });
+    } else {
+      page.drawRectangle({ x, y, width, height, rotate, color });
+    }
   }
 
   const firstLineTextHeight = heightOfFontAtSize(fontKitFont, fontSize);
@@ -151,7 +159,6 @@ export const pdfRender = async (arg: PDFRenderProps<TextSchema>) => {
     }
   }
 
-  const pivotPoint = { x: x + width / 2, y: pageHeight - mm2pt(schema.position.y) - height / 2 };
   const segmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
 
   lines.forEach((line, rowIndex) => {


### PR DESCRIPTION
- **Bug**: When the text was rotated, the position of the text and its background rectangle did not align correctly.  
- **Cause**: The text was rotated around a `pivotPoint` using `rotatePoint`, while the background rectangle relied only on the `rotate` option of `drawRectangle`, which rotates around the bottom-left corner.  
- **Fix**: Make the background rectangle use the same rotation logic as the text by rotating its position around the `pivotPoint` with `rotatePoint` before drawing it.

Before
[before.pdf](https://github.com/user-attachments/files/23694130/31f330cc-e0b8-4b12-8e49-dd9aad9e2a85.pdf)

After
[after.pdf](https://github.com/user-attachments/files/23694133/128470a5-14ac-4a36-8fbc-19148ff7446f.pdf)
