### PR TITLE
refactor(ui): Tidy designer right sidebar layout

### DIFF
--- a/packages/ui/__tests__/components/__snapshots__/Designer.test.tsx.snap
+++ b/packages/ui/__tests__/components/__snapshots__/Designer.test.tsx.snap
@@ -172,206 +172,203 @@ exports[`Designer snapshot 1`] = `
         class="pdfme-designer-right-sidebar"
         style="position: absolute; right: 0px; z-index: 1; height: 100%; width: 400px;"
       >
-        <div>
-          <button
-            class="ant-btn css-dev-only-do-not-override-11mmrso ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only pdfme-designer-sidebar-toggle"
-            style="position: absolute; display: flex; align-items: center; justify-content: center; top: 1rem; right: 1rem; z-index: 100;"
-            type="button"
+        <button
+          class="ant-btn css-dev-only-do-not-override-11mmrso ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only pdfme-designer-sidebar-toggle"
+          style="position: absolute; display: flex; align-items: center; justify-content: center; top: 14px; right: 16px; padding-top: 2px; z-index: 100;"
+          type="button"
+        >
+          <span
+            class="ant-btn-icon"
           >
-            <span
-              class="ant-btn-icon"
-            >
-              ArrowRight
-            </span>
-            
-          </button>
+            ArrowRight
+          </span>
+          
+        </button>
+        <div
+          style="width: 400px; height: 100%; display: flex; top: 0px; right: 0px; position: absolute; font-family: 'Open Sans', sans-serif; box-sizing: border-box; background: rgb(245, 245, 245); border-left: 1px solid rgba(5,5,5,0.06);"
+        >
           <div
-            style="width: 400px; height: 100%; display: block; top: 0px; right: 0px; position: absolute; padding: 0.7rem 1rem; overflow-y: auto; font-family: 'Open Sans', sans-serif; box-sizing: border-box; background: rgb(245, 245, 245);"
+            class="pdfme-designer-list-view"
+            style="height: 100%; display: flex; flex: 1; flex-direction: column;"
           >
-            <div>
+            <div
+              style="position: relative; min-height: 60px; display: flex; flex-shrink: 0; flex-direction: column; justify-content: center; padding: 8px 16px 0px;"
+            >
               <div
-                class="pdfme-designer-list-view"
+                style="min-height: 40px; display: flex; align-items: center; justify-content: center;"
               >
-                <div
-                  style="height: 40px; display: flex; align-items: center;"
+                <span
+                  class="ant-typography css-dev-only-do-not-override-11mmrso"
+                  style="text-align: center; width: 100%;"
                 >
-                  <span
-                    class="ant-typography css-dev-only-do-not-override-11mmrso"
-                    style="text-align: center; width: 100%;"
-                  >
-                    <strong>
-                      Field List
-                    </strong>
-                  </span>
-                </div>
-                <div
-                  class="ant-divider css-dev-only-do-not-override-11mmrso ant-divider-horizontal"
-                  role="separator"
-                  style="margin-top: 8px; margin-bottom: 8px;"
-                />
-                <div
-                  style="height: 1085px;"
+                  <strong>
+                    Field List
+                  </strong>
+                </span>
+              </div>
+              <div
+                class="ant-divider css-dev-only-do-not-override-11mmrso ant-divider-horizontal"
+                role="separator"
+                style="margin-top: 8px; margin-bottom: 0px;"
+              />
+            </div>
+            <div
+              style="flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; padding: 8px 16px;"
+            >
+              <ul
+                style="margin: 0px; padding: 0px; list-style: none; border-radius: 5px;"
+              >
+                <li
+                  style="margin-top: 10px; transform: translate(0px, 0px) scale(1, 1);"
                 >
                   <div
-                    style="height: 100%; overflow-y: auto;"
+                    style="display: flex; align-items: center; cursor: pointer; gap: 0.5rem; border: 1px solid transparent;"
                   >
-                    <ul
-                      style="margin: 0px; padding: 0px; list-style: none; border-radius: 5px;"
+                    <button
+                      class="ant-btn css-dev-only-do-not-override-11mmrso ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only"
+                      style="display: flex; align-items: center; background: none; box-shadow: none; padding-left: 0.25rem;"
+                      type="button"
                     >
-                      <li
-                        style="margin-top: 10px; transform: translate(0px, 0px) scale(1, 1);"
+                      <span
+                        class="ant-btn-icon"
                       >
-                        <div
-                          style="display: flex; align-items: center; cursor: pointer; gap: 0.5rem; border: 1px solid transparent;"
-                        >
-                          <button
-                            class="ant-btn css-dev-only-do-not-override-11mmrso ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only"
-                            style="display: flex; align-items: center; background: none; box-shadow: none; padding-left: 0.25rem;"
-                            type="button"
-                          >
-                            <span
-                              class="ant-btn-icon"
-                            >
-                              GripVertical
-                            </span>
-                            
-                          </button>
-                          <div
-                            style="color: rgba(0, 0, 0, 0.88); display: flex; justify-content: center;"
-                            title="text"
-                          >
-                            <svg
-                              fill="none"
-                              height="20"
-                              stroke="currentColor"
-                              stroke-linecap="round"
-                              stroke-linejoin="round"
-                              stroke-width="2"
-                              viewBox="0 0 24 24"
-                              width="20"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M12 20h-1a2 2 0 0 1-2-2 2 2 0 0 1-2 2H6"
-                              />
-                              <path
-                                d="M13 8h7a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2h-7"
-                              />
-                              <path
-                                d="M5 16H4a2 2 0 0 1-2-2v-4a2 2 0 0 1 2-2h1"
-                              />
-                              <path
-                                d="M6 4h1a2 2 0 0 1 2 2 2 2 0 0 1 2-2h1"
-                              />
-                              <path
-                                d="M9 6v12"
-                              />
-                            </svg>
-                          </div>
-                          <span
-                            class="ant-typography css-dev-only-do-not-override-11mmrso"
-                            style="overflow: hidden; white-space: nowrap; text-overflow: ellipsis; width: 100%;"
-                            title="Edit"
-                          >
-                            field1
-                          </span>
-                        </div>
-                      </li>
-                      <li
-                        style="margin-top: 10px; transform: translate(0px, 0px) scale(1, 1);"
+                        GripVertical
+                      </span>
+                      
+                    </button>
+                    <div
+                      style="color: rgba(0, 0, 0, 0.88); display: flex; justify-content: center;"
+                      title="text"
+                    >
+                      <svg
+                        fill="none"
+                        height="20"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        viewBox="0 0 24 24"
+                        width="20"
+                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        <div
-                          style="display: flex; align-items: center; cursor: pointer; gap: 0.5rem; border: 1px solid transparent;"
-                        >
-                          <button
-                            class="ant-btn css-dev-only-do-not-override-11mmrso ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only"
-                            style="display: flex; align-items: center; background: none; box-shadow: none; padding-left: 0.25rem;"
-                            type="button"
-                          >
-                            <span
-                              class="ant-btn-icon"
-                            >
-                              GripVertical
-                            </span>
-                            
-                          </button>
-                          <div
-                            style="color: rgba(0, 0, 0, 0.88); display: flex; justify-content: center;"
-                            title="image"
-                          >
-                            <svg
-                              fill="none"
-                              height="20"
-                              stroke="currentColor"
-                              stroke-linecap="round"
-                              stroke-linejoin="round"
-                              stroke-width="2"
-                              viewBox="0 0 24 24"
-                              width="20"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <rect
-                                height="18"
-                                rx="2"
-                                ry="2"
-                                width="18"
-                                x="3"
-                                y="3"
-                              />
-                              <circle
-                                cx="9"
-                                cy="9"
-                                r="2"
-                              />
-                              <path
-                                d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"
-                              />
-                            </svg>
-                          </div>
-                          <span
-                            class="ant-typography css-dev-only-do-not-override-11mmrso"
-                            style="overflow: hidden; white-space: nowrap; text-overflow: ellipsis; width: 100%;"
-                            title="Edit"
-                          >
-                            field2
-                          </span>
-                        </div>
-                      </li>
-                    </ul>
+                        <path
+                          d="M12 20h-1a2 2 0 0 1-2-2 2 2 0 0 1-2 2H6"
+                        />
+                        <path
+                          d="M13 8h7a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2h-7"
+                        />
+                        <path
+                          d="M5 16H4a2 2 0 0 1-2-2v-4a2 2 0 0 1 2-2h1"
+                        />
+                        <path
+                          d="M6 4h1a2 2 0 0 1 2 2 2 2 0 0 1 2-2h1"
+                        />
+                        <path
+                          d="M9 6v12"
+                        />
+                      </svg>
+                    </div>
+                    <span
+                      class="ant-typography css-dev-only-do-not-override-11mmrso"
+                      style="overflow: hidden; white-space: nowrap; text-overflow: ellipsis; width: 100%;"
+                      title="Edit"
+                    >
+                      field1
+                    </span>
                   </div>
+                </li>
+                <li
+                  style="margin-top: 10px; transform: translate(0px, 0px) scale(1, 1);"
+                >
                   <div
-                    id="DndDescribedBy-1"
-                    style="display: none;"
+                    style="display: flex; align-items: center; cursor: pointer; gap: 0.5rem; border: 1px solid transparent;"
                   >
-                    
+                    <button
+                      class="ant-btn css-dev-only-do-not-override-11mmrso ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only"
+                      style="display: flex; align-items: center; background: none; box-shadow: none; padding-left: 0.25rem;"
+                      type="button"
+                    >
+                      <span
+                        class="ant-btn-icon"
+                      >
+                        GripVertical
+                      </span>
+                      
+                    </button>
+                    <div
+                      style="color: rgba(0, 0, 0, 0.88); display: flex; justify-content: center;"
+                      title="image"
+                    >
+                      <svg
+                        fill="none"
+                        height="20"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        viewBox="0 0 24 24"
+                        width="20"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <rect
+                          height="18"
+                          rx="2"
+                          ry="2"
+                          width="18"
+                          x="3"
+                          y="3"
+                        />
+                        <circle
+                          cx="9"
+                          cy="9"
+                          r="2"
+                        />
+                        <path
+                          d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"
+                        />
+                      </svg>
+                    </div>
+                    <span
+                      class="ant-typography css-dev-only-do-not-override-11mmrso"
+                      style="overflow: hidden; white-space: nowrap; text-overflow: ellipsis; width: 100%;"
+                      title="Edit"
+                    >
+                      field2
+                    </span>
+                  </div>
+                </li>
+              </ul>
+              <div
+                id="DndDescribedBy-1"
+                style="display: none;"
+              >
+                
     To pick up a draggable item, press the space bar.
     While dragging, use the arrow keys to move the item.
     Press space again to drop the item in its new position, or press escape to cancel.
   
-                  </div>
-                  <div
-                    aria-atomic="true"
-                    aria-live="assertive"
-                    id="DndLiveRegion-0"
-                    role="status"
-                    style="position: fixed; top: 0px; left: 0px; width: 1px; height: 1px; margin: -1px; border: 0px; padding: 0px; overflow: hidden; clip-path: inset(100%); white-space: nowrap;"
-                  />
-                  <div
-                    style="padding-top: 0.5rem; display: flex; align-items: center; justify-content: flex-end;"
-                  >
-                    <button
-                      class="ant-btn css-dev-only-do-not-override-11mmrso ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm pdfme-designer-bulk-update"
-                      type="button"
-                    >
-                      <u>
-                         
-                        Bulk update field names
-                      </u>
-                      
-                    </button>
-                  </div>
-                </div>
               </div>
+              <div
+                aria-atomic="true"
+                aria-live="assertive"
+                id="DndLiveRegion-0"
+                role="status"
+                style="position: fixed; top: 0px; left: 0px; width: 1px; height: 1px; margin: -1px; border: 0px; padding: 0px; overflow: hidden; clip-path: inset(100%); white-space: nowrap;"
+              />
+            </div>
+            <div
+              style="display: flex; flex-shrink: 0; align-items: center; justify-content: flex-end; gap: 8px; padding: 16px;"
+            >
+              <button
+                class="ant-btn css-dev-only-do-not-override-11mmrso ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm pdfme-designer-bulk-update"
+                type="button"
+              >
+                <u>
+                   
+                  Bulk update field names
+                </u>
+                
+              </button>
             </div>
           </div>
         </div>

--- a/packages/ui/src/components/Designer/RightSidebar/ListView/SelectableSortableContainer.tsx
+++ b/packages/ui/src/components/Designer/RightSidebar/ListView/SelectableSortableContainer.tsx
@@ -135,29 +135,27 @@ const SelectableSortableContainer = (
       }}
     >
       <>
-        <div style={{ height: '100%', overflowY: 'auto' }}>
-          <SortableContext items={schemas} strategy={verticalListSortingStrategy}>
-            <ul style={{ margin: 0, padding: 0, listStyle: 'none', borderRadius: 5 }}>
-              {schemas.map((schema) => (
-                <SelectableSortableItem
-                  key={schema.id}
-                  style={{
-                    border: `1px solid ${
-                      schema.id === hoveringSchemaId ? token.colorPrimary : 'transparent'
-                    }`,
-                  }}
-                  schema={schema}
-                  schemas={schemas}
-                  isSelected={isItemSelected(schema.id) || activeId === schema.id}
-                  onEdit={onEdit}
-                  onSelect={onSelectionChanged}
-                  onMouseEnter={() => onChangeHoveringSchemaId(schema.id)}
-                  onMouseLeave={() => onChangeHoveringSchemaId(null)}
-                />
-              ))}
-            </ul>
-          </SortableContext>
-        </div>
+        <SortableContext items={schemas} strategy={verticalListSortingStrategy}>
+          <ul style={{ margin: 0, padding: 0, listStyle: 'none', borderRadius: 5 }}>
+            {schemas.map((schema) => (
+              <SelectableSortableItem
+                key={schema.id}
+                style={{
+                  border: `1px solid ${
+                    schema.id === hoveringSchemaId ? token.colorPrimary : 'transparent'
+                  }`,
+                }}
+                schema={schema}
+                schemas={schemas}
+                isSelected={isItemSelected(schema.id) || activeId === schema.id}
+                onEdit={onEdit}
+                onSelect={onSelectionChanged}
+                onMouseEnter={() => onChangeHoveringSchemaId(schema.id)}
+                onMouseLeave={() => onChangeHoveringSchemaId(null)}
+              />
+            ))}
+          </ul>
+        </SortableContext>
         {createPortal(
           <DragOverlay adjustScale>
             {activeId

--- a/packages/ui/src/components/Designer/RightSidebar/ListView/index.tsx
+++ b/packages/ui/src/components/Designer/RightSidebar/ListView/index.tsx
@@ -1,15 +1,13 @@
 import React, { useContext, useState } from 'react';
 import type { SidebarProps } from '../../../../types.js';
-import { RIGHT_SIDEBAR_WIDTH, DESIGNER_CLASSNAME } from '../../../../constants.js';
+import { DESIGNER_CLASSNAME } from '../../../../constants.js';
 import { I18nContext } from '../../../../contexts.js';
-import { getSidebarContentHeight } from '../../../../helper.js';
-import { theme, Input, Typography, Divider, Button } from 'antd';
+import { Input, Typography, Button } from 'antd';
 import SelectableSortableContainer from './SelectableSortableContainer.js';
+import { SidebarBody, SidebarFooter, SidebarFrame, SidebarHeader } from '../layout.js';
 
 const { Text } = Typography;
 const { TextArea } = Input;
-
-const headHeight = 40;
 
 const ListView = (
   props: Pick<
@@ -17,26 +15,16 @@ const ListView = (
     | 'schemas'
     | 'onSortEnd'
     | 'onEdit'
-    | 'size'
     | 'hoveringSchemaId'
     | 'onChangeHoveringSchemaId'
     | 'changeSchemas'
   >,
 ) => {
-  const {
-    schemas,
-    onSortEnd,
-    onEdit,
-    size,
-    hoveringSchemaId,
-    onChangeHoveringSchemaId,
-    changeSchemas,
-  } = props;
-  const { token } = theme.useToken();
+  const { schemas, onSortEnd, onEdit, hoveringSchemaId, onChangeHoveringSchemaId, changeSchemas } =
+    props;
   const i18n = useContext(I18nContext);
   const [isBulkUpdateFieldNamesMode, setIsBulkUpdateFieldNamesMode] = useState(false);
   const [fieldNamesValue, setFieldNamesValue] = useState('');
-  const height = getSidebarContentHeight(size.height);
 
   const commitBulk = () => {
     const names = fieldNamesValue.split('\n');
@@ -60,23 +48,22 @@ const ListView = (
   };
 
   return (
-    <div className={DESIGNER_CLASSNAME + 'list-view'}>
-      <div style={{ height: headHeight, display: 'flex', alignItems: 'center' }}>
+    <SidebarFrame className={DESIGNER_CLASSNAME + 'list-view'}>
+      <SidebarHeader>
         <Text strong style={{ textAlign: 'center', width: '100%' }}>
           {i18n('fieldsList')}
         </Text>
-      </div>
-      <Divider style={{ marginTop: token.marginXS, marginBottom: token.marginXS }} />
-      <div style={{ height: height - headHeight }}>
+      </SidebarHeader>
+      <SidebarBody>
         {isBulkUpdateFieldNamesMode ? (
           <TextArea
             wrap="off"
             value={fieldNamesValue}
             onChange={(e) => setFieldNamesValue(e.target.value)}
             style={{
-              paddingLeft: 30,
-              height: height - headHeight,
-              width: RIGHT_SIDEBAR_WIDTH - 35,
+              height: '100%',
+              width: '100%',
+              resize: 'none',
               lineHeight: '2.75rem',
             }}
           />
@@ -89,32 +76,40 @@ const ListView = (
             onEdit={onEdit}
           />
         )}
-        <div
-          style={{
-            paddingTop: '0.5rem',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'flex-end',
-          }}
-        >
-          {isBulkUpdateFieldNamesMode ? (
-            <>
-              <Button className={DESIGNER_CLASSNAME + 'bulk-commit'} size="small" type="text" onClick={commitBulk}>
-                <u> {i18n('commitBulkUpdateFieldName')}</u>
-              </Button>
-              <span style={{ margin: '0 1rem' }}>/</span>
-              <Button className={DESIGNER_CLASSNAME + 'bulk-cancel'} size="small" type="text" onClick={() => setIsBulkUpdateFieldNamesMode(false)}>
-                <u> {i18n('cancel')}</u>
-              </Button>
-            </>
-          ) : (
-            <Button className={DESIGNER_CLASSNAME + 'bulk-update'} size="small" type="text" onClick={startBulk}>
-              <u> {i18n('bulkUpdateFieldName')}</u>
+      </SidebarBody>
+      <SidebarFooter>
+        {isBulkUpdateFieldNamesMode ? (
+          <>
+            <Button
+              className={DESIGNER_CLASSNAME + 'bulk-commit'}
+              size="small"
+              type="text"
+              onClick={commitBulk}
+            >
+              <u> {i18n('commitBulkUpdateFieldName')}</u>
             </Button>
-          )}
-        </div>
-      </div>
-    </div>
+            <span>/</span>
+            <Button
+              className={DESIGNER_CLASSNAME + 'bulk-cancel'}
+              size="small"
+              type="text"
+              onClick={() => setIsBulkUpdateFieldNamesMode(false)}
+            >
+              <u> {i18n('cancel')}</u>
+            </Button>
+          </>
+        ) : (
+          <Button
+            className={DESIGNER_CLASSNAME + 'bulk-update'}
+            size="small"
+            type="text"
+            onClick={startBulk}
+          >
+            <u> {i18n('bulkUpdateFieldName')}</u>
+          </Button>
+        )}
+      </SidebarFooter>
+    </SidebarFrame>
   );
 };
 

--- a/packages/ui/src/components/Designer/RightSidebar/index.tsx
+++ b/packages/ui/src/components/Designer/RightSidebar/index.tsx
@@ -30,44 +30,40 @@ const Sidebar = (props: SidebarProps) => {
         width: sidebarOpen ? RIGHT_SIDEBAR_WIDTH : 0,
       }}
     >
-      <div>
-        <Button
-          className={DESIGNER_CLASSNAME + 'sidebar-toggle'}
-          style={{
-            position: 'absolute',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            top: '1rem',
-            right: '1rem',
-            zIndex: 100,
-          }}
-          icon={sidebarOpen ? <ArrowRight {...iconProps} /> : <ArrowLeft {...iconProps} />}
-          onClick={() => setSidebarOpen(!sidebarOpen)}
-        />
-        <div
-          style={{
-            width: RIGHT_SIDEBAR_WIDTH,
-            height: '100%',
-            display: sidebarOpen ? 'block' : 'none',
-            top: 0,
-            right: 0,
-            position: 'absolute',
-            padding: '0.7rem 1rem',
-            overflowY: 'auto',
-            fontFamily: "'Open Sans', sans-serif",
-            boxSizing: 'border-box',
-            background: token.colorBgLayout,
-          }}
-        >
-          <div>
-            {getActiveSchemas().length === 0 ? (
-              <ListView {...props} />
-            ) : (
-              <DetailView {...props} activeSchema={getLastActiveSchema()} />
-            )}
-          </div>
-        </div>
+      <Button
+        className={DESIGNER_CLASSNAME + 'sidebar-toggle'}
+        style={{
+          position: 'absolute',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          top: '14px',
+          right: '16px',
+          paddingTop: '2px',
+          zIndex: 100,
+        }}
+        icon={sidebarOpen ? <ArrowRight {...iconProps} /> : <ArrowLeft {...iconProps} />}
+        onClick={() => setSidebarOpen(!sidebarOpen)}
+      />
+      <div
+        style={{
+          width: RIGHT_SIDEBAR_WIDTH,
+          height: '100%',
+          display: sidebarOpen ? 'flex' : 'none',
+          top: 0,
+          right: 0,
+          position: 'absolute',
+          fontFamily: "'Open Sans', sans-serif",
+          boxSizing: 'border-box',
+          background: token.colorBgLayout,
+          borderLeft: `1px solid ${token.colorSplit}`,
+        }}
+      >
+        {getActiveSchemas().length === 0 ? (
+          <ListView {...props} />
+        ) : (
+          <DetailView {...props} activeSchema={getLastActiveSchema()} />
+        )}
       </div>
     </div>
   );

--- a/packages/ui/src/components/Designer/RightSidebar/layout.tsx
+++ b/packages/ui/src/components/Designer/RightSidebar/layout.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { Divider } from 'antd';
+
+export const SIDEBAR_H_PADDING_PX = 16;
+export const SIDEBAR_V_PADDING_PX = 8;
+export const SIDEBAR_HEADER_HEIGHT = 60;
+
+type SectionProps = {
+  children: React.ReactNode;
+};
+type SidebarFrameProps = SectionProps & {
+  className?: string;
+};
+
+export const SidebarFrame = ({ children, className }: SidebarFrameProps) => (
+  <div
+    className={className}
+    style={{
+      height: '100%',
+      display: 'flex',
+      flex: 1,
+      flexDirection: 'column',
+    }}
+  >
+    {children}
+  </div>
+);
+
+export const SidebarHeader = ({ children }: SectionProps) => (
+  <div
+    style={{
+      position: 'relative',
+      minHeight: SIDEBAR_HEADER_HEIGHT,
+      display: 'flex',
+      flexShrink: 0,
+      flexDirection: 'column',
+      justifyContent: 'center',
+      padding: `${SIDEBAR_V_PADDING_PX}px ${SIDEBAR_H_PADDING_PX}px 0`,
+    }}
+  >
+    <div style={{ minHeight: 40, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      {children}
+    </div>
+    <Divider style={{ marginTop: `${SIDEBAR_V_PADDING_PX}px`, marginBottom: 0 }} />
+  </div>
+);
+
+export const SidebarBody = ({ children }: SectionProps) => (
+  <div
+    style={{
+      flex: 1,
+      minHeight: 0,
+      overflowY: 'auto',
+      overflowX: 'hidden',
+      padding: `${SIDEBAR_V_PADDING_PX}px ${SIDEBAR_H_PADDING_PX}px`,
+    }}
+  >
+    {children}
+  </div>
+);
+
+export const SidebarFooter = ({ children }: SectionProps) => (
+  <div
+    style={{
+      display: 'flex',
+      flexShrink: 0,
+      alignItems: 'center',
+      justifyContent: 'flex-end',
+      gap: `${SIDEBAR_V_PADDING_PX}px`,
+      padding: `${SIDEBAR_H_PADDING_PX}px`,
+    }}
+  >
+    {children}
+  </div>
+);

--- a/packages/ui/src/helper.ts
+++ b/packages/ui/src/helper.ts
@@ -420,9 +420,6 @@ export const getPagesScrollTopByIndex = (pageSizes: Size[], index: number, scale
     .reduce((acc, cur) => acc + (cur.height * ZOOM + RULER_HEIGHT * scale) * scale, 0);
 };
 
-export const getSidebarContentHeight = (sidebarHeight: number) =>
-  sidebarHeight - RULER_HEIGHT - RULER_HEIGHT / 2 - 30;
-
 const handlePositionSizeChange = (
   schema: SchemaForUI,
   key: string,


### PR DESCRIPTION
BEFORE 
- double-scrollbars, and scrollbars don't go to the edge

https://github.com/user-attachments/assets/c9b62cd5-3176-4bb5-9038-fc9097e868cd


NEW:
- introduce shared sidebar frame/header/body/footer wrappers with consistent padding
- adjust ListView and DetailView to use new structure so scrollbars reach edge
- pad icons so they appear centered within their buttons
- align close and detail icons vertically
- tighten hooks in DetailView (memoized i18n helper, correct deps) and tidy sidebar container styling

https://github.com/user-attachments/assets/9182dc1d-2030-4ed5-b4a5-10131fa76137


