### PR TITLE
build(deps-dev): bump @types/node from 24 to 25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@humanwhocodes/config-array": "^0.13.0",
         "@types/jest": "^29.5.14",
         "@types/jest-image-snapshot": "^6.4.1",
-        "@types/node": "^24.3.0",
+        "@types/node": "^25.3.3",
         "@typescript-eslint/eslint-plugin": "^8.56.1",
         "@typescript-eslint/parser": "^8.32.0",
         "babel-loader": "^10.0.0",
@@ -3068,13 +3068,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.10.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.0.tgz",
-      "integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/pako": {
@@ -12673,9 +12673,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@humanwhocodes/config-array": "^0.13.0",
     "@types/jest": "^29.5.14",
     "@types/jest-image-snapshot": "^6.4.1",
-    "@types/node": "^24.3.0",
+    "@types/node": "^25.3.3",
     "@typescript-eslint/eslint-plugin": "^8.56.1",
     "@typescript-eslint/parser": "^8.32.0",
     "babel-loader": "^10.0.0",


### PR DESCRIPTION
## Summary
- Bumps `@types/node` from `^24.3.0` to `^25.3.3`
- Supersedes #1364

## Verification
- [x] `npm run build` - passed
- [x] `npm run test` - passed
- [x] `npm run lint` - passed
- [x] `playground build` - passed
- [x] `playground test` (E2E) - passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)