### PR TITLE
fix: resize window down scales canvas height too

### DIFF
--- a/packages/ui/src/class.ts
+++ b/packages/ui/src/class.ts
@@ -40,10 +40,19 @@ export abstract class BaseUIClass {
     if (!this.domContainer) {
       return;
     }
+
+    const rect = this.domContainer.getBoundingClientRect();
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+
+    const visibleWidth = Math.max(0, Math.min(rect.right, vw) - Math.max(rect.left, 0));
+    const visibleHeight = Math.max(0, Math.min(rect.bottom, vh) - Math.max(rect.top, 0));
+
     this.size = {
-      height: this.domContainer.clientHeight || window.innerHeight,
-      width: this.domContainer.clientWidth || window.innerWidth,
+      height: visibleHeight,
+      width: visibleWidth,
     };
+
     this.render();
   }, 100);
 


### PR DESCRIPTION
fixes #1248 

BEFORE - scale up increases size, but scale down doesn't.
This is because element.clientHeight does not return the visible height, but the overall height of the element - even if it's not visible because it's being scrolled. Therefore the height (and width) can never decrease.

https://github.com/user-attachments/assets/8bc59c67-f4cc-4414-981c-8625f2f39f1e


AFTER - scaling up and down consistently on resize using boundingRect

https://github.com/user-attachments/assets/72ae9425-8516-461f-b930-cdfd1c910338

