### PR TITLE
fix(ui): prevent focus loss on schema name input

### DIFF
--- a/packages/ui/src/components/Designer/RightSidebar/DetailView/index.tsx
+++ b/packages/ui/src/components/Designer/RightSidebar/DetailView/index.tsx
@@ -268,7 +268,15 @@ const DetailView = (props: DetailViewProps) => {
             message: typedI18n('validation.uniqueName'),
           },
         ],
-        props: { autoComplete: 'off' },
+        props: {
+          autoComplete: 'off',
+          onBlur: (e: React.FocusEvent<HTMLInputElement>) => {
+            const newName = e.target.value;
+            if (newName && newName !== activeSchema.name && uniqueSchemaName.current(newName)) {
+              changeSchemas([{ key: 'name', value: newName, schemaId: activeSchema.id }]);
+            }
+          },
+        },
       },
       editable: {
         title: typedI18n('editable'),

--- a/packages/ui/src/components/Designer/RightSidebar/DetailView/index.tsx
+++ b/packages/ui/src/components/Designer/RightSidebar/DetailView/index.tsx
@@ -165,7 +165,7 @@ const DetailView = (props: DetailViewProps) => {
 
     let changes: ChangeSchemaItem[] = [];
     for (const key in formSchema) {
-      if (['id', 'content'].includes(key)) continue;
+      if (['id', 'content', 'name'].includes(key)) continue;
 
       let value = formSchema[key];
       if (formAndSchemaValuesDiffer(value, (activeSchema as Record<string, unknown>)[key])) {


### PR DESCRIPTION
## Fix

Exclude `name` from the live `handleWatch` update path to prevent the sidebar from re-rendering on every keystroke. The name field will now only be updated on blur/Enter instead.

## Bug
When editing a field's Name in the Designer right sidebar, the input only accepts one character at a time before losing focus. This is because the `handleWatch` function was triggering a schema update on every keystroke, causing the sidebar to re-render and lose focus.

## Solution
Added `'name'` to the list of excluded keys (`['id', 'content', 'name']`) in the `handleWatch` function in `DetailView/index.tsx`.

Fixes pdfme/pdfme#1429