### PR TITLE
fix(schemas): correct CMYK color conversion for zero RGB channels

### DIFF
--- a/packages/schemas/__tests__/utils.test.ts
+++ b/packages/schemas/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import { Schema, mm2pt, pt2mm } from '@pdfme/common';
-import { convertForPdfLayoutProps, rotatePoint, hex2RgbColor, createSvgStr } from '../src/utils.js';
+import { convertForPdfLayoutProps, rotatePoint, hex2RgbColor, hex2PrintingColor, createSvgStr } from '../src/utils.js';
 import { SquareCheck, IconNode } from 'lucide';
 
 describe('hex2RgbColor', () => {
@@ -30,6 +30,40 @@ describe('hex2RgbColor', () => {
     const hex = '#fffee';
     expect(() => hex2RgbColor(hex)).toThrow('Invalid hex color value #ff');
   });
+});
+
+describe('hex2PrintingColor (CMYK)', () => {
+  // hex2CmykColor is not directly exported — test via hex2PrintingColor with 'cmyk'.
+  // Regression guard for the bug where individual RGB channel === 0 incorrectly
+  // zeroed the corresponding CMYK output. The division-by-zero guard should be
+  // k === 1, not per-channel.
+
+  const cmykExpect = (hex: string, c: number, m: number, y: number, k: number) => {
+    const result = hex2PrintingColor(hex, 'cmyk') as {
+      type: string; cyan: number; magenta: number; yellow: number; key: number;
+    };
+    expect(result.type).toBe('CMYK');
+    expect(result.cyan).toBeCloseTo(c, 5);
+    expect(result.magenta).toBeCloseTo(m, 5);
+    expect(result.yellow).toBeCloseTo(y, 5);
+    expect(result.key).toBeCloseTo(k, 5);
+  };
+
+  it('pure black → K=1', () => cmykExpect('#000000', 0, 0, 0, 1));
+  it('pure white → all zeros', () => cmykExpect('#ffffff', 0, 0, 0, 0));
+
+  // These three used to be incorrectly converted to (0,0,0,0) because the
+  // division-by-zero guard checked individual RGB channels.
+  it('pure red → Y=1, M=1 (regression guard)', () => cmykExpect('#ff0000', 0, 1, 1, 0));
+  it('pure green → C=1, Y=1 (regression guard)', () => cmykExpect('#00ff00', 1, 0, 1, 0));
+  it('pure blue → C=1, M=1 (regression guard)', () => cmykExpect('#0000ff', 1, 1, 0, 0));
+  it('pure yellow → Y=1 (regression guard)', () => cmykExpect('#ffff00', 0, 0, 1, 0));
+  it('pure magenta → M=1 (regression guard)', () => cmykExpect('#ff00ff', 0, 1, 0, 0));
+  it('pure cyan → C=1 (regression guard)', () => cmykExpect('#00ffff', 1, 0, 0, 0));
+  it('orange (ff8000) → M=0.498, Y=1 (regression guard)', () =>
+    cmykExpect('#ff8000', 0, 0.498039, 1, 0));
+
+  it('mid-gray → K=0.5', () => cmykExpect('#808080', 0, 0, 0, 0.498039));
 });
 
 describe('rotatePoint', () => {

--- a/packages/schemas/src/utils.ts
+++ b/packages/schemas/src/utils.ts
@@ -136,9 +136,9 @@ const hex2CmykColor = (hexString: string | undefined) => {
 
     // Calculate the CMYK values
     const k = 1 - Math.max(r, g, b);
-    const c = r === 0 ? 0 : (1 - r - k) / (1 - k);
-    const m = g === 0 ? 0 : (1 - g - k) / (1 - k);
-    const y = b === 0 ? 0 : (1 - b - k) / (1 - k);
+    const c = k === 1 ? 0 : (1 - r - k) / (1 - k);
+    const m = k === 1 ? 0 : (1 - g - k) / (1 - k);
+    const y = k === 1 ? 0 : (1 - b - k) / (1 - k);
 
     return cmyk(c, m, y, k);
   }


### PR DESCRIPTION
  ## Summary

  The `hex2CmykColor` function in `packages/schemas/src/utils.ts` has an incorrect division-by-zero guard that causes any color with
  a zero RGB channel to produce wrong CMYK values.

  ## Bug

  Lines 139-141 check `r === 0` / `g === 0` / `b === 0` to guard against division by zero. This is wrong — the division is `/ (1 -
  k)`, which is only zero when `k === 1` (pure black). Checking individual RGB channels causes the corresponding CMYK component to be
   incorrectly zeroed.

  ## Impact

  Any color containing a zero RGB channel renders incorrectly in CMYK mode:

  | Input | Expected CMYK | Produced CMYK |
  |---|---|---|
  | `#ffff00` (yellow) | 0, 0, 1, 0 | 0, 0, 0, 0 (white / no ink) |
  | `#ff0000` (red)    | 0, 1, 1, 0 | 0, 0, 0, 0 |
  | `#00ff00` (green)  | 1, 0, 1, 0 | 0, 0, 0, 0 |
  | `#ff8000` (orange) | 0, 0.498, 1, 0 | 0, 0.498, 0, 0 |

  ## Fix

  Replace the three `x === 0` checks with `k === 1`.
  
  - fixed using claude -