### PR TITLE
fix(common): mark antd and form-render as optional peer dependencies in common

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12766,6 +12766,14 @@
       "peerDependencies": {
         "antd": "^5.11.2",
         "form-render": "^2.2.20"
+      },
+      "peerDependenciesMeta": {
+        "antd": {
+          "optional": true
+        },
+        "form-render": {
+          "optional": true
+        }
       }
     },
     "packages/converter": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -57,6 +57,14 @@
     "antd": "^5.11.2",
     "form-render": "^2.2.20"
   },
+  "peerDependenciesMeta": {
+    "antd": {
+      "optional": true
+    },
+    "form-render": {
+      "optional": true
+    }
+  },
   "jest": {
     "resolver": "ts-jest-resolver",
     "moduleFileExtensions": [


### PR DESCRIPTION
As suggested in https://github.com/pdfme/pdfme/issues/443, this pull request makes a small change to the `packages/common/package.json` file, marking `antd` and `form-render` as optional peer dependencies.

From https://github.com/pdfme/pdfme/issues/443#issuecomment-3427184466:

> The interfaces from antd and form-render have already been marked as optional in a previously merged PR (https://github.com/pdfme/pdfme/pull/477), so common is functional even if these packages aren’t installed.
> 
> However, the main issue remains: although both dependencies have already been moved from dependencies to peerDependencies, they are still automatically installed alongside the common package. This is because from npm v7 onwards, all peer dependencies are installed by default (see [docs](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#peerdependencies)).
> 
> Both dependencies can be marked as optional within the common package using peerDependenciesMeta.
> According to https://github.com/npm/rfcs/issues/221, optional peer dependencies are not installed automatically.

Both packages are still included in the ui package.json, so they are still installed during development and when using the ui package, but they are skipped when *only* common is needed (e.g. in NodeJS environments), preventing build issues.

Related issues: https://github.com/pdfme/pdfme/issues/474, https://github.com/pdfme/pdfme/issues/443