### PR TITLE
fix(ui): preserve page cursor and scroll position on updateTemplate

### DIFF
--- a/packages/ui/src/components/Designer/index.tsx
+++ b/packages/ui/src/components/Designer/index.tsx
@@ -181,15 +181,17 @@ const TemplateEditor = ({
     onEditEnd,
   });
 
-  const updateTemplate = useCallback(async (newTemplate: Template) => {
-    const sl = await template2SchemasList(newTemplate);
-    setSchemasList(sl);
-    onEditEnd();
+const updateTemplate = useCallback(async (newTemplate: Template, preservePage = false) => {
+  const sl = await template2SchemasList(newTemplate);
+  setSchemasList(sl);
+  onEditEnd();
+  if (!preservePage) {
     setPageCursor(0);
     if (canvasRef.current?.scroll) {
       canvasRef.current.scroll({ top: 0, behavior: 'smooth' });
     }
-  }, []);
+  }
+}, []);
 
   const addSchema = (defaultSchema: Schema) => {
     const [paddingTop, paddingRight, paddingBottom, paddingLeft] = isBlankPdf(template.basePdf)
@@ -283,7 +285,7 @@ const TemplateEditor = ({
 
   if (prevTemplate !== template) {
     setPrevTemplate(template);
-    void updateTemplate(template);
+    void updateTemplate(template, true);
   }
 
   const canvasWidth = size.width - LEFT_SIDEBAR_WIDTH;


### PR DESCRIPTION
## Problem
When `updateTemplate()` is called externally (e.g. on element 
drag/resize), the Designer unconditionally resets pageCursor to 0 
and scrolls the canvas to top. This makes working on any page 
beyond page 1 frustrating — every change snaps you back.

## Root cause
`updateTemplate` callback in Designer/index.tsx hardcodes 
`setPageCursor(0)` with no conditional path.

## Fix
Add an optional `preservePage` boolean param. External template 
updates pass `true`; fresh template loads keep the default (`false`) 
so initial behaviour is unchanged.

## Testing
- Open Designer with a 3-page template
- Navigate to page 2 or 3
- Edit any element — page position should be preserved
- Loading a new template should still start at page 1