### PR TITLE
chore: replace npm-run-all with npm-run-all2

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "scripts": {
     "postinstall": "./scripts/link-workspaces.sh",
-    "clean": "npm-run-all2 --parallel clean:*",
+    "clean": "run-p clean:*",
     "clean:common": "npm run -w packages/common clean",
     "clean:pdf-lib": "npm run -w packages/pdf-lib clean",
     "clean:converter": "npm run -w packages/converter clean",
@@ -40,7 +40,7 @@
     "clean:generator": "npm run -w packages/generator clean",
     "clean:manipulator": "npm run -w packages/manipulator clean",
     "clean:ui": "npm run -w packages/ui clean",
-    "build": "npm run clean && npm run build:pdf-lib && npm run build:common && npm run build:converter && npm run build:schemas && npm-run-all2 --parallel build:generator build:ui build:manipulator",
+    "build": "npm run clean && npm run build:pdf-lib && npm run build:common && npm run build:converter && npm run build:schemas && run-p build:generator build:ui build:manipulator",
     "build:common": "npm run -w packages/common build",
     "build:pdf-lib": "npm run -w packages/pdf-lib build",
     "build:converter": "npm run -w packages/converter build",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -37,7 +37,7 @@
   "scripts": {
     "dev": "node set-version.js && tsc -p tsconfig.esm.json -w",
     "prebuild": "node set-version.js",
-    "build": "npm-run-all2 --parallel build:cjs build:esm build:node",
+    "build": "run-p build:cjs build:esm build:node",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:node": "tsc -p tsconfig.node.json",

--- a/packages/converter/package.json
+++ b/packages/converter/package.json
@@ -34,7 +34,7 @@
   },
   "scripts": {
     "dev": "tsc -p tsconfig.esm.json -w",
-    "build": "npm-run-all2 --parallel build:cjs build:esm",
+    "build": "run-p build:cjs build:esm",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json",
     "clean": "rimraf dist",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "dev": "tsc -p tsconfig.esm.json -w",
-    "build": "npm-run-all2 --parallel build:cjs build:esm build:node",
+    "build": "run-p build:cjs build:esm build:node",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:node": "tsc -p tsconfig.node.json",

--- a/packages/manipulator/package.json
+++ b/packages/manipulator/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "dev": "tsc -p tsconfig.esm.json -w",
-    "build": "npm-run-all2 --parallel build:cjs build:esm",
+    "build": "run-p build:cjs build:esm",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json",
     "clean": "rimraf dist",

--- a/packages/pdf-lib/package.json
+++ b/packages/pdf-lib/package.json
@@ -42,7 +42,7 @@
   },
   "scripts": {
     "dev": "tsc -p tsconfig.esm.json -w",
-    "build": "npm-run-all2 --parallel build:cjs build:esm build:node",
+    "build": "run-p build:cjs build:esm build:node",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:node": "tsc -p tsconfig.node.json",

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -44,7 +44,7 @@
   },
   "scripts": {
     "dev": "tsc -p tsconfig.esm.json -w",
-    "build": "npm-run-all2 --parallel build:cjs build:esm build:node",
+    "build": "run-p build:cjs build:esm build:node",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:node": "tsc -p tsconfig.node.json",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -25,7 +25,7 @@
   "module": "dist/index.es.js",
   "types": "dist/types/src/index.d.ts",
   "scripts": {
-    "dev": "npm-run-all2 --parallel devBuild:watch devBuildType:watch",
+    "dev": "run-p devBuild:watch devBuildType:watch",
     "devBuild:watch": "esbuild src/index.ts --bundle --outfile=dist/index.es.js --format=esm --watch",
     "devBuildType:watch": "tsc --emitDeclarationOnly --watch",
     "build": "vite build && tsc --emitDeclarationOnly",


### PR DESCRIPTION
npm-run-all is unmaintained anymore and there are some critical bugs.
npm-run-all2 is a fork of npm-run-all and it is actively maintained.

https://www.npmjs.com/package/npm-run-all2

p.s. i think it is better to switch our package manager to pnpm because we can reduce lots of dependencies including npm-run-all2, but it depends on what you want!!