### PR TITLE
build(deps-dev): bump vite-plugin-css-injected-by-js from 3 to 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12884,6 +12884,16 @@
         }
       }
     },
+    "node_modules/vite-plugin-css-injected-by-js": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-css-injected-by-js/-/vite-plugin-css-injected-by-js-4.0.1.tgz",
+      "integrity": "sha512-WfyRojojQyAO/KzWf+efcXpTPv6zJPXaRmr9EYq5a4v5I3PWCR7kR01hiri2lW6+rHm3a57kpwsf+iahIJi1Qw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "vite": ">2.0.0-0"
+      }
+    },
     "node_modules/vite-tsconfig-paths": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-6.1.1.tgz",
@@ -13592,7 +13602,7 @@
         "process": "^0.11.10",
         "rollup": "^4.59.0",
         "vite": "^7.3.1",
-        "vite-plugin-css-injected-by-js": "^3.3.0",
+        "vite-plugin-css-injected-by-js": "^4.0.1",
         "vite-tsconfig-paths": "^6.1.1"
       },
       "peerDependencies": {
@@ -13813,16 +13823,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "packages/ui/node_modules/vite-plugin-css-injected-by-js": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/vite-plugin-css-injected-by-js/-/vite-plugin-css-injected-by-js-3.5.2.tgz",
-      "integrity": "sha512-2MpU/Y+SCZyWUB6ua3HbJCrgnF0KACAsmzOQt1UvRVJCGF6S8xdA3ZUhWcWdM9ivG4I5az8PnQmwwrkC2CAQrQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "vite": ">2.0.0-0"
       }
     }
   }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -74,7 +74,7 @@
     "process": "^0.11.10",
     "rollup": "^4.59.0",
     "vite": "^7.3.1",
-    "vite-plugin-css-injected-by-js": "^3.3.0",
+    "vite-plugin-css-injected-by-js": "^4.0.1",
     "vite-tsconfig-paths": "^6.1.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary
- Bumps `vite-plugin-css-injected-by-js` from `^3.3.0` to `^4.0.1` in `packages/ui`
- Supersedes #1365

## Verification
- [x] `npm run build` - passed
- [x] `npm run test` - passed
- [x] `npm run lint` - passed
- [x] `playground build` - passed
- [x] `playground test` (E2E) - passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)