### PR TITLE
[@pdme/converter] Change Worker loading in local environment to ESM

### DIFF
--- a/packages/converter/src/index.browser.ts
+++ b/packages/converter/src/index.browser.ts
@@ -1,10 +1,11 @@
 import * as pdfjsLib from 'pdfjs-dist';
-// @ts-expect-error - PDFJSWorker import is not properly typed but required for functionality
-import PDFJSWorker from 'pdfjs-dist/build/pdf.worker.entry.js';
 import { pdf2img as _pdf2img, Pdf2ImgOptions } from './pdf2img.js';
 import { pdf2size as _pdf2size, Pdf2SizeOptions } from './pdf2size.js';
 
-pdfjsLib.GlobalWorkerOptions.workerSrc = PDFJSWorker as unknown as string;
+pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
+  'pdfjs-dist/build/pdf.worker.entry.js',
+  import.meta.url,
+).toString();
 
 function dataURLToArrayBuffer(dataURL: string): ArrayBuffer {
   // Split out the actual base64 string from the data URL scheme

--- a/packages/converter/src/index.browser.ts
+++ b/packages/converter/src/index.browser.ts
@@ -3,7 +3,7 @@ import { pdf2img as _pdf2img, Pdf2ImgOptions } from './pdf2img.js';
 import { pdf2size as _pdf2size, Pdf2SizeOptions } from './pdf2size.js';
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
-  'pdfjs-dist/build/pdf.worker.entry.js',
+  'pdfjs-dist/build/pdf.worker.min.js',
   import.meta.url,
 ).toString();
 

--- a/packages/converter/tsconfig.cjs.json
+++ b/packages/converter/tsconfig.cjs.json
@@ -6,5 +6,6 @@
     "declaration": true,
     "declarationDir": "dist/types",
     "skipLibCheck": true
-  }
+  },
+  "exclude": ["src/**/*.browser.ts"]
 }

--- a/playground/e2e/index.test.ts
+++ b/playground/e2e/index.test.ts
@@ -50,8 +50,8 @@ async function generatePdf(page: Page, browser: Browser): Promise<Buffer> {
   await page.click('#generate-pdf');
 
   const newTarget = await browser.waitForTarget(
-    (target) => target.url().startsWith('blob:'),
-    { timeout }
+    (target) => target.url().startsWith('blob:') && target.type() === 'page',
+    { timeout },
   );
   const newPage = await newTarget?.page();
   if (!newPage) {

--- a/playground/e2e/index.test.ts
+++ b/playground/e2e/index.test.ts
@@ -31,8 +31,8 @@ async function waitForServerReady(url: string, maxRetries = 30, retryInterval = 
 }
 
 const baseUrl = 'http://localhost:4173';
-const timeout = 40000; // Increased timeout to avoid test failures
-jest.setTimeout(timeout * 6);
+const timeout = 50000; // Increased timeout to avoid test failures
+jest.setTimeout(timeout * 5);
 
 const isRunningLocal = process.env.LOCAL === 'true';
 

--- a/playground/e2e/index.test.ts
+++ b/playground/e2e/index.test.ts
@@ -32,7 +32,7 @@ async function waitForServerReady(url: string, maxRetries = 30, retryInterval = 
 
 const baseUrl = 'http://localhost:4173';
 const timeout = 40000; // Increased timeout to avoid test failures
-jest.setTimeout(timeout * 5);
+jest.setTimeout(timeout * 6);
 
 const isRunningLocal = process.env.LOCAL === 'true';
 


### PR DESCRIPTION
## Overview
While developing a feature that imports and uses `converter` locally, I noticed an error during module resolution when initializing the Worker.

## Detail
### Before Fix
This is an error log when executing `pdf2img` in a browser runtime, for example.
```
Uncaught SyntaxError: The requested module '/node_modules/.vite/deps/pdfjs-dist_build_pdf__worker__entry__js.js?v=0b0a5bfb' does not provide an export named 'default' (at index.browser.ts:3:8)Understand this error
```

### After Fix
Executing `pdf2img` in a browser runtime now correctly resolves source modules without errors.
**pdf2img conversion in Reference is successful✨**

### Reference
This is reference code that was incorporated into the Playground for confirmation, although it is not an actual feature.

```tsx
const Converter = () => {
  const [url, setUrl] = useState('');

  const uiRef = useRef<HTMLDivElement | null>(null);

  const navItems: NavItem[] = [
    {
      label: '',
      content: React.createElement(ExternalButton, {
        href: 'https://github.com/pdfme/pdfme/issues/new?template=template_feedback.yml&title=TEMPLATE_NAME',
        title: 'Feedback this template',
      }),
    },
  ];

  useEffect(() => {
    const init = async () => {
      const template = templateJson as Template;

      const pdf = await generate({
        template: template,
        inputs: getInputFromTemplate(template),
        options: getFontsData(),
        plugins: getPlugins(),
      });

      if (pdf) console.log('✨ generate pdf');

      const image = await pdf2img(pdf.buffer);
      if (image) console.log('✨ convert image');

      const blob = new Blob(image, { type: 'image/png' });
      const url = URL.createObjectURL(blob);

      setUrl(url);
    };

    init();
  }, []);

  return (
    <>
      <NavBar items={navItems} />
      <button
        style={{ width: '300px', height: '100px' }}
        onClick={() => {
          const confirmed = window.confirm('OK?');
          if (confirmed) {
            window.open(url);
            window.setTimeout(() => {
              URL.revokeObjectURL(url);
            }, 100);
          }
        }}
      >
        Go!
      </button>
      <div ref={uiRef} className="flex-1 w-full" />
    </>
  );
};

```

## Test
- [x] The `converter` functionality works on the Playground's dev server.
- [x] The `converter` functionality continues to work without changes in the Playground's preview.
- [x]  

## Note
- The fix could not be implemented because the browser module in the converter was being built for CJS. Therefore, we confirmed that https://github.com/pdfme/pdfme/pull/1122 is planned and modified the tsconfig.


## Triage disposition (2026-09-13)

Closed as superseded by #1558, which replaced the pdfjs-dist renderer with clawpdf/PDFium. Current main uses a dedicated clawpdf module worker, so the pdfjs worker import addressed by this PR is no longer present. This does not mark the separate EXIF-orientation issue #1183 or the clawpdf/Vite integration issue #1560 as resolved.
