### PR TITLE
fix(schemas): preserve font weight in Designer read-only text

### DIFF
--- a/packages/schemas/src/text/uiRender.ts
+++ b/packages/schemas/src/text/uiRender.ts
@@ -81,7 +81,7 @@ export const uiRender = async (arg: UIRenderProps<TextSchema>) => {
   );
 
   const processedText = replaceUnsupportedChars(value, fontKitFont);
-  const resolvedFontName = fontKitFont.postscriptName || schema.familyName;
+  const resolvedFontName = fontKitFont.postscriptName || schema.fontName;
   if (!isEditable(mode, schema)) {
     // Read-only mode
     textBlock.innerHTML = processedText

--- a/packages/schemas/src/text/uiRender.ts
+++ b/packages/schemas/src/text/uiRender.ts
@@ -81,16 +81,16 @@ export const uiRender = async (arg: UIRenderProps<TextSchema>) => {
   );
 
   const processedText = replaceUnsupportedChars(value, fontKitFont);
-
+  const resolvedFontName = fontKitFont.postscriptName || schema.familyName;
   if (!isEditable(mode, schema)) {
     // Read-only mode
     textBlock.innerHTML = processedText
       .split('')
       .map(
         (l, i) =>
-          `<span style="letter-spacing:${
-            String(value).length === i + 1 ? 0 : 'inherit'
-          };">${l}</span>`,
+          `<span style="
+        font-family:${resolvedFontName};
+        letter-spacing:${String(value).length === i + 1 ? 0 : 'inherit'};">${l}</span>`,
       )
       .join('');
     return;
@@ -214,7 +214,11 @@ export const buildStyledTextContainer = (
 
   const textBlockStyle: CSS.Properties = {
     // Font formatting styles
-    fontFamily: schema.fontName ? `'${schema.fontName}'` : 'inherit',
+    fontFamily: fontKitFont?.postscriptName
+      ? `'${fontKitFont.postscriptName}'`
+      : schema.fontName
+        ? `'${schema.fontName}'`
+        : 'inherit',
     color: schema.fontColor ? schema.fontColor : DEFAULT_FONT_COLOR,
     fontSize: `${dynamicFontSize ?? schema.fontSize ?? DEFAULT_FONT_SIZE}pt`,
     letterSpacing: `${schema.characterSpacing ?? DEFAULT_CHARACTER_SPACING}pt`,


### PR DESCRIPTION
### Problem
In the Designer, text rendered in read-only mode loses its font weight
after blur because characters are rendered as individual `<span>` elements
without explicitly setting the resolved font-family.

### Solution
Apply the resolved font-family (using postscriptName when available, otherwise schema.fontName)
 to each character span in read-only mode to ensure
consistent font rendering.

### Impact
- Fixes bold / font-weight mismatch in Designer
- No change to PDF output
- No breaking changes
- Scoped only to UI rendering
