### PR TITLE
[wip] textschema markdown and  page break

### DIFF
--- a/packages/common/src/dynamicTemplate.ts
+++ b/packages/common/src/dynamicTemplate.ts
@@ -152,14 +152,24 @@ function placeRowsOnPages(
       position: { ...schema.position, y: currentYInPage + paddingTop },
     };
 
-    // Set bodyRange for splittable elements
-    // dynamicHeights[0] = header row, dynamicHeights[1] = body[0]
-    // So subtract 1 to convert to body index
+    // Set range for splittable elements based on schema type
     if (isSplittable) {
-      newSchema.__bodyRange = {
-        start: startRowIndex === 0 ? 0 : startRowIndex - 1,
-        end: currentRowIndex - 1,
-      };
+      const isTableLike = schema.type === 'table' || schema.type === 'multiVariableText';
+
+      if (isTableLike) {
+        // For tables: dynamicHeights[0] = header row, dynamicHeights[1] = body[0]
+        // So subtract 1 to convert to body index
+        newSchema.__bodyRange = {
+          start: startRowIndex === 0 ? 0 : startRowIndex - 1,
+          end: currentRowIndex - 1,
+        };
+      } else {
+        // For text-based schemas (text, cell, etc.): line indices directly
+        newSchema.__lineRange = {
+          start: startRowIndex,
+          end: currentRowIndex - 1,
+        };
+      }
       newSchema.__isSplit = startRowIndex > 0;
     }
 

--- a/packages/common/src/schema.ts
+++ b/packages/common/src/schema.ts
@@ -111,6 +111,7 @@ export const Schema = z
     readOnly: z.boolean().optional(),
     required: z.boolean().optional(),
     __bodyRange: z.object({ start: z.number(), end: z.number().optional() }).optional(),
+    __lineRange: z.object({ start: z.number(), end: z.number() }).optional(),
     __isSplit: z.boolean().optional(),
   })
   .passthrough();

--- a/packages/generator/src/generate.ts
+++ b/packages/generator/src/generate.ts
@@ -8,7 +8,7 @@ import {
   pt2mm,
   cloneDeep,
 } from '@pdfme/common';
-import { getDynamicHeightsForTable } from '@pdfme/schemas';
+import { getDynamicHeightsForTable, getDynamicHeightsForText } from '@pdfme/schemas';
 import {
   insertPage,
   preprocessing,
@@ -49,6 +49,9 @@ const generate = async (props: GenerateProps): Promise<Uint8Array<ArrayBuffer>> 
         switch (args.schema.type) {
           case 'table':
             return getDynamicHeightsForTable(value, args);
+          case 'text':
+          case 'multiVariableText':
+            return getDynamicHeightsForText(value, args);
           default:
             return Promise.resolve([args.schema.height]);
         }

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -37,3 +37,13 @@ export {
 
 // Export utility functions
 export { getDynamicHeightsForTable } from './tables/dynamicTemplate.js';
+export { getDynamicHeightsForText } from './text/dynamicTemplate.js';
+
+// Export types from text schema
+export type {
+  TextSchema,
+  TextSegment,
+  TextLine,
+  TextBlock,
+  HeadingLevel,
+} from './text/index.js';

--- a/packages/schemas/src/text/dynamicTemplate.ts
+++ b/packages/schemas/src/text/dynamicTemplate.ts
@@ -1,0 +1,221 @@
+import type { Font as FontKitFont } from 'fontkit';
+import type { Schema, BasePdf, CommonOptions } from '@pdfme/common';
+import { mm2pt, pt2mm } from '@pdfme/common';
+import type { TextSchema } from './types.js';
+import { splitTextToSize, getFontKitFont, heightOfFontAtSize } from './helper.js';
+import {
+  DEFAULT_FONT_SIZE,
+  DEFAULT_LINE_HEIGHT,
+  DEFAULT_CHARACTER_SPACING,
+} from './constants.js';
+import { parseRichText, HEADING_SIZE_MULTIPLIERS } from './richText/index.js';
+import {
+  CODE_FONT_SIZE_RATIO,
+  BLOCKQUOTE_PADDING_LEFT,
+  LIST_ITEM_SPACING,
+  TABLE_CELL_PADDING,
+} from './richText/constants.js';
+
+/**
+ * Calculate dynamic heights for text schema (per-line heights for page breaking).
+ * Only calculates line-by-line heights when schema.richText is true.
+ * @returns Array of line heights in mm
+ */
+export const getDynamicHeightsForText = async (
+  value: string,
+  args: {
+    schema: Schema;
+    basePdf: BasePdf;
+    options: CommonOptions;
+    _cache: Map<string | number, unknown>;
+  },
+): Promise<number[]> => {
+  const schema = args.schema as TextSchema;
+
+  if (!value || value.trim() === '') {
+    return [schema.height];
+  }
+
+  if (!schema.richText) {
+    return [schema.height];
+  }
+
+  const font = args.options.font;
+  if (!font) {
+    return [schema.height];
+  }
+
+  const fontKitFont = await getFontKitFont(
+    schema.fontName,
+    font,
+    args._cache as Map<string | number, FontKitFont>,
+  );
+
+  const fontSize = schema.fontSize ?? DEFAULT_FONT_SIZE;
+  const lineHeight = schema.lineHeight ?? DEFAULT_LINE_HEIGHT;
+  const characterSpacing = schema.characterSpacing ?? DEFAULT_CHARACTER_SPACING;
+  const boxWidthInPt = mm2pt(schema.width);
+
+  const lineHeights = calculateRichTextLineHeights({
+    value,
+    fontKitFont,
+    fontSize,
+    lineHeight,
+    characterSpacing,
+    boxWidthInPt,
+  });
+
+  return lineHeights;
+};
+
+function calculateRichTextLineHeights(params: {
+  value: string;
+  fontKitFont: FontKitFont;
+  fontSize: number;
+  lineHeight: number;
+  characterSpacing: number;
+  boxWidthInPt: number;
+}): number[] {
+  const { value, fontKitFont, fontSize, lineHeight, characterSpacing, boxWidthInPt } = params;
+  const blocks = parseRichText(value);
+  const lineHeights: number[] = [];
+
+  for (const block of blocks) {
+    switch (block.type) {
+      case 'heading': {
+        const level = block.level ?? 1;
+        const sizeMultiplier = HEADING_SIZE_MULTIPLIERS[level];
+        const headingFontSize = fontSize * sizeMultiplier;
+        const headingTextHeight = heightOfFontAtSize(fontKitFont, headingFontSize);
+        const headingLineHeightInMm = pt2mm(headingTextHeight * lineHeight);
+
+        const segments = block.lines[0]?.segments ?? [];
+        const plainText = segments.map((s) => s.content).join('');
+
+        const lines = splitTextToSize({
+          value: plainText,
+          characterSpacing,
+          fontSize: headingFontSize,
+          fontKitFont,
+          boxWidthInPt,
+        });
+
+        for (let i = 0; i < lines.length; i++) {
+          if (i === 0) {
+            lineHeights.push(headingLineHeightInMm);
+          } else {
+            lineHeights.push(pt2mm(headingFontSize * lineHeight));
+          }
+        }
+
+        lineHeights.push(pt2mm(fontSize * 0.3)); // spacing after heading
+        break;
+      }
+
+      case 'code': {
+        const codeFontSize = fontSize * CODE_FONT_SIZE_RATIO;
+        const content = block.lines[0]?.segments[0]?.content ?? '';
+        const codeLines = content.split('\n').filter((l) => l !== '');
+
+        for (let i = 0; i < codeLines.length; i++) {
+          // First line includes top padding
+          const topPadding = i === 0 ? pt2mm(5) : 0;
+          lineHeights.push(pt2mm(codeFontSize * lineHeight) + topPadding);
+        }
+
+        lineHeights.push(pt2mm(fontSize * 1.0) + pt2mm(5)); // spacing + bottom padding
+        break;
+      }
+
+      case 'blockquote': {
+        const segments = block.lines[0]?.segments ?? [];
+        const plainText = segments.map((s) => s.content).join('');
+
+        const lines = splitTextToSize({
+          value: plainText,
+          characterSpacing,
+          fontSize,
+          fontKitFont,
+          boxWidthInPt: boxWidthInPt - mm2pt(pt2mm(BLOCKQUOTE_PADDING_LEFT)),
+        });
+
+        const firstLineTextHeight = heightOfFontAtSize(fontKitFont, fontSize);
+
+        for (let i = 0; i < lines.length; i++) {
+          if (i === 0) {
+            lineHeights.push(pt2mm(firstLineTextHeight * lineHeight));
+          } else {
+            lineHeights.push(pt2mm(fontSize * lineHeight));
+          }
+        }
+
+        lineHeights.push(pt2mm(fontSize * 0.3)); // spacing after blockquote
+        break;
+      }
+
+      case 'table': {
+        const tableData = block.tableData;
+        if (!tableData) break;
+
+        const { headers, rows } = tableData;
+        const rowHeight = fontSize * lineHeight + TABLE_CELL_PADDING * 2;
+        const rowHeightInMm = pt2mm(rowHeight);
+
+        if (headers.length > 0) {
+          lineHeights.push(rowHeightInMm); // header row
+        }
+
+        for (let i = 0; i < rows.length; i++) {
+          lineHeights.push(rowHeightInMm);
+        }
+
+        lineHeights.push(pt2mm(fontSize * 0.5)); // spacing after table
+        break;
+      }
+
+      case 'list': {
+        const listItems = block.listItems;
+        if (!listItems || listItems.length === 0) break;
+
+        const textHeight = heightOfFontAtSize(fontKitFont, fontSize);
+        const itemHeightInMm = pt2mm(textHeight * lineHeight + LIST_ITEM_SPACING);
+
+        for (let i = 0; i < listItems.length; i++) {
+          lineHeights.push(itemHeightInMm);
+        }
+
+        lineHeights.push(pt2mm(fontSize * 0.3)); // spacing after list
+        break;
+      }
+
+      case 'paragraph':
+      default: {
+        const segments = block.lines[0]?.segments ?? [];
+        const plainText = segments.map((s) => s.content).join('');
+
+        const lines = splitTextToSize({
+          value: plainText,
+          characterSpacing,
+          fontSize,
+          fontKitFont,
+          boxWidthInPt,
+        });
+
+        const firstLineTextHeight = heightOfFontAtSize(fontKitFont, fontSize);
+
+        for (let i = 0; i < lines.length; i++) {
+          if (i === 0) {
+            lineHeights.push(pt2mm(firstLineTextHeight * lineHeight));
+          } else {
+            lineHeights.push(pt2mm(fontSize * lineHeight));
+          }
+        }
+
+        lineHeights.push(pt2mm(fontSize * 0.3)); // spacing after paragraph
+        break;
+      }
+    }
+  }
+
+  return lineHeights;
+}

--- a/packages/schemas/src/text/helper.ts
+++ b/packages/schemas/src/text/helper.ts
@@ -24,6 +24,7 @@ import {
   LINE_END_FORBIDDEN_CHARS,
   LINE_START_FORBIDDEN_CHARS,
 } from './constants.js';
+import { stripRichText } from './richText/index.js';
 
 export const getBrowserVerticalFontAdjustments = (
   fontKitFont: FontKitFont,
@@ -252,7 +253,9 @@ export const calculateDynamicFontSize = ({
   if (dynamicFontSizeSetting.max < dynamicFontSizeSetting.min) return fontSize;
 
   const characterSpacing = schemaCharacterSpacing ?? DEFAULT_CHARACTER_SPACING;
-  const paragraphs = value.split('\n');
+  // Strip markdown syntax for width calculation in rich text mode
+  const plainValue = textSchema.richText ? stripRichText(value) : value;
+  const paragraphs = plainValue.split('\n');
 
   let dynamicFontSize = fontSize;
   if (dynamicFontSize < dynamicFontSizeSetting.min) {

--- a/packages/schemas/src/text/index.ts
+++ b/packages/schemas/src/text/index.ts
@@ -6,6 +6,22 @@ import type { TextSchema } from './types.js';
 import { TextCursorInput } from 'lucide';
 import { createSvgStr } from '../utils.js';
 
+export { getDynamicHeightsForText } from './dynamicTemplate.js';
+export {
+  parseRichText,
+  parseInlineStyles,
+  isRichText,
+  stripRichText,
+  HEADING_SIZE_MULTIPLIERS,
+} from './richText/index.js';
+export type {
+  TextSchema,
+  TextSegment,
+  TextLine,
+  TextBlock,
+  HeadingLevel,
+} from './types.js';
+
 const textSchema: Plugin<TextSchema> = {
   pdf: pdfRender,
   ui: uiRender,

--- a/packages/schemas/src/text/propPanel.ts
+++ b/packages/schemas/src/text/propPanel.ts
@@ -48,6 +48,26 @@ const UseDynamicFontSize = (props: PropPanelWidgetProps) => {
   rootElement.appendChild(label);
 };
 
+const UseRichText = (props: PropPanelWidgetProps) => {
+  const { rootElement, changeSchemas, activeSchema, i18n } = props;
+
+  const checkbox = document.createElement('input');
+  checkbox.type = 'checkbox';
+  checkbox.checked = Boolean((activeSchema as { richText?: unknown })?.richText);
+  checkbox.onchange = (e: Event) => {
+    const val = (e.target as HTMLInputElement).checked ? true : undefined;
+    changeSchemas([{ key: 'richText', value: val, schemaId: activeSchema.id }]);
+  };
+  const label = document.createElement('label');
+  const span = document.createElement('span');
+  span.innerText = i18n('schemas.text.richText') || 'Rich Text (Markdown)';
+  span.style.cssText = 'margin-left: 0.5rem';
+  label.style.cssText = 'display: flex; width: 100%;';
+  label.appendChild(checkbox);
+  label.appendChild(span);
+  rootElement.appendChild(label);
+};
+
 export const propPanel: PropPanel<TextSchema> = {
   schema: ({ options, activeSchema, i18n }) => {
     const font = options.font || { [DEFAULT_FONT_NAME]: { data: '', fallback: true } };
@@ -91,7 +111,12 @@ export const propPanel: PropPanel<TextSchema> = {
         props: { step: 0.1, min: 0 },
         span: 8,
       },
-      useDynamicFontSize: { type: 'boolean', widget: 'UseDynamicFontSize', bind: false, span: 16 },
+      useDynamicFontSize: {
+        type: 'boolean',
+        widget: 'UseDynamicFontSize',
+        bind: false,
+        span: 8,
+      },
       dynamicFontSize: {
         type: 'object',
         widget: 'card',
@@ -153,11 +178,17 @@ export const propPanel: PropPanel<TextSchema> = {
           },
         ],
       },
+      useRichText: {
+        type: 'boolean',
+        widget: 'UseRichText',
+        bind: false,
+        span: 8,
+      },
     };
 
     return textSchema;
   },
-  widgets: { UseDynamicFontSize },
+  widgets: { UseDynamicFontSize, UseRichText },
   defaultSchema: {
     name: '',
     type: 'text',
@@ -174,6 +205,7 @@ export const propPanel: PropPanel<TextSchema> = {
     lineHeight: DEFAULT_LINE_HEIGHT,
     characterSpacing: DEFAULT_CHARACTER_SPACING,
     dynamicFontSize: undefined,
+    richText: undefined,
     fontColor: DEFAULT_FONT_COLOR,
     fontName: undefined,
     backgroundColor: '',

--- a/packages/schemas/src/text/richText/__tests__/parser.test.ts
+++ b/packages/schemas/src/text/richText/__tests__/parser.test.ts
@@ -1,0 +1,260 @@
+import {
+  parseInlineStyles,
+  parseRichText,
+  isRichText,
+  stripRichText,
+  HEADING_SIZE_MULTIPLIERS,
+} from '../parser';
+
+describe('parseInlineStyles', () => {
+  it('should parse plain text as a single segment', () => {
+    const result = parseInlineStyles('Hello World');
+    expect(result).toEqual([{ content: 'Hello World' }]);
+  });
+
+  it('should parse bold text with **', () => {
+    const result = parseInlineStyles('Hello **World**');
+    expect(result).toEqual([
+      { content: 'Hello ' },
+      { content: 'World', bold: true },
+    ]);
+  });
+
+  it('should parse bold text with __', () => {
+    const result = parseInlineStyles('Hello __World__');
+    expect(result).toEqual([
+      { content: 'Hello ' },
+      { content: 'World', bold: true },
+    ]);
+  });
+
+  it('should parse italic text with *', () => {
+    const result = parseInlineStyles('Hello *World*');
+    expect(result).toEqual([
+      { content: 'Hello ' },
+      { content: 'World', italic: true },
+    ]);
+  });
+
+  it('should parse text color', () => {
+    const result = parseInlineStyles('Hello {#FF0000}Red{/} World');
+    expect(result).toEqual([
+      { content: 'Hello ' },
+      { content: 'Red', color: '#FF0000' },
+      { content: ' World' },
+    ]);
+  });
+
+  it('should parse background color (marker)', () => {
+    const result = parseInlineStyles('Hello {bg:#FFFF00}Highlight{/bg} World');
+    expect(result).toEqual([
+      { content: 'Hello ' },
+      { content: 'Highlight', backgroundColor: '#FFFF00' },
+      { content: ' World' },
+    ]);
+  });
+
+  it('should parse multiple styles', () => {
+    const result = parseInlineStyles('**Bold** and *italic* and {#FF0000}red{/}');
+    expect(result.length).toBeGreaterThan(1);
+    expect(result.some((s) => s.bold)).toBe(true);
+    expect(result.some((s) => s.italic)).toBe(true);
+    expect(result.some((s) => s.color === '#FF0000')).toBe(true);
+  });
+
+  it('should parse inline code', () => {
+    const result = parseInlineStyles('Use `console.log()` for debugging');
+    expect(result).toEqual([
+      { content: 'Use ' },
+      { content: 'console.log()', code: true },
+      { content: ' for debugging' },
+    ]);
+  });
+
+  it('should not parse other styles inside inline code', () => {
+    const result = parseInlineStyles('Code: `**not bold**`');
+    expect(result).toEqual([
+      { content: 'Code: ' },
+      { content: '**not bold**', code: true },
+    ]);
+  });
+});
+
+describe('parseRichText', () => {
+  it('should parse heading level 1', () => {
+    const result = parseRichText('# Heading 1');
+    expect(result).toEqual([
+      {
+        type: 'heading',
+        level: 1,
+        lines: [{ segments: [{ content: 'Heading 1' }], heightInMm: 0 }],
+      },
+    ]);
+  });
+
+  it('should parse heading level 6', () => {
+    const result = parseRichText('###### Heading 6');
+    expect(result).toEqual([
+      {
+        type: 'heading',
+        level: 6,
+        lines: [{ segments: [{ content: 'Heading 6' }], heightInMm: 0 }],
+      },
+    ]);
+  });
+
+  it('should parse paragraph', () => {
+    const result = parseRichText('This is a paragraph');
+    expect(result).toEqual([
+      {
+        type: 'paragraph',
+        lines: [{ segments: [{ content: 'This is a paragraph' }], heightInMm: 0 }],
+        rawText: 'This is a paragraph',
+      },
+    ]);
+  });
+
+  it('should parse heading with inline styles', () => {
+    const result = parseRichText('# **Bold** Heading');
+    expect(result[0].type).toBe('heading');
+    expect(result[0].level).toBe(1);
+    expect(result[0].lines[0].segments.some((s) => s.bold)).toBe(true);
+  });
+
+  it('should parse code block', () => {
+    const result = parseRichText('```js\nconst x = 1;\n```');
+    expect(result).toEqual([
+      {
+        type: 'code',
+        language: 'js',
+        lines: [{ segments: [{ content: 'const x = 1;\n' }], heightInMm: 0 }],
+      },
+    ]);
+  });
+
+  it('should parse code block without language', () => {
+    const result = parseRichText('```\ncode here\n```');
+    expect(result[0].type).toBe('code');
+    expect(result[0].language).toBeUndefined();
+  });
+
+  it('should parse blockquote', () => {
+    const result = parseRichText('> This is a quote');
+    expect(result).toEqual([
+      {
+        type: 'blockquote',
+        lines: [{ segments: [{ content: 'This is a quote' }], heightInMm: 0 }],
+      },
+    ]);
+  });
+
+  it('should parse multi-line blockquote', () => {
+    const result = parseRichText('> Line 1\n> Line 2');
+    expect(result[0].type).toBe('blockquote');
+    expect(result[0].lines[0].segments[0].content).toContain('Line 1');
+    expect(result[0].lines[0].segments[0].content).toContain('Line 2');
+  });
+
+  it('should parse mixed content', () => {
+    const result = parseRichText('# Heading\n\nParagraph\n\n```\ncode\n```\n\n> Quote');
+    expect(result.length).toBe(4);
+    expect(result[0].type).toBe('heading');
+    expect(result[1].type).toBe('paragraph');
+    expect(result[2].type).toBe('code');
+    expect(result[3].type).toBe('blockquote');
+  });
+});
+
+describe('isRichText', () => {
+  it('should return true for headings', () => {
+    expect(isRichText('# Heading')).toBe(true);
+    expect(isRichText('## Heading')).toBe(true);
+  });
+
+  it('should return true for bold text', () => {
+    expect(isRichText('**bold**')).toBe(true);
+    expect(isRichText('__bold__')).toBe(true);
+  });
+
+  it('should return true for italic text', () => {
+    expect(isRichText('*italic*')).toBe(true);
+    expect(isRichText('_italic_')).toBe(true);
+  });
+
+  it('should return true for color text', () => {
+    expect(isRichText('{#FF0000}red{/}')).toBe(true);
+  });
+
+  it('should return true for background color', () => {
+    expect(isRichText('{bg:#FFFF00}highlight{/bg}')).toBe(true);
+  });
+
+  it('should return true for inline code', () => {
+    expect(isRichText('Use `code` here')).toBe(true);
+  });
+
+  it('should return true for code block', () => {
+    expect(isRichText('```\ncode\n```')).toBe(true);
+  });
+
+  it('should return true for blockquote', () => {
+    expect(isRichText('> quote')).toBe(true);
+  });
+
+  it('should return false for plain text', () => {
+    expect(isRichText('Hello World')).toBe(false);
+    expect(isRichText('Just a normal paragraph')).toBe(false);
+  });
+});
+
+describe('stripRichText', () => {
+  it('should remove heading markers', () => {
+    expect(stripRichText('# Heading')).toBe('Heading');
+    expect(stripRichText('## Heading')).toBe('Heading');
+  });
+
+  it('should remove bold markers', () => {
+    expect(stripRichText('**bold**')).toBe('bold');
+    expect(stripRichText('__bold__')).toBe('bold');
+  });
+
+  it('should remove color markers', () => {
+    expect(stripRichText('{#FF0000}red{/}')).toBe('red');
+  });
+
+  it('should remove background color markers', () => {
+    expect(stripRichText('{bg:#FFFF00}highlight{/bg}')).toBe('highlight');
+  });
+
+  it('should remove inline code markers', () => {
+    expect(stripRichText('Use `code` here')).toBe('Use code here');
+  });
+
+  it('should remove code block markers', () => {
+    expect(stripRichText('```js\ncode\n```')).toBe('code\n');
+  });
+
+  it('should remove blockquote markers', () => {
+    expect(stripRichText('> quote')).toBe('quote');
+    expect(stripRichText('> Line 1\n> Line 2')).toBe('Line 1\nLine 2');
+  });
+
+  it('should handle complex text', () => {
+    const input = '# **Bold** Heading with {#FF0000}color{/}';
+    const result = stripRichText(input);
+    expect(result).not.toContain('**');
+    expect(result).not.toContain('{#');
+    expect(result).not.toContain('{/}');
+  });
+});
+
+describe('HEADING_SIZE_MULTIPLIERS', () => {
+  it('should have correct multipliers', () => {
+    expect(HEADING_SIZE_MULTIPLIERS[1]).toBe(2.0);
+    expect(HEADING_SIZE_MULTIPLIERS[2]).toBe(1.5);
+    expect(HEADING_SIZE_MULTIPLIERS[3]).toBe(1.25);
+    expect(HEADING_SIZE_MULTIPLIERS[4]).toBe(1.0);
+    expect(HEADING_SIZE_MULTIPLIERS[5]).toBe(0.875);
+    expect(HEADING_SIZE_MULTIPLIERS[6]).toBe(0.75);
+  });
+});

--- a/packages/schemas/src/text/richText/constants.ts
+++ b/packages/schemas/src/text/richText/constants.ts
@@ -1,0 +1,27 @@
+// Bold styling
+export const BOLD_STROKE_WIDTH_RATIO = 0.03;
+export const BOLD_STROKE_WIDTH_CSS = '0.5px';
+
+// Code block styling (GitHub-style)
+export const CODE_BG_COLOR = '#f6f8fa';
+export const CODE_BORDER_COLOR = '#d0d7de';
+export const CODE_FONT_SIZE_RATIO = 0.875;
+
+// Blockquote styling (GitHub-style)
+export const BLOCKQUOTE_BORDER_COLOR = '#d0d7de';
+export const BLOCKQUOTE_TEXT_COLOR = '#656d76';
+export const BLOCKQUOTE_BORDER_WIDTH = 3;
+export const BLOCKQUOTE_PADDING_LEFT = 10;
+
+// List styling (values in pt)
+export const LIST_INDENT_PER_LEVEL = 15;
+export const LIST_MARKER_WIDTH = 15;
+export const LIST_BULLET_CHAR = '•';
+export const LIST_ITEM_SPACING = 2;
+
+// Table styling (values in pt)
+export const TABLE_BORDER_COLOR = '#d0d7de';
+export const TABLE_HEADER_BG_COLOR = '#f6f8fa';
+export const TABLE_BORDER_WIDTH = 0.5;
+export const TABLE_CELL_PADDING = 6;
+export const TABLE_CELL_MIN_WIDTH = 40;

--- a/packages/schemas/src/text/richText/index.ts
+++ b/packages/schemas/src/text/richText/index.ts
@@ -1,0 +1,35 @@
+export {
+  parseRichText,
+  parseInlineStyles,
+  isRichText,
+  stripRichText,
+  HEADING_SIZE_MULTIPLIERS,
+} from './parser.js';
+
+export type { TextBlock, TextSegment, TextLine, HeadingLevel, ListItem, TableData } from '../types.js';
+
+export {
+  BOLD_STROKE_WIDTH_RATIO,
+  BOLD_STROKE_WIDTH_CSS,
+  CODE_BG_COLOR,
+  CODE_BORDER_COLOR,
+  CODE_FONT_SIZE_RATIO,
+  BLOCKQUOTE_BORDER_COLOR,
+  BLOCKQUOTE_TEXT_COLOR,
+  BLOCKQUOTE_BORDER_WIDTH,
+  BLOCKQUOTE_PADDING_LEFT,
+  LIST_INDENT_PER_LEVEL,
+  LIST_MARKER_WIDTH,
+  LIST_BULLET_CHAR,
+  LIST_ITEM_SPACING,
+  TABLE_BORDER_COLOR,
+  TABLE_HEADER_BG_COLOR,
+  TABLE_BORDER_WIDTH,
+  TABLE_CELL_PADDING,
+  TABLE_CELL_MIN_WIDTH,
+} from './constants.js';
+
+export { renderRichTextBlocks, drawSegments, hexToRgb } from './pdfRender.js';
+export type { RenderRichTextParams } from './pdfRender.js';
+
+export { richTextToHtml, segmentToHtml } from './uiRender.js';

--- a/packages/schemas/src/text/richText/parser.ts
+++ b/packages/schemas/src/text/richText/parser.ts
@@ -1,0 +1,523 @@
+import type { TextSegment, TextBlock, HeadingLevel, ListItem, TableData } from '../types.js';
+
+export const HEADING_SIZE_MULTIPLIERS: Record<HeadingLevel, number> = {
+  1: 2.0,
+  2: 1.5,
+  3: 1.25,
+  4: 1.0,
+  5: 0.875,
+  6: 0.75,
+};
+
+const HEADING_PATTERN = /^(#{1,6})\s+(.*)$/;
+const CODE_BLOCK_PATTERN = /^```(\w*)\n?([\s\S]*?)```$/;
+const BLOCKQUOTE_PATTERN = /^>\s?(.*)$/;
+const TABLE_ROW_PATTERN = /^\|(.+)\|$/;
+const TABLE_SEPARATOR_PATTERN = /^\|[\s\-:|]+\|$/;
+const UNORDERED_LIST_PATTERN = /^(\s*)[-*]\s+(.*)$/;
+const ORDERED_LIST_PATTERN = /^(\s*)(\d+)\.\s+(.*)$/;
+
+const INLINE_PATTERNS = {
+  bold: /(\*\*|__)(.*?)\1/g,
+  italic: /(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)|(?<!_)_(?!_)(.+?)(?<!_)_(?!_)/g,
+  color: /\{#([0-9A-Fa-f]{6})\}(.*?)\{\/\}/g,
+  backgroundColor: /\{bg:#([0-9A-Fa-f]{6})\}(.*?)\{\/bg\}/g,
+};
+
+type TokenType = 'text' | 'bold' | 'italic' | 'code' | 'color' | 'backgroundColor';
+
+interface Token {
+  type: TokenType;
+  content: string;
+  value?: string;
+  start: number;
+  end: number;
+}
+
+function tokenize(text: string): Token[] {
+  const tokens: Token[] = [];
+
+  let match: RegExpExecArray | null;
+
+  const codePattern = /`([^`]+)`/g;
+  while ((match = codePattern.exec(text)) !== null) {
+    tokens.push({
+      type: 'code',
+      content: match[1],
+      start: match.index,
+      end: match.index + match[0].length,
+    });
+  }
+
+  const boldPattern = /(\*\*|__)(.*?)\1/g;
+  while ((match = boldPattern.exec(text)) !== null) {
+    const overlapsCode = tokens.some(
+      (t) => t.type === 'code' && match!.index >= t.start && match!.index < t.end,
+    );
+    if (!overlapsCode) {
+      tokens.push({
+        type: 'bold',
+        content: match[2],
+        start: match.index,
+        end: match.index + match[0].length,
+      });
+    }
+  }
+
+  const italicPattern = /(?<!\*)\*(?!\*)((?:(?!\*).)+?)(?<!\*)\*(?!\*)|(?<!_)_(?!_)((?:(?!_).)+?)(?<!_)_(?!_)/g;
+  while ((match = italicPattern.exec(text)) !== null) {
+    const overlaps = tokens.some(
+      (t) => (t.type === 'bold' || t.type === 'code') && match!.index >= t.start && match!.index < t.end,
+    );
+    if (!overlaps) {
+      tokens.push({
+        type: 'italic',
+        content: match[1] || match[2],
+        start: match.index,
+        end: match.index + match[0].length,
+      });
+    }
+  }
+
+  const colorPattern = /\{#([0-9A-Fa-f]{6})\}(.*?)\{\/\}/g;
+  while ((match = colorPattern.exec(text)) !== null) {
+    const overlapsCode = tokens.some(
+      (t) => t.type === 'code' && match!.index >= t.start && match!.index < t.end,
+    );
+    if (!overlapsCode) {
+      tokens.push({
+        type: 'color',
+        content: match[2],
+        value: `#${match[1]}`,
+        start: match.index,
+        end: match.index + match[0].length,
+      });
+    }
+  }
+
+  const bgPattern = /\{bg:#([0-9A-Fa-f]{6})\}(.*?)\{\/bg\}/g;
+  while ((match = bgPattern.exec(text)) !== null) {
+    const overlapsCode = tokens.some(
+      (t) => t.type === 'code' && match!.index >= t.start && match!.index < t.end,
+    );
+    if (!overlapsCode) {
+      tokens.push({
+        type: 'backgroundColor',
+        content: match[2],
+        value: `#${match[1]}`,
+        start: match.index,
+        end: match.index + match[0].length,
+      });
+    }
+  }
+
+  tokens.sort((a, b) => a.start - b.start);
+
+  return tokens;
+}
+
+function tokensToSegments(text: string, tokens: Token[]): TextSegment[] {
+  if (tokens.length === 0) {
+    return [{ content: text }];
+  }
+
+  const segments: TextSegment[] = [];
+  let currentPos = 0;
+
+  for (const token of tokens) {
+    if (token.start > currentPos) {
+      const plainText = text.slice(currentPos, token.start);
+      if (plainText) {
+        segments.push({ content: plainText });
+      }
+    }
+
+    const nestedTokens = tokens.filter(
+      (t) => t !== token && t.start >= token.start && t.end <= token.end,
+    );
+
+    if (nestedTokens.length > 0) {
+      const nestedSegments = tokensToSegments(token.content, nestedTokens.map((t) => ({
+        ...t,
+        start: t.start - token.start - getMarkerLength(token),
+        end: t.end - token.start - getMarkerLength(token),
+      })));
+
+      for (const seg of nestedSegments) {
+        const segment: TextSegment = { ...seg };
+        applyTokenStyle(segment, token);
+        segments.push(segment);
+      }
+    } else {
+      const segment: TextSegment = { content: token.content };
+      applyTokenStyle(segment, token);
+      segments.push(segment);
+    }
+
+    currentPos = token.end;
+  }
+
+  if (currentPos < text.length) {
+    const plainText = text.slice(currentPos);
+    if (plainText) {
+      segments.push({ content: plainText });
+    }
+  }
+
+  return segments;
+}
+
+function getMarkerLength(token: Token): number {
+  switch (token.type) {
+    case 'bold':
+      return 2;
+    case 'italic':
+      return 1;
+    case 'code':
+      return 1;
+    case 'color':
+      return 10;
+    case 'backgroundColor':
+      return 13;
+    default:
+      return 0;
+  }
+}
+
+function applyTokenStyle(segment: TextSegment, token: Token): void {
+  switch (token.type) {
+    case 'bold':
+      segment.bold = true;
+      break;
+    case 'italic':
+      segment.italic = true;
+      break;
+    case 'code':
+      segment.code = true;
+      break;
+    case 'color':
+      segment.color = token.value;
+      break;
+    case 'backgroundColor':
+      segment.backgroundColor = token.value;
+      break;
+  }
+}
+
+export function parseInlineStyles(text: string): TextSegment[] {
+  const tokens = tokenize(text);
+  return tokensToSegments(text, tokens);
+}
+
+export function parseRichText(text: string): TextBlock[] {
+  const blocks: TextBlock[] = [];
+
+  const codeBlockRegex = /```(\w*)\n?([\s\S]*?)```/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = codeBlockRegex.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      const beforeText = text.slice(lastIndex, match.index);
+      blocks.push(...parseNonCodeBlocks(beforeText));
+    }
+
+    const language = match[1] || undefined;
+    const codeContent = match[2];
+    blocks.push({
+      type: 'code',
+      language,
+      lines: [{ segments: [{ content: codeContent }], heightInMm: 0 }],
+    });
+
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    const remainingText = text.slice(lastIndex);
+    blocks.push(...parseNonCodeBlocks(remainingText));
+  }
+
+  return blocks;
+}
+
+function parseTableBlock(lines: string[]): { block: TextBlock; consumedLines: number } | null {
+  if (lines.length < 2) return null;
+
+  const firstLine = lines[0].trim();
+  const secondLine = lines[1].trim();
+
+  if (!TABLE_ROW_PATTERN.test(firstLine) || !TABLE_SEPARATOR_PATTERN.test(secondLine)) {
+    return null;
+  }
+
+  const headerCells = firstLine
+    .slice(1, -1)
+    .split('|')
+    .map((cell) => cell.trim());
+
+  const rows: string[][] = [];
+  let i = 2;
+  while (i < lines.length) {
+    const line = lines[i].trim();
+    if (!TABLE_ROW_PATTERN.test(line)) break;
+
+    const cells = line
+      .slice(1, -1)
+      .split('|')
+      .map((cell) => cell.trim());
+    rows.push(cells);
+    i++;
+  }
+
+  const tableData: TableData = {
+    headers: headerCells,
+    rows,
+  };
+
+  return {
+    block: {
+      type: 'table',
+      lines: [],
+      tableData,
+    },
+    consumedLines: i,
+  };
+}
+
+function parseListBlock(lines: string[]): { block: TextBlock; consumedLines: number } | null {
+  const listItems: ListItem[] = [];
+  let i = 0;
+
+  const orderCounters: Map<number, number> = new Map();
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    const unorderedMatch = UNORDERED_LIST_PATTERN.exec(line);
+    if (unorderedMatch) {
+      const indent = unorderedMatch[1].length;
+      const level = Math.floor(indent / 2);
+      const content = unorderedMatch[2];
+      const segments = parseInlineStyles(content);
+
+      listItems.push({
+        level,
+        ordered: false,
+        segments,
+      });
+      i++;
+      continue;
+    }
+
+    const orderedMatch = ORDERED_LIST_PATTERN.exec(line);
+    if (orderedMatch) {
+      const indent = orderedMatch[1].length;
+      const level = Math.floor(indent / 2);
+      const content = orderedMatch[3];
+      const segments = parseInlineStyles(content);
+
+      const currentCount = (orderCounters.get(level) || 0) + 1;
+      orderCounters.set(level, currentCount);
+
+      for (const [key] of orderCounters) {
+        if (key > level) {
+          orderCounters.delete(key);
+        }
+      }
+
+      listItems.push({
+        level,
+        ordered: true,
+        orderNumber: currentCount,
+        segments,
+      });
+      i++;
+      continue;
+    }
+
+    if (line.trim() === '' && i + 1 < lines.length) {
+      const nextLine = lines[i + 1];
+      if (UNORDERED_LIST_PATTERN.test(nextLine) || ORDERED_LIST_PATTERN.test(nextLine)) {
+        i++;
+        continue;
+      }
+    }
+
+    break;
+  }
+
+  if (listItems.length === 0) {
+    return null;
+  }
+
+  return {
+    block: {
+      type: 'list',
+      lines: [],
+      listItems,
+    },
+    consumedLines: i,
+  };
+}
+
+function isListLine(line: string): boolean {
+  return UNORDERED_LIST_PATTERN.test(line) || ORDERED_LIST_PATTERN.test(line);
+}
+
+function isTableLine(line: string): boolean {
+  return TABLE_ROW_PATTERN.test(line.trim());
+}
+
+function parseNonCodeBlocks(text: string): TextBlock[] {
+  const blocks: TextBlock[] = [];
+  const allLines = text.split('\n');
+  let i = 0;
+
+  while (i < allLines.length) {
+    const line = allLines[i];
+
+    if (line.trim() === '') {
+      i++;
+      continue;
+    }
+
+    const headingMatch = HEADING_PATTERN.exec(line);
+    if (headingMatch) {
+      const level = headingMatch[1].length as HeadingLevel;
+      const content = headingMatch[2];
+      const segments = parseInlineStyles(content);
+
+      blocks.push({
+        type: 'heading',
+        level,
+        lines: [{ segments, heightInMm: 0 }],
+      });
+      i++;
+      continue;
+    }
+
+    const tableResult = parseTableBlock(allLines.slice(i));
+    if (tableResult) {
+      blocks.push(tableResult.block);
+      i += tableResult.consumedLines;
+      continue;
+    }
+
+    if (isListLine(line)) {
+      const listResult = parseListBlock(allLines.slice(i));
+      if (listResult) {
+        blocks.push(listResult.block);
+        i += listResult.consumedLines;
+        continue;
+      }
+    }
+
+    if (BLOCKQUOTE_PATTERN.test(line)) {
+      const quoteLines: string[] = [];
+      while (i < allLines.length) {
+        const currentLine = allLines[i];
+        if (BLOCKQUOTE_PATTERN.test(currentLine)) {
+          const match = BLOCKQUOTE_PATTERN.exec(currentLine);
+          quoteLines.push(match ? match[1] : '');
+          i++;
+        } else if (currentLine.trim() === '') {
+          break;
+        } else {
+          break;
+        }
+      }
+      const segments = parseInlineStyles(quoteLines.join('\n'));
+      blocks.push({
+        type: 'blockquote',
+        lines: [{ segments, heightInMm: 0 }],
+      });
+      continue;
+    }
+
+    const paragraphLines: string[] = [];
+    while (i < allLines.length) {
+      const currentLine = allLines[i];
+
+      if (currentLine.trim() === '') {
+        break;
+      }
+
+      if (
+        HEADING_PATTERN.test(currentLine) ||
+        isListLine(currentLine) ||
+        isTableLine(currentLine) ||
+        BLOCKQUOTE_PATTERN.test(currentLine)
+      ) {
+        break;
+      }
+
+      paragraphLines.push(currentLine);
+      i++;
+    }
+
+    if (paragraphLines.length > 0) {
+      const paragraphText = paragraphLines.join('\n');
+      const segments = parseInlineStyles(paragraphText);
+      blocks.push({
+        type: 'paragraph',
+        lines: [{ segments, heightInMm: 0 }],
+        rawText: paragraphText,
+      });
+    }
+  }
+
+  return blocks;
+}
+
+export function isRichText(text: string): boolean {
+  const lines = text.split('\n');
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    if (HEADING_PATTERN.test(line)) return true;
+    if (BLOCKQUOTE_PATTERN.test(line)) return true;
+    if (UNORDERED_LIST_PATTERN.test(line)) return true;
+    if (ORDERED_LIST_PATTERN.test(line)) return true;
+
+    if (i < lines.length - 1) {
+      if (TABLE_ROW_PATTERN.test(line.trim()) && TABLE_SEPARATOR_PATTERN.test(lines[i + 1].trim())) {
+        return true;
+      }
+    }
+  }
+
+  if (/```[\s\S]*?```/.test(text)) return true;
+  if (/`[^`]+`/.test(text)) return true;
+  if (/\*\*.+?\*\*/.test(text)) return true;
+  if (/__[^_]+__/.test(text)) return true;
+  if (/(?<!\*)\*(?!\*)[^*]+\*(?!\*)/.test(text)) return true;
+  if (/(?<!_)_(?!_)[^_]+_(?!_)/.test(text)) return true;
+  if (/\{#[0-9A-Fa-f]{6}\}.+?\{\/\}/.test(text)) return true;
+  if (/\{bg:#[0-9A-Fa-f]{6}\}.+?\{\/bg\}/.test(text)) return true;
+
+  return false;
+}
+
+export function stripRichText(text: string): string {
+  let result = text;
+
+  result = result.replace(/```\w*\n?([\s\S]*?)```/g, '$1');
+  result = result.replace(/`([^`]+)`/g, '$1');
+  result = result.replace(/^#{1,6}\s+/gm, '');
+  result = result.replace(/^>\s?/gm, '');
+  result = result.replace(/^\|[\s\-:|]+\|$/gm, '');
+  result = result.replace(/^\|(.+)\|$/gm, (_, content) => {
+    return content.split('|').map((cell: string) => cell.trim()).join(' ');
+  });
+  result = result.replace(/^(\s*)[-*]\s+/gm, '$1');
+  result = result.replace(/^(\s*)\d+\.\s+/gm, '$1');
+  result = result.replace(/(\*\*|__)(.*?)\1/g, '$2');
+  result = result.replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, '$1');
+  result = result.replace(/(?<!_)_(?!_)(.+?)(?<!_)_(?!_)/g, '$1');
+  result = result.replace(/\{#[0-9A-Fa-f]{6}\}(.*?)\{\/\}/g, '$1');
+  result = result.replace(/\{bg:#[0-9A-Fa-f]{6}\}(.*?)\{\/bg\}/g, '$1');
+
+  return result;
+}

--- a/packages/schemas/src/text/richText/pdfRender.ts
+++ b/packages/schemas/src/text/richText/pdfRender.ts
@@ -1,0 +1,1470 @@
+import { PDFFont, rgb, Rotation } from '@pdfme/pdf-lib';
+import type { Font as FontKitFont } from 'fontkit';
+import type { PDFRenderProps } from '@pdfme/common';
+import type { TextSchema, TextSegment, TextBlock } from '../types.js';
+import {
+  heightOfFontAtSize,
+  widthOfTextAtSize,
+  splitTextToSize,
+} from '../helper.js';
+import { rotatePoint, hex2PrintingColor } from '../../utils.js';
+import { parseInlineStyles, HEADING_SIZE_MULTIPLIERS, stripRichText } from './index.js';
+import {
+  BOLD_STROKE_WIDTH_RATIO,
+  CODE_BG_COLOR,
+  CODE_FONT_SIZE_RATIO,
+  BLOCKQUOTE_BORDER_COLOR,
+  BLOCKQUOTE_TEXT_COLOR,
+  BLOCKQUOTE_BORDER_WIDTH,
+  BLOCKQUOTE_PADDING_LEFT,
+  LIST_INDENT_PER_LEVEL,
+  LIST_MARKER_WIDTH,
+  LIST_BULLET_CHAR,
+  LIST_ITEM_SPACING,
+  TABLE_BORDER_COLOR,
+  TABLE_HEADER_BG_COLOR,
+  TABLE_BORDER_WIDTH,
+  TABLE_CELL_PADDING,
+} from './constants.js';
+
+export const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  return result
+    ? {
+        r: parseInt(result[1], 16) / 255,
+        g: parseInt(result[2], 16) / 255,
+        b: parseInt(result[3], 16) / 255,
+      }
+    : null;
+};
+
+export const drawSegments = (params: {
+  segments: TextSegment[];
+  xStart: number;
+  yLine: number;
+  fontSize: number;
+  textHeight: number;
+  fontKitFont: FontKitFont;
+  characterSpacing: number;
+  lineHeight: number;
+  color: ReturnType<typeof hex2PrintingColor>;
+  pdfFontValue: PDFFont;
+  page: PDFRenderProps<TextSchema>['page'];
+  rotate: Rotation;
+  pivotPoint: { x: number; y: number };
+  opacity: number | undefined;
+  colorOverride?: string;
+}) => {
+  const {
+    segments,
+    xStart,
+    yLine,
+    fontSize,
+    textHeight,
+    fontKitFont,
+    characterSpacing,
+    lineHeight,
+    color,
+    pdfFontValue,
+    page,
+    rotate,
+    pivotPoint,
+    opacity,
+    colorOverride,
+  } = params;
+
+  let currentX = xStart;
+  for (const segment of segments) {
+    if (!segment.content) continue;
+
+    const segmentFontSize = segment.code ? fontSize * CODE_FONT_SIZE_RATIO : fontSize;
+    const segmentWidth = widthOfTextAtSize(
+      segment.content,
+      fontKitFont,
+      segmentFontSize,
+      characterSpacing,
+    );
+
+    if (segment.code) {
+      const bgRgb = hexToRgb(CODE_BG_COLOR);
+      if (bgRgb) {
+        const bgColor = rgb(bgRgb.r, bgRgb.g, bgRgb.b);
+        const bgY = yLine - textHeight * 0.15;
+        const bgHeight = textHeight * 1.1;
+        const padding = 2;
+        if (rotate.angle !== 0) {
+          const rotatedBgPoint = rotatePoint({ x: currentX - padding, y: bgY }, pivotPoint, rotate.angle);
+          page.drawRectangle({
+            x: rotatedBgPoint.x,
+            y: rotatedBgPoint.y,
+            width: segmentWidth + padding * 2,
+            height: bgHeight,
+            color: bgColor,
+            rotate,
+            opacity,
+          });
+        } else {
+          page.drawRectangle({
+            x: currentX - padding,
+            y: bgY,
+            width: segmentWidth + padding * 2,
+            height: bgHeight,
+            color: bgColor,
+            opacity,
+          });
+        }
+      }
+    } else if (segment.backgroundColor) {
+      const bgRgb = hexToRgb(segment.backgroundColor);
+      if (bgRgb) {
+        const bgColor = rgb(bgRgb.r, bgRgb.g, bgRgb.b);
+        const bgY = yLine - textHeight * 0.2;
+        const bgHeight = textHeight * 1.2;
+        if (rotate.angle !== 0) {
+          const rotatedBgPoint = rotatePoint({ x: currentX, y: bgY }, pivotPoint, rotate.angle);
+          page.drawRectangle({
+            x: rotatedBgPoint.x,
+            y: rotatedBgPoint.y,
+            width: segmentWidth,
+            height: bgHeight,
+            color: bgColor,
+            rotate,
+            opacity,
+          });
+        } else {
+          page.drawRectangle({
+            x: currentX,
+            y: bgY,
+            width: segmentWidth,
+            height: bgHeight,
+            color: bgColor,
+            opacity,
+          });
+        }
+      }
+    }
+
+    let segmentColor = color;
+    if (colorOverride) {
+      const overrideRgb = hexToRgb(colorOverride);
+      if (overrideRgb) {
+        segmentColor = rgb(overrideRgb.r, overrideRgb.g, overrideRgb.b);
+      }
+    } else if (segment.color) {
+      const colorRgb = hexToRgb(segment.color);
+      if (colorRgb) {
+        segmentColor = rgb(colorRgb.r, colorRgb.g, colorRgb.b);
+      }
+    }
+
+    page.drawText(segment.content, {
+      x: currentX,
+      y: yLine,
+      rotate,
+      size: segmentFontSize,
+      color: segmentColor,
+      lineHeight: lineHeight * fontSize,
+      font: pdfFontValue,
+      opacity,
+    });
+
+    if (segment.bold) {
+      const strokeWidth = segmentFontSize * BOLD_STROKE_WIDTH_RATIO;
+      page.drawText(segment.content, {
+        x: currentX + strokeWidth * 0.5,
+        y: yLine,
+        rotate,
+        size: segmentFontSize,
+        color: segmentColor,
+        lineHeight: lineHeight * fontSize,
+        font: pdfFontValue,
+        opacity,
+      });
+    }
+
+    currentX += segmentWidth + characterSpacing;
+  }
+};
+
+export interface RenderRichTextParams {
+  blocks: TextBlock[];
+  schema: TextSchema;
+  page: PDFRenderProps<TextSchema>['page'];
+  pdfLib: PDFRenderProps<TextSchema>['pdfLib'];
+  fontKitFont: FontKitFont;
+  pdfFontValue: PDFFont;
+  baseFontSize: number;
+  color: ReturnType<typeof hex2PrintingColor>;
+  alignment: string;
+  verticalAlignment: string;
+  lineHeight: number;
+  characterSpacing: number;
+  x: number;
+  width: number;
+  pageHeight: number;
+  schemaPositionY: number;
+  rotate: Rotation;
+  pivotPoint: { x: number; y: number };
+  opacity: number | undefined;
+}
+
+export const renderRichTextBlocks = (params: RenderRichTextParams) => {
+  const {
+    blocks,
+    schema,
+    page,
+    pdfLib,
+    fontKitFont,
+    pdfFontValue,
+    baseFontSize,
+    color,
+    alignment,
+    verticalAlignment,
+    lineHeight,
+    characterSpacing,
+    x,
+    width,
+    pageHeight,
+    schemaPositionY,
+    rotate,
+    pivotPoint,
+    opacity,
+  } = params;
+
+  let currentY = pageHeight - schemaPositionY;
+  const firstLineTextHeight = heightOfFontAtSize(fontKitFont, baseFontSize);
+  const halfLineHeightAdjustment = lineHeight === 0 ? 0 : ((lineHeight - 1) * baseFontSize) / 2;
+
+  if (verticalAlignment === 'top') {
+    currentY -= firstLineTextHeight + halfLineHeightAdjustment;
+  }
+
+  const segmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+
+  const lineRange = schema.__lineRange;
+  let globalLineIndex = 0;
+
+  const shouldRenderLine = (index: number): boolean => {
+    if (!lineRange) return true;
+    return index >= lineRange.start && index <= lineRange.end;
+  };
+
+  const isBeyondRange = (index: number): boolean => {
+    if (!lineRange) return false;
+    return index > lineRange.end;
+  };
+
+  for (const block of blocks) {
+    switch (block.type) {
+      case 'heading':
+        currentY = renderHeading({
+          block,
+          currentY,
+          globalLineIndex,
+          shouldRenderLine,
+          isBeyondRange,
+          baseFontSize,
+          fontKitFont,
+          pdfFontValue,
+          characterSpacing,
+          lineHeight,
+          width,
+          x,
+          color,
+          page,
+          rotate,
+          pivotPoint,
+          opacity,
+          alignment,
+        });
+        globalLineIndex += countHeadingLines(block, fontKitFont, baseFontSize, characterSpacing, width) + 1;
+        break;
+
+      case 'code':
+        currentY = renderCodeBlock({
+          block,
+          currentY,
+          globalLineIndex,
+          shouldRenderLine,
+          isBeyondRange,
+          baseFontSize,
+          fontKitFont,
+          pdfFontValue,
+          characterSpacing,
+          lineHeight,
+          width,
+          x,
+          color,
+          page,
+          pdfLib,
+          rotate,
+          pivotPoint,
+          opacity,
+        });
+        globalLineIndex += countCodeLines(block) + 1;
+        break;
+
+      case 'blockquote':
+        currentY = renderBlockquote({
+          block,
+          currentY,
+          globalLineIndex,
+          shouldRenderLine,
+          isBeyondRange,
+          baseFontSize,
+          fontKitFont,
+          pdfFontValue,
+          characterSpacing,
+          lineHeight,
+          width,
+          x,
+          color,
+          page,
+          pdfLib,
+          rotate,
+          pivotPoint,
+          opacity,
+        });
+        globalLineIndex += countBlockquoteLines(block, fontKitFont, baseFontSize, characterSpacing, width) + 1;
+        break;
+
+      case 'table':
+        currentY = renderTable({
+          block,
+          currentY,
+          globalLineIndex,
+          shouldRenderLine,
+          isBeyondRange,
+          baseFontSize,
+          fontKitFont,
+          pdfFontValue,
+          characterSpacing,
+          lineHeight,
+          width,
+          x,
+          color,
+          page,
+          pdfLib,
+          rotate,
+          pivotPoint,
+          opacity,
+        });
+        globalLineIndex += countTableLines(block) + 1;
+        break;
+
+      case 'list':
+        currentY = renderList({
+          block,
+          currentY,
+          globalLineIndex,
+          shouldRenderLine,
+          isBeyondRange,
+          baseFontSize,
+          fontKitFont,
+          pdfFontValue,
+          characterSpacing,
+          lineHeight,
+          width,
+          x,
+          color,
+          page,
+          pdfLib,
+          rotate,
+          pivotPoint,
+          opacity,
+        });
+        globalLineIndex += countListLines(block) + 1;
+        break;
+
+      case 'paragraph':
+      default:
+        currentY = renderParagraph({
+          block,
+          currentY,
+          globalLineIndex,
+          shouldRenderLine,
+          isBeyondRange,
+          baseFontSize,
+          fontKitFont,
+          pdfFontValue,
+          characterSpacing,
+          lineHeight,
+          width,
+          x,
+          color,
+          page,
+          pdfLib,
+          rotate,
+          pivotPoint,
+          opacity,
+          alignment,
+          segmenter,
+        });
+        globalLineIndex += countParagraphLines(block, fontKitFont, baseFontSize, characterSpacing, width) + 1;
+        break;
+    }
+  }
+};
+
+const splitSegmentsIntoLines = (
+  rawText: string,
+  fontKitFont: FontKitFont,
+  fontSize: number,
+  characterSpacing: number,
+  boxWidthInPt: number,
+): TextSegment[][] => {
+  const segments = parseInlineStyles(rawText);
+
+  const result: TextSegment[][] = [];
+  let currentLine: TextSegment[] = [];
+  let currentLineWidth = 0;
+
+  for (const segment of segments) {
+    const content = segment.content;
+
+    const parts = content.split('\n');
+
+    for (let partIndex = 0; partIndex < parts.length; partIndex++) {
+      const part = parts[partIndex];
+
+      if (partIndex > 0) {
+        if (currentLine.length > 0) {
+          result.push(currentLine);
+        } else {
+          result.push([{ content: '' }]);
+        }
+        currentLine = [];
+        currentLineWidth = 0;
+      }
+
+      if (part.length === 0) continue;
+
+      let remainingText = part;
+      while (remainingText.length > 0) {
+        const textWidth = widthOfTextAtSize(remainingText, fontKitFont, fontSize, characterSpacing);
+
+        if (currentLineWidth + textWidth <= boxWidthInPt) {
+          if (remainingText.trim().length > 0 || currentLine.length === 0) {
+            currentLine.push({
+              ...segment,
+              content: remainingText,
+            });
+          }
+          currentLineWidth += textWidth;
+          remainingText = '';
+        } else {
+          let splitPos = 0;
+          let lastBreakPos = 0;
+          let testWidth = 0;
+
+          for (let i = 0; i < remainingText.length; i++) {
+            const char = remainingText[i];
+            const charWidth = widthOfTextAtSize(char, fontKitFont, fontSize, characterSpacing);
+
+            if (currentLineWidth + testWidth + charWidth > boxWidthInPt) {
+              if (lastBreakPos > 0) {
+                splitPos = lastBreakPos;
+              } else if (splitPos === 0 && currentLine.length === 0) {
+                splitPos = Math.max(1, i);
+              } else {
+                splitPos = i;
+              }
+              break;
+            }
+
+            testWidth += charWidth;
+            splitPos = i + 1;
+
+            if (char === ' ' || char === '-' || char === '　') {
+              lastBreakPos = i + 1;
+            }
+          }
+
+          if (splitPos === 0) splitPos = 1;
+
+          const fitPart = remainingText.substring(0, splitPos).trimEnd();
+          remainingText = remainingText.substring(splitPos).trimStart();
+
+          if (fitPart.length > 0) {
+            currentLine.push({
+              ...segment,
+              content: fitPart,
+            });
+          }
+
+          if (currentLine.length > 0) {
+            result.push(currentLine);
+          }
+          currentLine = [];
+          currentLineWidth = 0;
+        }
+      }
+    }
+  }
+
+  if (currentLine.length > 0) {
+    result.push(currentLine);
+  }
+
+  if (result.length === 0) {
+    result.push([{ content: '' }]);
+  }
+
+  return result;
+};
+
+const countHeadingLines = (
+  block: TextBlock,
+  fontKitFont: FontKitFont,
+  baseFontSize: number,
+  characterSpacing: number,
+  width: number,
+): number => {
+  const level = block.level ?? 1;
+  const sizeMultiplier = HEADING_SIZE_MULTIPLIERS[level];
+  const headingFontSize = baseFontSize * sizeMultiplier;
+  const segments = block.lines[0]?.segments ?? [];
+  const plainText = segments.map((s) => s.content).join('');
+  const lines = splitTextToSize({
+    value: plainText,
+    characterSpacing,
+    fontSize: headingFontSize,
+    fontKitFont,
+    boxWidthInPt: width,
+  });
+  return lines.length;
+};
+
+const countCodeLines = (block: TextBlock): number => {
+  const content = block.lines[0]?.segments[0]?.content ?? '';
+  return content.split('\n').filter((l) => l !== '').length;
+};
+
+const countBlockquoteLines = (
+  block: TextBlock,
+  fontKitFont: FontKitFont,
+  baseFontSize: number,
+  characterSpacing: number,
+  width: number,
+): number => {
+  const segments = block.lines[0]?.segments ?? [];
+  const plainText = segments.map((s) => s.content).join('');
+  const lines = splitTextToSize({
+    value: plainText,
+    characterSpacing,
+    fontSize: baseFontSize,
+    fontKitFont,
+    boxWidthInPt: width - BLOCKQUOTE_PADDING_LEFT,
+  });
+  return lines.length;
+};
+
+const countParagraphLines = (
+  block: TextBlock,
+  fontKitFont: FontKitFont,
+  baseFontSize: number,
+  characterSpacing: number,
+  width: number,
+): number => {
+  const rawText = block.rawText;
+  const segments = block.lines[0]?.segments ?? [];
+  const plainText = segments.map((s) => s.content).join('');
+  // splitSegmentsIntoLinesと同じロジックで行数をカウント
+  const segmentsByLine = splitSegmentsIntoLines(
+    rawText ?? plainText,
+    fontKitFont,
+    baseFontSize,
+    characterSpacing,
+    width,
+  );
+  return segmentsByLine.length;
+};
+
+const countTableLines = (block: TextBlock): number => {
+  const tableData = block.tableData;
+  if (!tableData) return 0;
+  return 1 + tableData.rows.length;
+};
+
+const countListLines = (block: TextBlock): number => {
+  const listItems = block.listItems;
+  if (!listItems) return 0;
+  return listItems.length;
+};
+
+const renderHeading = (params: {
+  block: TextBlock;
+  currentY: number;
+  globalLineIndex: number;
+  shouldRenderLine: (index: number) => boolean;
+  isBeyondRange: (index: number) => boolean;
+  baseFontSize: number;
+  fontKitFont: FontKitFont;
+  pdfFontValue: PDFFont;
+  characterSpacing: number;
+  lineHeight: number;
+  width: number;
+  x: number;
+  color: ReturnType<typeof hex2PrintingColor>;
+  page: PDFRenderProps<TextSchema>['page'];
+  rotate: Rotation;
+  pivotPoint: { x: number; y: number };
+  opacity: number | undefined;
+  alignment: string;
+}): number => {
+  const {
+    block,
+    currentY: initialY,
+    globalLineIndex: startLineIndex,
+    shouldRenderLine,
+    isBeyondRange,
+    baseFontSize,
+    fontKitFont,
+    pdfFontValue,
+    characterSpacing,
+    lineHeight,
+    width,
+    x,
+    color,
+    page,
+    rotate,
+    pivotPoint,
+    opacity,
+    alignment,
+  } = params;
+
+  if (isBeyondRange(startLineIndex)) return initialY;
+
+  let currentY = initialY;
+  let lineIndex = startLineIndex;
+
+  const level = block.level ?? 1;
+  const sizeMultiplier = HEADING_SIZE_MULTIPLIERS[level];
+  const headingFontSize = baseFontSize * sizeMultiplier;
+
+  const segments = block.lines[0]?.segments ?? [];
+  const plainText = segments.map((s) => s.content).join('');
+
+  const lines = splitTextToSize({
+    value: plainText,
+    characterSpacing,
+    fontSize: headingFontSize,
+    fontKitFont,
+    boxWidthInPt: width,
+  });
+
+  for (let i = 0; i < lines.length; i++) {
+    const currentLineIndex = lineIndex;
+    lineIndex++;
+
+    if (!shouldRenderLine(currentLineIndex)) {
+      continue;
+    }
+
+    const line = lines[i].replace('\n', '');
+    if (!line) continue;
+
+    const lineSegments = i === 0 ? segments : [{ content: line }];
+    const lineTextWidth = widthOfTextAtSize(line, fontKitFont, headingFontSize, characterSpacing);
+
+    let xLine = x;
+    if (alignment === 'center') {
+      xLine += (width - lineTextWidth) / 2;
+    } else if (alignment === 'right') {
+      xLine += width - lineTextWidth;
+    }
+
+    let finalX = xLine;
+    let finalY = currentY;
+    if (rotate.angle !== 0) {
+      const rotatedPoint = rotatePoint({ x: xLine, y: currentY }, pivotPoint, rotate.angle);
+      finalX = rotatedPoint.x;
+      finalY = rotatedPoint.y;
+    }
+
+    for (const segment of lineSegments) {
+      if (!segment.content) continue;
+      const segmentWidth = widthOfTextAtSize(segment.content, fontKitFont, headingFontSize, characterSpacing);
+
+      let segmentColor = color;
+      if (segment.color) {
+        const colorRgb = hexToRgb(segment.color);
+        if (colorRgb) {
+          segmentColor = rgb(colorRgb.r, colorRgb.g, colorRgb.b);
+        }
+      }
+
+      page.drawText(segment.content, {
+        x: finalX,
+        y: finalY,
+        rotate,
+        size: headingFontSize,
+        color: segmentColor,
+        lineHeight: lineHeight * headingFontSize,
+        font: pdfFontValue,
+        opacity,
+      });
+
+      const strokeWidth = headingFontSize * BOLD_STROKE_WIDTH_RATIO;
+      page.drawText(segment.content, {
+        x: finalX + strokeWidth * 0.5,
+        y: finalY,
+        rotate,
+        size: headingFontSize,
+        color: segmentColor,
+        lineHeight: lineHeight * headingFontSize,
+        font: pdfFontValue,
+        opacity,
+      });
+
+      finalX += segmentWidth + characterSpacing;
+    }
+
+    currentY -= lineHeight * headingFontSize;
+  }
+
+  if (shouldRenderLine(lineIndex)) {
+    currentY -= baseFontSize * 0.3;
+  }
+
+  return currentY;
+};
+
+const renderCodeBlock = (params: {
+  block: TextBlock;
+  currentY: number;
+  globalLineIndex: number;
+  shouldRenderLine: (index: number) => boolean;
+  isBeyondRange: (index: number) => boolean;
+  baseFontSize: number;
+  fontKitFont: FontKitFont;
+  pdfFontValue: PDFFont;
+  characterSpacing: number;
+  lineHeight: number;
+  width: number;
+  x: number;
+  color: ReturnType<typeof hex2PrintingColor>;
+  page: PDFRenderProps<TextSchema>['page'];
+  pdfLib: PDFRenderProps<TextSchema>['pdfLib'];
+  rotate: Rotation;
+  pivotPoint: { x: number; y: number };
+  opacity: number | undefined;
+}): number => {
+  const {
+    block,
+    currentY: initialY,
+    globalLineIndex: startLineIndex,
+    shouldRenderLine,
+    isBeyondRange,
+    baseFontSize,
+    fontKitFont,
+    pdfFontValue,
+    characterSpacing,
+    lineHeight,
+    width,
+    x,
+    color,
+    page,
+    pdfLib,
+    rotate,
+    pivotPoint,
+    opacity,
+  } = params;
+
+  if (isBeyondRange(startLineIndex)) return initialY;
+
+  let currentY = initialY;
+  let lineIndex = startLineIndex;
+
+  const codeFontSize = baseFontSize * CODE_FONT_SIZE_RATIO;
+  const codeTextHeight = heightOfFontAtSize(fontKitFont, codeFontSize);
+  const content = block.lines[0]?.segments[0]?.content ?? '';
+  const codeLines = content.split('\n').filter((l) => l !== '');
+
+  const linesToRender: { index: number; line: string; isFirst: boolean }[] = [];
+  for (let i = 0; i < codeLines.length; i++) {
+    const currentLineIndex = lineIndex;
+    lineIndex++;
+    if (shouldRenderLine(currentLineIndex)) {
+      linesToRender.push({ index: currentLineIndex, line: codeLines[i], isFirst: i === 0 });
+    }
+  }
+
+  if (linesToRender.length > 0) {
+    const bgRgb = hexToRgb(CODE_BG_COLOR);
+    if (bgRgb) {
+      const bgColor = rgb(bgRgb.r, bgRgb.g, bgRgb.b);
+      const bgHeight = linesToRender.length * lineHeight * codeFontSize + (linesToRender[0].isFirst ? 5 : 0) + 5;
+      const bgY = currentY - bgHeight + codeTextHeight;
+      if (rotate.angle !== 0) {
+        const rotatedBgPoint = rotatePoint({ x, y: bgY }, pivotPoint, rotate.angle);
+        page.drawRectangle({
+          x: rotatedBgPoint.x,
+          y: rotatedBgPoint.y,
+          width,
+          height: bgHeight,
+          color: bgColor,
+          rotate,
+          opacity,
+        });
+      } else {
+        page.drawRectangle({
+          x,
+          y: bgY,
+          width,
+          height: bgHeight,
+          color: bgColor,
+          opacity,
+        });
+      }
+    }
+  }
+
+  const codePadding = 5;
+  for (const renderLine of linesToRender) {
+    const codeLine = renderLine.line;
+    if (!codeLine) continue;
+
+    let finalX = x + codePadding;
+    let finalY = currentY;
+    if (rotate.angle !== 0) {
+      const rotatedPoint = rotatePoint({ x: finalX, y: currentY }, pivotPoint, rotate.angle);
+      finalX = rotatedPoint.x;
+      finalY = rotatedPoint.y;
+    }
+
+    page.pushOperators(pdfLib.setCharacterSpacing(characterSpacing));
+    page.drawText(codeLine, {
+      x: finalX,
+      y: finalY,
+      rotate,
+      size: codeFontSize,
+      color,
+      lineHeight: lineHeight * codeFontSize,
+      font: pdfFontValue,
+      opacity,
+    });
+
+    currentY -= lineHeight * codeFontSize;
+  }
+
+  if (shouldRenderLine(lineIndex)) {
+    currentY -= baseFontSize * 1.0;
+  }
+
+  return currentY;
+};
+
+const renderBlockquote = (params: {
+  block: TextBlock;
+  currentY: number;
+  globalLineIndex: number;
+  shouldRenderLine: (index: number) => boolean;
+  isBeyondRange: (index: number) => boolean;
+  baseFontSize: number;
+  fontKitFont: FontKitFont;
+  pdfFontValue: PDFFont;
+  characterSpacing: number;
+  lineHeight: number;
+  width: number;
+  x: number;
+  color: ReturnType<typeof hex2PrintingColor>;
+  page: PDFRenderProps<TextSchema>['page'];
+  pdfLib: PDFRenderProps<TextSchema>['pdfLib'];
+  rotate: Rotation;
+  pivotPoint: { x: number; y: number };
+  opacity: number | undefined;
+}): number => {
+  const {
+    block,
+    currentY: initialY,
+    globalLineIndex: startLineIndex,
+    shouldRenderLine,
+    isBeyondRange,
+    baseFontSize,
+    fontKitFont,
+    pdfFontValue,
+    characterSpacing,
+    lineHeight,
+    width,
+    x,
+    page,
+    pdfLib,
+    rotate,
+    pivotPoint,
+    opacity,
+  } = params;
+
+  if (isBeyondRange(startLineIndex)) return initialY;
+
+  let currentY = initialY;
+  let lineIndex = startLineIndex;
+
+  const segments = block.lines[0]?.segments ?? [];
+  const plainText = segments.map((s) => s.content).join('');
+
+  const lines = splitTextToSize({
+    value: plainText,
+    characterSpacing,
+    fontSize: baseFontSize,
+    fontKitFont,
+    boxWidthInPt: width - BLOCKQUOTE_PADDING_LEFT,
+  });
+
+  const linesToRender: { index: number; line: string }[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const currentLineIndex = lineIndex;
+    lineIndex++;
+    if (shouldRenderLine(currentLineIndex)) {
+      linesToRender.push({ index: currentLineIndex, line: lines[i] });
+    }
+  }
+
+  if (linesToRender.length > 0) {
+    const borderRgb = hexToRgb(BLOCKQUOTE_BORDER_COLOR);
+    if (borderRgb) {
+      const borderColor = rgb(borderRgb.r, borderRgb.g, borderRgb.b);
+      const quoteBlockHeight = linesToRender.length * lineHeight * baseFontSize;
+      const borderStartY = currentY;
+      const borderEndY = borderStartY - quoteBlockHeight + heightOfFontAtSize(fontKitFont, baseFontSize);
+
+      if (rotate.angle !== 0) {
+        const startPoint = rotatePoint({ x, y: borderStartY }, pivotPoint, rotate.angle);
+        const endPoint = rotatePoint({ x, y: borderEndY }, pivotPoint, rotate.angle);
+        page.drawLine({
+          start: startPoint,
+          end: endPoint,
+          thickness: BLOCKQUOTE_BORDER_WIDTH,
+          color: borderColor,
+          opacity,
+        });
+      } else {
+        page.drawLine({
+          start: { x, y: borderStartY },
+          end: { x, y: borderEndY },
+          thickness: BLOCKQUOTE_BORDER_WIDTH,
+          color: borderColor,
+          opacity,
+        });
+      }
+    }
+  }
+
+  const quoteColorRgb = hexToRgb(BLOCKQUOTE_TEXT_COLOR);
+  const quoteColor = quoteColorRgb ? rgb(quoteColorRgb.r, quoteColorRgb.g, quoteColorRgb.b) : undefined;
+
+  for (const renderLine of linesToRender) {
+    const line = renderLine.line.replace('\n', '');
+    if (!line) continue;
+
+    let finalX = x + BLOCKQUOTE_PADDING_LEFT;
+    let finalY = currentY;
+    if (rotate.angle !== 0) {
+      const rotatedPoint = rotatePoint({ x: finalX, y: currentY }, pivotPoint, rotate.angle);
+      finalX = rotatedPoint.x;
+      finalY = rotatedPoint.y;
+    }
+
+    page.pushOperators(pdfLib.setCharacterSpacing(characterSpacing));
+    page.drawText(line, {
+      x: finalX,
+      y: finalY,
+      rotate,
+      size: baseFontSize,
+      color: quoteColor,
+      lineHeight: lineHeight * baseFontSize,
+      font: pdfFontValue,
+      opacity,
+    });
+
+    currentY -= lineHeight * baseFontSize;
+  }
+
+  if (shouldRenderLine(lineIndex)) {
+    currentY -= baseFontSize * 0.3;
+  }
+
+  return currentY;
+};
+
+const renderParagraph = (params: {
+  block: TextBlock;
+  currentY: number;
+  globalLineIndex: number;
+  shouldRenderLine: (index: number) => boolean;
+  isBeyondRange: (index: number) => boolean;
+  baseFontSize: number;
+  fontKitFont: FontKitFont;
+  pdfFontValue: PDFFont;
+  characterSpacing: number;
+  lineHeight: number;
+  width: number;
+  x: number;
+  color: ReturnType<typeof hex2PrintingColor>;
+  page: PDFRenderProps<TextSchema>['page'];
+  pdfLib: PDFRenderProps<TextSchema>['pdfLib'];
+  rotate: Rotation;
+  pivotPoint: { x: number; y: number };
+  opacity: number | undefined;
+  alignment: string;
+  segmenter: Intl.Segmenter;
+}): number => {
+  const {
+    block,
+    currentY: initialY,
+    globalLineIndex: startLineIndex,
+    shouldRenderLine,
+    isBeyondRange,
+    baseFontSize,
+    fontKitFont,
+    pdfFontValue,
+    characterSpacing,
+    lineHeight,
+    width,
+    x,
+    color,
+    page,
+    pdfLib,
+    rotate,
+    pivotPoint,
+    opacity,
+    alignment,
+    segmenter,
+  } = params;
+
+  if (isBeyondRange(startLineIndex)) return initialY;
+
+  let currentY = initialY;
+  let lineIndex = startLineIndex;
+
+  const textHeight = heightOfFontAtSize(fontKitFont, baseFontSize);
+  const rawText = block.rawText;
+  const segments = block.lines[0]?.segments ?? [];
+  const plainText = segments.map((s) => s.content).join('');
+
+  const segmentsByLine = splitSegmentsIntoLines(
+    rawText ?? plainText,
+    fontKitFont,
+    baseFontSize,
+    characterSpacing,
+    width,
+  );
+
+  const linesToRender: { index: number; lineSegments: TextSegment[]; originalIndex: number }[] = [];
+  for (let i = 0; i < segmentsByLine.length; i++) {
+    const currentLineIndex = lineIndex;
+    lineIndex++;
+    if (shouldRenderLine(currentLineIndex)) {
+      linesToRender.push({ index: currentLineIndex, lineSegments: segmentsByLine[i], originalIndex: i });
+    }
+  }
+
+  for (const renderLine of linesToRender) {
+    const lineSegments = renderLine.lineSegments;
+    if (lineSegments.length === 0) continue;
+
+    const lineTextForWidth = lineSegments.map((s) => s.content).join('');
+    if (!lineTextForWidth) continue;
+
+    const lineTextWidth = widthOfTextAtSize(lineTextForWidth, fontKitFont, baseFontSize, characterSpacing);
+
+    let xLine = x;
+    if (alignment === 'center') {
+      xLine += (width - lineTextWidth) / 2;
+    } else if (alignment === 'right') {
+      xLine += width - lineTextWidth;
+    }
+
+    let finalX = xLine;
+    let finalY = currentY;
+    if (rotate.angle !== 0) {
+      const rotatedPoint = rotatePoint({ x: xLine, y: currentY }, pivotPoint, rotate.angle);
+      finalX = rotatedPoint.x;
+      finalY = rotatedPoint.y;
+    }
+
+    let spacing = characterSpacing;
+    const isLastLine = renderLine.originalIndex === segmentsByLine.length - 1;
+    if (alignment === 'justify' && !isLastLine) {
+      const iterator = segmenter.segment(lineTextForWidth)[Symbol.iterator]();
+      const len = Array.from(iterator).length;
+      if (len > 1) {
+        spacing += (width - lineTextWidth) / (len - 1);
+      }
+    }
+    page.pushOperators(pdfLib.setCharacterSpacing(spacing));
+
+    drawSegments({
+      segments: lineSegments,
+      xStart: finalX,
+      yLine: finalY,
+      fontSize: baseFontSize,
+      textHeight,
+      fontKitFont,
+      characterSpacing: spacing,
+      lineHeight,
+      color,
+      pdfFontValue,
+      page,
+      rotate,
+      pivotPoint,
+      opacity,
+    });
+
+    currentY -= lineHeight * baseFontSize;
+  }
+
+  if (shouldRenderLine(lineIndex)) {
+    currentY -= baseFontSize * 0.3;
+  }
+
+  return currentY;
+};
+
+const renderTable = (params: {
+  block: TextBlock;
+  currentY: number;
+  globalLineIndex: number;
+  shouldRenderLine: (index: number) => boolean;
+  isBeyondRange: (index: number) => boolean;
+  baseFontSize: number;
+  fontKitFont: FontKitFont;
+  pdfFontValue: PDFFont;
+  characterSpacing: number;
+  lineHeight: number;
+  width: number;
+  x: number;
+  color: ReturnType<typeof hex2PrintingColor>;
+  page: PDFRenderProps<TextSchema>['page'];
+  pdfLib: PDFRenderProps<TextSchema>['pdfLib'];
+  rotate: Rotation;
+  pivotPoint: { x: number; y: number };
+  opacity: number | undefined;
+}): number => {
+  const {
+    block,
+    currentY: initialY,
+    globalLineIndex: startLineIndex,
+    shouldRenderLine,
+    isBeyondRange,
+    baseFontSize,
+    fontKitFont,
+    pdfFontValue,
+    characterSpacing,
+    lineHeight,
+    width,
+    x,
+    color,
+    page,
+    pdfLib,
+    rotate,
+    pivotPoint,
+    opacity,
+  } = params;
+
+  if (isBeyondRange(startLineIndex)) return initialY;
+
+  const tableData = block.tableData;
+  if (!tableData) return initialY;
+
+  let currentY = initialY;
+  let lineIndex = startLineIndex;
+
+  const { headers, rows } = tableData;
+  const columnCount = headers.length;
+  if (columnCount === 0) return initialY;
+
+  const availableWidth = width - TABLE_CELL_PADDING * 2;
+  const cellWidth = availableWidth / columnCount;
+  const rowHeight = lineHeight * baseFontSize + TABLE_CELL_PADDING * 2;
+  const textHeight = heightOfFontAtSize(fontKitFont, baseFontSize);
+
+  const borderRgb = hexToRgb(TABLE_BORDER_COLOR);
+  const borderColor = borderRgb ? rgb(borderRgb.r, borderRgb.g, borderRgb.b) : color;
+
+  const headerBgRgb = hexToRgb(TABLE_HEADER_BG_COLOR);
+  const headerBgColor = headerBgRgb ? rgb(headerBgRgb.r, headerBgRgb.g, headerBgRgb.b) : undefined;
+
+  if (shouldRenderLine(lineIndex)) {
+    const headerY = currentY;
+
+    if (headerBgColor) {
+      if (rotate.angle !== 0) {
+        const rotatedBgPoint = rotatePoint({ x, y: headerY - rowHeight + textHeight }, pivotPoint, rotate.angle);
+        page.drawRectangle({
+          x: rotatedBgPoint.x,
+          y: rotatedBgPoint.y,
+          width: availableWidth,
+          height: rowHeight,
+          color: headerBgColor,
+          rotate,
+          opacity,
+        });
+      } else {
+        page.drawRectangle({
+          x,
+          y: headerY - rowHeight + textHeight,
+          width: availableWidth,
+          height: rowHeight,
+          color: headerBgColor,
+          opacity,
+        });
+      }
+    }
+
+    for (let col = 0; col < columnCount; col++) {
+      const cellX = x + col * cellWidth + TABLE_CELL_PADDING;
+      const cellText = headers[col] || '';
+
+      let finalX = cellX;
+      let finalY = headerY;
+      if (rotate.angle !== 0) {
+        const rotatedPoint = rotatePoint({ x: cellX, y: headerY }, pivotPoint, rotate.angle);
+        finalX = rotatedPoint.x;
+        finalY = rotatedPoint.y;
+      }
+
+      page.pushOperators(pdfLib.setCharacterSpacing(characterSpacing));
+      page.drawText(cellText, {
+        x: finalX,
+        y: finalY,
+        rotate,
+        size: baseFontSize,
+        color,
+        font: pdfFontValue,
+        opacity,
+      });
+
+      const strokeWidth = baseFontSize * BOLD_STROKE_WIDTH_RATIO;
+      page.drawText(cellText, {
+        x: finalX + strokeWidth * 0.5,
+        y: finalY,
+        rotate,
+        size: baseFontSize,
+        color,
+        font: pdfFontValue,
+        opacity,
+      });
+    }
+
+    const lineY = headerY - rowHeight + textHeight;
+    if (rotate.angle !== 0) {
+      const startPoint = rotatePoint({ x, y: lineY }, pivotPoint, rotate.angle);
+      const endPoint = rotatePoint({ x: x + availableWidth, y: lineY }, pivotPoint, rotate.angle);
+      page.drawLine({
+        start: startPoint,
+        end: endPoint,
+        thickness: TABLE_BORDER_WIDTH,
+        color: borderColor,
+        opacity,
+      });
+    } else {
+      page.drawLine({
+        start: { x, y: lineY },
+        end: { x: x + availableWidth, y: lineY },
+        thickness: TABLE_BORDER_WIDTH,
+        color: borderColor,
+        opacity,
+      });
+    }
+
+    currentY -= rowHeight;
+  }
+  lineIndex++;
+
+  for (let rowIdx = 0; rowIdx < rows.length; rowIdx++) {
+    if (!shouldRenderLine(lineIndex)) {
+      lineIndex++;
+      continue;
+    }
+
+    const row = rows[rowIdx];
+    const rowY = currentY;
+
+    for (let col = 0; col < columnCount; col++) {
+      const cellX = x + col * cellWidth + TABLE_CELL_PADDING;
+      const cellText = row[col] || '';
+
+      const segments = parseInlineStyles(cellText);
+
+      let finalX = cellX;
+      let finalY = rowY;
+      if (rotate.angle !== 0) {
+        const rotatedPoint = rotatePoint({ x: cellX, y: rowY }, pivotPoint, rotate.angle);
+        finalX = rotatedPoint.x;
+        finalY = rotatedPoint.y;
+      }
+
+      page.pushOperators(pdfLib.setCharacterSpacing(characterSpacing));
+      drawSegments({
+        segments,
+        xStart: finalX,
+        yLine: finalY,
+        fontSize: baseFontSize,
+        textHeight,
+        fontKitFont,
+        characterSpacing,
+        lineHeight,
+        color,
+        pdfFontValue,
+        page,
+        rotate,
+        pivotPoint,
+        opacity,
+      });
+    }
+
+    const lineY = rowY - rowHeight + textHeight;
+    if (rotate.angle !== 0) {
+      const startPoint = rotatePoint({ x, y: lineY }, pivotPoint, rotate.angle);
+      const endPoint = rotatePoint({ x: x + availableWidth, y: lineY }, pivotPoint, rotate.angle);
+      page.drawLine({
+        start: startPoint,
+        end: endPoint,
+        thickness: TABLE_BORDER_WIDTH,
+        color: borderColor,
+        opacity,
+      });
+    } else {
+      page.drawLine({
+        start: { x, y: lineY },
+        end: { x: x + availableWidth, y: lineY },
+        thickness: TABLE_BORDER_WIDTH,
+        color: borderColor,
+        opacity,
+      });
+    }
+
+    currentY -= rowHeight;
+    lineIndex++;
+  }
+
+  if (shouldRenderLine(lineIndex)) {
+    currentY -= baseFontSize * 0.5;
+  }
+
+  return currentY;
+};
+
+const renderList = (params: {
+  block: TextBlock;
+  currentY: number;
+  globalLineIndex: number;
+  shouldRenderLine: (index: number) => boolean;
+  isBeyondRange: (index: number) => boolean;
+  baseFontSize: number;
+  fontKitFont: FontKitFont;
+  pdfFontValue: PDFFont;
+  characterSpacing: number;
+  lineHeight: number;
+  width: number;
+  x: number;
+  color: ReturnType<typeof hex2PrintingColor>;
+  page: PDFRenderProps<TextSchema>['page'];
+  pdfLib: PDFRenderProps<TextSchema>['pdfLib'];
+  rotate: Rotation;
+  pivotPoint: { x: number; y: number };
+  opacity: number | undefined;
+}): number => {
+  const {
+    block,
+    currentY: initialY,
+    globalLineIndex: startLineIndex,
+    shouldRenderLine,
+    isBeyondRange,
+    baseFontSize,
+    fontKitFont,
+    pdfFontValue,
+    characterSpacing,
+    lineHeight,
+    width,
+    x,
+    color,
+    page,
+    pdfLib,
+    rotate,
+    pivotPoint,
+    opacity,
+  } = params;
+
+  if (isBeyondRange(startLineIndex)) return initialY;
+
+  const listItems = block.listItems;
+  if (!listItems || listItems.length === 0) return initialY;
+
+  let currentY = initialY;
+  let lineIndex = startLineIndex;
+
+  const textHeight = heightOfFontAtSize(fontKitFont, baseFontSize);
+
+  for (const item of listItems) {
+    if (!shouldRenderLine(lineIndex)) {
+      lineIndex++;
+      continue;
+    }
+
+    const indent = item.level * LIST_INDENT_PER_LEVEL;
+    const markerX = x + indent;
+    const textX = markerX + LIST_MARKER_WIDTH;
+
+    let marker: string;
+    if (item.ordered) {
+      marker = `${item.orderNumber ?? 1}.`;
+    } else {
+      marker = LIST_BULLET_CHAR;
+    }
+
+    let finalMarkerX = markerX;
+    let finalY = currentY;
+    if (rotate.angle !== 0) {
+      const rotatedPoint = rotatePoint({ x: markerX, y: currentY }, pivotPoint, rotate.angle);
+      finalMarkerX = rotatedPoint.x;
+      finalY = rotatedPoint.y;
+    }
+
+    page.pushOperators(pdfLib.setCharacterSpacing(characterSpacing));
+    page.drawText(marker, {
+      x: finalMarkerX,
+      y: finalY,
+      rotate,
+      size: baseFontSize,
+      color,
+      font: pdfFontValue,
+      opacity,
+    });
+
+    let finalTextX = textX;
+    let finalTextY = currentY;
+    if (rotate.angle !== 0) {
+      const rotatedPoint = rotatePoint({ x: textX, y: currentY }, pivotPoint, rotate.angle);
+      finalTextX = rotatedPoint.x;
+      finalTextY = rotatedPoint.y;
+    }
+
+    drawSegments({
+      segments: item.segments,
+      xStart: finalTextX,
+      yLine: finalTextY,
+      fontSize: baseFontSize,
+      textHeight,
+      fontKitFont,
+      characterSpacing,
+      lineHeight,
+      color,
+      pdfFontValue,
+      page,
+      rotate,
+      pivotPoint,
+      opacity,
+    });
+
+    currentY -= lineHeight * baseFontSize + LIST_ITEM_SPACING;
+    lineIndex++;
+  }
+
+  if (shouldRenderLine(lineIndex)) {
+    currentY -= baseFontSize * 0.3;
+  }
+
+  return currentY;
+};

--- a/packages/schemas/src/text/richText/pdfRender.ts
+++ b/packages/schemas/src/text/richText/pdfRender.ts
@@ -232,8 +232,19 @@ export const renderRichTextBlocks = (params: RenderRichTextParams) => {
   } = params;
 
   let currentY = pageHeight - schemaPositionY;
-  const firstLineTextHeight = heightOfFontAtSize(fontKitFont, baseFontSize);
-  const halfLineHeightAdjustment = lineHeight === 0 ? 0 : ((lineHeight - 1) * baseFontSize) / 2;
+
+  // Determine the actual font size for the first block (headings use different size)
+  let firstBlockFontSize = baseFontSize;
+  if (blocks.length > 0 && blocks[0].type === 'heading') {
+    const level = blocks[0].level ?? 1;
+    const sizeMultiplier = HEADING_SIZE_MULTIPLIERS[level];
+    firstBlockFontSize = baseFontSize * sizeMultiplier;
+  } else if (blocks.length > 0 && blocks[0].type === 'code') {
+    firstBlockFontSize = baseFontSize * CODE_FONT_SIZE_RATIO;
+  }
+
+  const firstLineTextHeight = heightOfFontAtSize(fontKitFont, firstBlockFontSize);
+  const halfLineHeightAdjustment = lineHeight === 0 ? 0 : ((lineHeight - 1) * firstBlockFontSize) / 2;
 
   if (verticalAlignment === 'top') {
     currentY -= firstLineTextHeight + halfLineHeightAdjustment;
@@ -569,7 +580,6 @@ const countParagraphLines = (
   const rawText = block.rawText;
   const segments = block.lines[0]?.segments ?? [];
   const plainText = segments.map((s) => s.content).join('');
-  // splitSegmentsIntoLinesと同じロジックで行数をカウント
   const segmentsByLine = splitSegmentsIntoLines(
     rawText ?? plainText,
     fontKitFont,

--- a/packages/schemas/src/text/richText/uiRender.ts
+++ b/packages/schemas/src/text/richText/uiRender.ts
@@ -1,0 +1,143 @@
+import type { TextSchema, TextSegment } from '../types.js';
+import { parseRichText, HEADING_SIZE_MULTIPLIERS } from './index.js';
+import {
+  CODE_BG_COLOR,
+  CODE_BORDER_COLOR,
+  CODE_FONT_SIZE_RATIO,
+  BLOCKQUOTE_BORDER_COLOR,
+  BLOCKQUOTE_TEXT_COLOR,
+  BOLD_STROKE_WIDTH_CSS,
+  TABLE_BORDER_COLOR,
+  TABLE_HEADER_BG_COLOR,
+  TABLE_CELL_PADDING,
+  LIST_INDENT_PER_LEVEL,
+  LIST_BULLET_CHAR,
+} from './constants.js';
+
+const escapeHtml = (text: string): string => {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+};
+
+export const segmentToHtml = (segment: TextSegment, schema: TextSchema): string => {
+  const styles: string[] = [];
+
+  if (segment.bold) {
+    styles.push(`-webkit-text-stroke: ${BOLD_STROKE_WIDTH_CSS} currentColor`);
+    styles.push(`text-stroke: ${BOLD_STROKE_WIDTH_CSS} currentColor`);
+  }
+
+  if (segment.italic) {
+    styles.push('font-style: italic');
+  }
+
+  if (segment.code) {
+    styles.push(`background-color: ${CODE_BG_COLOR}`);
+    styles.push(`border: 1px solid ${CODE_BORDER_COLOR}`);
+    styles.push('border-radius: 6px');
+    styles.push('padding: 0.2em 0.4em');
+    styles.push(`font-size: ${CODE_FONT_SIZE_RATIO}em`);
+    styles.push('font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace');
+  }
+
+  if (segment.color) {
+    styles.push(`color: ${segment.color}`);
+  }
+
+  if (segment.backgroundColor && !segment.code) {
+    styles.push(`background-color: ${segment.backgroundColor}`);
+    styles.push('padding: 0 2px');
+    styles.push('border-radius: 2px');
+  }
+
+  const styleAttr = styles.length > 0 ? ` style="${styles.join('; ')}"` : '';
+  const escapedContent = escapeHtml(segment.content);
+
+  return `<span${styleAttr}>${escapedContent}</span>`;
+};
+
+export const richTextToHtml = (text: string, schema: TextSchema): string => {
+  const blocks = parseRichText(text);
+  const baseFontSize = schema.fontSize ?? 13;
+
+  return blocks.map((block) => {
+    switch (block.type) {
+      case 'heading': {
+        const level = block.level ?? 1;
+        const sizeMultiplier = HEADING_SIZE_MULTIPLIERS[level];
+        const fontSize = baseFontSize * sizeMultiplier;
+        const segments = block.lines[0]?.segments ?? [];
+        const content = segments.map((seg) => segmentToHtml(seg, schema)).join('');
+        return `<div style="font-size: ${fontSize}pt; -webkit-text-stroke: ${BOLD_STROKE_WIDTH_CSS} currentColor; text-stroke: ${BOLD_STROKE_WIDTH_CSS} currentColor; margin-bottom: 0.3em;">${content}</div>`;
+      }
+
+      case 'code': {
+        const content = block.lines[0]?.segments[0]?.content ?? '';
+        const escapedContent = escapeHtml(content).replace(/\n/g, '<br>');
+        return `<div style="background-color: ${CODE_BG_COLOR}; border: 1px solid ${CODE_BORDER_COLOR}; border-radius: 6px; padding: 0.5em 1em; font-size: ${baseFontSize * CODE_FONT_SIZE_RATIO}pt; font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace; white-space: pre-wrap; margin: 0.5em 0;">${escapedContent}</div>`;
+      }
+
+      case 'blockquote': {
+        const segments = block.lines[0]?.segments ?? [];
+        const content = segments.map((seg) => segmentToHtml(seg, schema)).join('');
+        return `<div style="border-left: 3px solid ${BLOCKQUOTE_BORDER_COLOR}; padding-left: 1em; color: ${BLOCKQUOTE_TEXT_COLOR}; margin: 0.5em 0;">${content}</div>`;
+      }
+
+      case 'table': {
+        const tableData = block.tableData;
+        if (!tableData) return '';
+
+        const { headers, rows } = tableData;
+        const cellStyle = `padding: ${TABLE_CELL_PADDING}px; border: 1px solid ${TABLE_BORDER_COLOR}; text-align: left;`;
+        const headerCellStyle = `${cellStyle} background-color: ${TABLE_HEADER_BG_COLOR}; -webkit-text-stroke: ${BOLD_STROKE_WIDTH_CSS} currentColor;`;
+
+        const headerRow = headers
+          .map((header) => `<th style="${headerCellStyle}">${escapeHtml(header)}</th>`)
+          .join('');
+
+        const dataRows = rows
+          .map((row) => {
+            const cells = row
+              .map((cell) => {
+                const parsed = parseRichText(cell);
+                const segments = parsed[0]?.lines[0]?.segments ?? [{ content: cell }];
+                const cellContent = segments.map((seg) => segmentToHtml(seg, schema)).join('');
+                return `<td style="${cellStyle}">${cellContent}</td>`;
+              })
+              .join('');
+            return `<tr>${cells}</tr>`;
+          })
+          .join('');
+
+        return `<table style="border-collapse: collapse; width: 100%; margin: 0.5em 0;"><thead><tr>${headerRow}</tr></thead><tbody>${dataRows}</tbody></table>`;
+      }
+
+      case 'list': {
+        const listItems = block.listItems;
+        if (!listItems || listItems.length === 0) return '';
+
+        const items = listItems
+          .map((item) => {
+            const indent = item.level * LIST_INDENT_PER_LEVEL;
+            const marker = item.ordered ? `${item.orderNumber ?? 1}.` : LIST_BULLET_CHAR;
+            const content = item.segments.map((seg) => segmentToHtml(seg, schema)).join('');
+            return `<div style="padding-left: ${indent}px; margin-bottom: 0.2em;"><span style="display: inline-block; width: 15px;">${marker}</span>${content}</div>`;
+          })
+          .join('');
+
+        return `<div style="margin: 0.5em 0;">${items}</div>`;
+      }
+
+      case 'paragraph':
+      default: {
+        const segments = block.lines[0]?.segments ?? [];
+        const content = segments.map((seg) => segmentToHtml(seg, schema)).join('');
+        return `<div style="margin-bottom: 0.3em;">${content}</div>`;
+      }
+    }
+  }).join('');
+};

--- a/packages/schemas/src/text/types.ts
+++ b/packages/schemas/src/text/types.ts
@@ -11,6 +11,45 @@ export type FontWidthCalcValues = {
   characterSpacing: number;
   boxWidthInPt: number;
 };
+
+export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
+
+export interface TextSegment {
+  content: string;
+  bold?: boolean;
+  italic?: boolean;
+  code?: boolean;
+  color?: string;
+  backgroundColor?: string;
+}
+
+export interface TextLine {
+  segments: TextSegment[];
+  heightInMm: number;
+}
+
+export interface ListItem {
+  level: number;
+  ordered: boolean;
+  orderNumber?: number;
+  segments: TextSegment[];
+}
+
+export interface TableData {
+  headers: string[];
+  rows: string[][];
+}
+
+export interface TextBlock {
+  type: 'paragraph' | 'heading' | 'code' | 'blockquote' | 'table' | 'list';
+  level?: HeadingLevel;
+  language?: string;
+  lines: TextLine[];
+  rawText?: string;
+  tableData?: TableData;
+  listItems?: ListItem[];
+}
+
 export interface TextSchema extends Schema {
   fontName?: string;
   alignment: ALIGNMENT;
@@ -27,4 +66,7 @@ export interface TextSchema extends Schema {
   };
   fontColor: string;
   backgroundColor: string;
+  richText?: boolean;
+  __lineRange?: { start: number; end: number };
+  __isSplit?: boolean;
 }


### PR DESCRIPTION
This PR adds **Rich Text (Markdown) support** to the Text Schema,
   enabling users to use Markdown syntax for text formatting in PDF
   generation.

   ## Features Implemented ✅

   ### Markdown Syntax Support
   The following Markdown elements are now supported:

   | Element | Syntax | Example |
   |---------|--------|---------|
   | **Headings** | `# H1` to `###### H6` | `# Title` |
   | **Bold** | `**text**` or `__text__` | `**important**` |
   | **Italic** | `*text*` or `_text_` | `*emphasis*` |
   | **Inline Code** | `` `code` `` | `` `variable` `` |
   | **Code Block** | ` ``` code ``` ` | Multi-line code |
   | **Blockquote** | `> quote` | `> Note:` |
   | **Unordered List** | `- item` or `* item` | `- First item` |
   | **Ordered List** | `1. item` | `1. First step` |
   | **Tables** | `\| col1 \| col2 \|` | GFM-style tables |
   | **Text Color** | `{#FF0000}red text{/}` | Custom syntax |
   | **Background Color** | `{bg:#FFFF00}highlighted{/bg}` | Custom
   syntax |

   ### Architecture
   - **Parser** (`richText/parser.ts`): Tokenizes and parses Markdown
   into structured `TextBlock` and `TextSegment` objects
   - **PDF Renderer** (`richText/pdfRender.ts`): Renders rich text blocks
    to PDF with proper styling
   - **UI Renderer** (`richText/uiRender.ts`): Renders rich text as HTML
   for Designer/Form preview
   - **Dynamic Template** (`text/dynamicTemplate.ts`): Calculates dynamic
    height for rich text with automatic page breaking

   ### Schema Property
   - Added `richText: boolean` property to TextSchema
   - Toggle available in the property panel to enable/disable rich text
   mode

   ## Needs Verification 🔍

   - [ ] **Heading overlap fix** - Initial Y-position calculation for
   headings (recently fixed)
   - [ ] **Multi-page rich text** - Page breaking behavior with mixed
   content (headings, tables, lists)
   - [ ] **Nested formatting** - Bold + italic combined (`***text***`)
   - [ ] **Long tables** - Tables spanning multiple pages
   - [ ] **RTL text support** - Right-to-left languages with rich text
   - [ ] **Font embedding** - Custom fonts with rich text rendering
   - [ ] **Performance** - Large documents with extensive Markdown
   content

   ## Example

- Enter a long string into Template(Invoice) / billedToInput

   markdown set
<img width="955" height="598" alt="test1" src="https://github.com/user-attachments/assets/28695625-4efa-44f0-a5e5-ab2924f2cd7c" />

<img width="264" height="678" alt="test2" src="https://github.com/user-attachments/assets/a7323699-fe0c-4b91-9a2d-709a1861318e" />


[Uploading df9188ba-acc6-4a01-bcad-44706046a76a.pdf…]()

   