### PR TITLE
fix(cli): stop pulling ui peers through common

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -55,9 +55,5 @@
   },
   "devDependencies": {
     "@types/estree": "^1.0.6"
-  },
-  "peerDependencies": {
-    "antd": "^5.11.2 || ^6.0.0",
-    "form-render": "^2.2.20"
   }
 }

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -1,7 +1,5 @@
 import { z } from 'zod';
 import type { PDFPage, PDFDocument } from '@pdfme/pdf-lib';
-import type { ThemeConfig } from 'antd';
-import type { WidgetProps as _PropPanelWidgetProps, Schema as _PropPanelSchema } from 'form-render';
 import {
   Lang,
   Dict,
@@ -26,7 +24,48 @@ import {
   SchemaPageArray,
 } from './schema.js';
 
-export type PropPanelSchema = _PropPanelSchema;
+export interface UIOptionsThemeToken {
+  colorPrimary?: string;
+  colorPrimaryBg?: string;
+  colorWhite?: string;
+  [key: string]: unknown;
+}
+
+export interface UIOptionsTheme {
+  token?: UIOptionsThemeToken;
+  components?: Record<string, Record<string, unknown>>;
+  [key: string]: unknown;
+}
+
+export interface PropPanelRule {
+  validator?: (...args: any[]) => unknown;
+  message?: string;
+  pattern?: RegExp | string;
+  [key: string]: unknown;
+}
+
+export interface PropPanelSchema {
+  title?: string;
+  type?: string;
+  widget?: string;
+  default?: unknown;
+  placeholder?: string;
+  format?: string;
+  required?: boolean;
+  hidden?: boolean | string;
+  disabled?: boolean;
+  bind?: string | false | string[];
+  span?: number;
+  column?: number;
+  min?: number;
+  max?: number;
+  props?: Record<string, unknown>;
+  rules?: PropPanelRule[];
+  properties?: Record<string, PropPanelSchema>;
+  items?: PropPanelSchema | PropPanelSchema[];
+  [key: string]: unknown;
+}
+
 export type ChangeSchemaItem = {
   key: string;
   value: unknown;
@@ -124,7 +163,15 @@ type PropPanelProps = {
   i18n: (key: string) => string;
 };
 
-export type PropPanelWidgetProps = _PropPanelWidgetProps & PropPanelProps;
+type PropPanelWidgetRuntimeProps = {
+  schema?: PropPanelSchema;
+  value?: unknown;
+  onChange?: (...args: any[]) => unknown;
+  error?: unknown;
+  [key: string]: unknown;
+};
+
+export type PropPanelWidgetProps = PropPanelWidgetRuntimeProps & PropPanelProps;
 
 /**
  * Used for customizing the property panel.
@@ -195,7 +242,7 @@ export type Template = z.infer<typeof Template>;
 export type CommonOptions = z.infer<typeof CommonOptions>;
 export type GeneratorOptions = z.infer<typeof GeneratorOptions>;
 export type GenerateProps = Omit<z.infer<typeof GenerateProps>, 'plugins'> & { plugins?: Plugins };
-export type UIOptions = z.infer<typeof UIOptions> & { theme?: ThemeConfig };
+export type UIOptions = z.infer<typeof UIOptions> & { theme?: UIOptionsTheme };
 export type UIProps = Omit<z.infer<typeof UIProps>, 'plugins'> & { plugins?: Plugins };
 export type PreviewProps = Omit<z.infer<typeof PreviewProps>, 'plugins'> & { plugins?: Plugins };
 export type DesignerProps = Omit<z.infer<typeof DesignerProps>, 'plugins'> & { plugins?: Plugins };

--- a/packages/ui/src/components/Designer/RightSidebar/DetailView/AlignWidget.tsx
+++ b/packages/ui/src/components/Designer/RightSidebar/DetailView/AlignWidget.tsx
@@ -209,7 +209,7 @@ const AlignWidget = (props: PropPanelWidgetProps) => {
   ];
 
   return (
-    <Form.Item label={schema.title}>
+    <Form.Item label={schema?.title}>
       <Space.Compact>
         {layoutBtns.map((btn) => (
           <Button

--- a/packages/ui/src/components/Designer/RightSidebar/DetailView/ButtonGroupWidget.tsx
+++ b/packages/ui/src/components/Designer/RightSidebar/DetailView/ButtonGroupWidget.tsx
@@ -11,6 +11,7 @@ interface ButtonConfig {
 const ButtonGroupWidget = (props: PropPanelWidgetProps) => {
   const { activeElements, changeSchemas, schemas, schema } = props;
   const { token } = theme.useToken();
+  const buttons = Array.isArray(schema?.buttons) ? (schema.buttons as ButtonConfig[]) : [];
 
   const apply = (btn: ButtonConfig) => {
     const key = btn.key;
@@ -54,7 +55,7 @@ const ButtonGroupWidget = (props: PropPanelWidgetProps) => {
   return (
     <Form.Item>
       <Space.Compact>
-        {(schema.buttons as ButtonConfig[]).map((btn: ButtonConfig, index: number) => {
+        {buttons.map((btn: ButtonConfig, index: number) => {
           const active = isActive(btn);
           return (
             <Button

--- a/packages/ui/src/components/Designer/RightSidebar/DetailView/index.tsx
+++ b/packages/ui/src/components/Designer/RightSidebar/DetailView/index.tsx
@@ -1,4 +1,5 @@
 import { useForm } from 'form-render';
+import type { Schema as FormRenderSchema } from 'form-render';
 import React, { useRef, useContext, useEffect, useCallback, useMemo } from 'react';
 import type {
   Dict,
@@ -450,7 +451,7 @@ const DetailView = (props: DetailViewProps) => {
       <SidebarBody>
         <FormRenderComponent
           form={form}
-          schema={propPanelSchema}
+          schema={propPanelSchema as unknown as FormRenderSchema}
           widgets={widgets}
           watch={{ '#': handleWatch }}
           locale="en-US"


### PR DESCRIPTION
## What changed
Stop `@pdfme/common` from exposing `antd` and `form-render` through its public type surface.

This replaces those public type references with local structural types and removes the corresponding peer dependencies from `@pdfme/common`.

## Why
`@pdfme/cli` depends on `@pdfme/common`, and the published `@pdfme/common` package currently advertises `antd` and `form-render` as peer dependencies.

That causes `npx @pdfme/cli` to pull UI-related dependency resolution into a CLI install path. In practice, npm ends up traversing a large React/UI tree and can get stuck around peer resolution conflicts involving `form-render` -> `rc-color-picker` requiring React 16 while newer UI packages resolve React 19.

## Impact
CLI users should no longer pull UI peer dependencies indirectly through `@pdfme/common`.

This keeps the UI package behavior intact by only using `form-render`'s concrete schema type inside `@pdfme/ui`, while `@pdfme/common` exports looser structural types for its public API.

## Validation
- `npm run build -w packages/common`
- `npm run build -w packages/schemas`
- `npm run build -w packages/ui`
- `npm run build -w packages/generator`
- `npm run build -w packages/cli`
