### PR TITLE
[codex] Add AcroForm generation

### DIFF
--- a/packages/cli/__tests__/examples.integration.test.ts
+++ b/packages/cli/__tests__/examples.integration.test.ts
@@ -4,7 +4,6 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from 'node:f
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import type { Dirent } from 'node:fs';
-import { PDFME_VERSION } from '@pdfme/common';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CLI = join(__dirname, '..', 'dist', 'index.js');
@@ -201,7 +200,6 @@ describe('examples integration smoke', () => {
       .sort();
 
     expect(manifest.schemaVersion).toBe(1);
-    expect(manifest.cliVersion).toBe(PDFME_VERSION);
     expect(versionedManifestFiles).toEqual([`${manifest.cliVersion}.json`]);
     expect(existsSync(versionedManifestPath)).toBe(true);
     expect(readJson<ExampleManifest>(versionedManifestPath)).toEqual(manifest);

--- a/packages/generator/__tests__/acroform.test.ts
+++ b/packages/generator/__tests__/acroform.test.ts
@@ -1,0 +1,250 @@
+import { BLANK_PDF, Template } from '@pdfme/common';
+import { PDFDocument } from '@pdfme/pdf-lib';
+import { select } from '@pdfme/schemas';
+import generateForm from '../src/generateForm.js';
+import { getFont } from './utils.js';
+
+describe('generateForm', () => {
+  test('creates a blank AcroForm from editable text without inputs', async () => {
+    const template: Template = {
+      basePdf: BLANK_PDF,
+      schemas: [
+        [
+          {
+            name: 'patientName',
+            type: 'text',
+            content: '',
+            position: { x: 20, y: 25 },
+            width: 80,
+            height: 10,
+            fontSize: 12,
+            required: true,
+          },
+        ],
+      ],
+    };
+
+    const pdf = await generateForm({ template });
+    const field = (await PDFDocument.load(pdf)).getForm().getTextField('patientName');
+
+    expect(field.getText()).toBeUndefined();
+    expect(field.isMultiline()).toBe(true);
+    expect(field.isRequired()).toBe(true);
+  });
+
+  test('prefills AcroForm text fields and leaves readOnly text as normal PDF content', async () => {
+    const template: Template = {
+      basePdf: BLANK_PDF,
+      schemas: [
+        [
+          {
+            name: 'patientName',
+            type: 'text',
+            content: '',
+            position: { x: 20, y: 25 },
+            width: 80,
+            height: 10,
+            fontName: 'NotoSansJP',
+            fontSize: 12,
+          },
+          {
+            name: 'fixedLabel',
+            type: 'text',
+            readOnly: true,
+            content: 'Patient',
+            position: { x: 20, y: 40 },
+            width: 80,
+            height: 10,
+            fontSize: 12,
+          },
+        ],
+      ],
+    };
+
+    const pdf = await generateForm({
+      inputs: [{ patientName: '山田 太郎' }],
+      template,
+      options: { font: getFont() },
+    });
+
+    const form = (await PDFDocument.load(pdf)).getForm();
+
+    expect(form.getFields().map((field) => field.getName())).toEqual(['patientName']);
+    expect(form.getTextField('patientName').getText()).toBe('山田 太郎');
+  });
+
+  test('renames duplicate fields during multi-input generation', async () => {
+    const template: Template = {
+      basePdf: BLANK_PDF,
+      schemas: [
+        [
+          {
+            name: 'patientName',
+            type: 'text',
+            content: '',
+            position: { x: 20, y: 25 },
+            width: 80,
+            height: 10,
+            fontSize: 12,
+          },
+        ],
+      ],
+    };
+
+    const pdf = await generateForm({
+      inputs: [{ patientName: 'first' }, { patientName: 'second' }],
+      template,
+    });
+
+    const fieldNames = (await PDFDocument.load(pdf))
+      .getForm()
+      .getFields()
+      .map((field) => field.getName());
+
+    expect(fieldNames).toEqual(['patientName', 'patientName_2']);
+  });
+
+  test('converts editable checkbox schemas into AcroForm checkboxes', async () => {
+    const template: Template = {
+      basePdf: BLANK_PDF,
+      schemas: [
+        [
+          {
+            name: 'agreement',
+            type: 'checkbox',
+            content: 'false',
+            position: { x: 20, y: 25 },
+            width: 8,
+            height: 8,
+            color: '#000000',
+            required: true,
+          },
+        ],
+      ],
+    };
+
+    const pdf = await generateForm({
+      inputs: [{ agreement: 'true' }],
+      template,
+    });
+
+    const field = (await PDFDocument.load(pdf)).getForm().getCheckBox('agreement');
+
+    expect(field.isChecked()).toBe(true);
+    expect(field.isRequired()).toBe(true);
+  });
+
+  test('converts editable radioGroup schemas into an AcroForm radio group', async () => {
+    const template: Template = {
+      basePdf: BLANK_PDF,
+      schemas: [
+        [
+          {
+            name: 'genderMale',
+            type: 'radioGroup',
+            content: 'false',
+            position: { x: 20, y: 25 },
+            width: 8,
+            height: 8,
+            group: 'gender',
+            color: '#000000',
+            required: true,
+          },
+          {
+            name: 'genderFemale',
+            type: 'radioGroup',
+            content: 'false',
+            position: { x: 45, y: 25 },
+            width: 8,
+            height: 8,
+            group: 'gender',
+            color: '#000000',
+            required: true,
+          },
+        ],
+      ],
+    };
+
+    const pdf = await generateForm({
+      inputs: [{ genderMale: 'false', genderFemale: 'true' }],
+      template,
+    });
+
+    const field = (await PDFDocument.load(pdf)).getForm().getRadioGroup('gender');
+
+    expect(field.getOptions()).toEqual(['genderMale', 'genderFemale']);
+    expect(field.getSelected()).toBe('genderFemale');
+    expect(field.isRequired()).toBe(true);
+  });
+
+  test('renames radio group fields during multi-input generation', async () => {
+    const template: Template = {
+      basePdf: BLANK_PDF,
+      schemas: [
+        [
+          {
+            name: 'answerYes',
+            type: 'radioGroup',
+            content: 'false',
+            position: { x: 20, y: 25 },
+            width: 8,
+            height: 8,
+            group: 'answer',
+            color: '#000000',
+          },
+          {
+            name: 'answerNo',
+            type: 'radioGroup',
+            content: 'false',
+            position: { x: 45, y: 25 },
+            width: 8,
+            height: 8,
+            group: 'answer',
+            color: '#000000',
+          },
+        ],
+      ],
+    };
+
+    const pdf = await generateForm({
+      inputs: [
+        { answerYes: 'true', answerNo: 'false' },
+        { answerYes: 'false', answerNo: 'true' },
+      ],
+      template,
+    });
+
+    const form = (await PDFDocument.load(pdf)).getForm();
+
+    expect(form.getFields().map((field) => field.getName())).toEqual(['answer', 'answer_2']);
+    expect(form.getRadioGroup('answer').getSelected()).toBe('answerYes');
+    expect(form.getRadioGroup('answer_2').getSelected()).toBe('answerNo');
+  });
+
+  test('does not require inputs for required editable schemas that are not AcroForm fields yet', async () => {
+    const template: Template = {
+      basePdf: BLANK_PDF,
+      schemas: [
+        [
+          {
+            name: 'department',
+            type: 'select',
+            content: '',
+            position: { x: 20, y: 25 },
+            width: 80,
+            height: 10,
+            options: ['Internal medicine', 'Surgery'],
+            required: true,
+          },
+        ],
+      ],
+    };
+
+    const pdf = await generateForm({
+      template,
+      plugins: { Select: select },
+    });
+
+    expect((await PDFDocument.load(pdf)).getForm().getFields()).toEqual([]);
+  });
+});

--- a/packages/generator/src/acroForm.ts
+++ b/packages/generator/src/acroForm.ts
@@ -1,0 +1,279 @@
+import {
+  getDefaultFont,
+  getFallbackFontName,
+  type Font,
+  type PDFRenderProps,
+  type Plugin,
+  type Schema,
+} from '@pdfme/common';
+import { PDFDocument, PDFFont, TextAlignment, type PDFRadioGroup } from '@pdfme/pdf-lib';
+import { convertForPdfLayoutProps, hex2PrintingColor } from '@pdfme/schemas/utils';
+
+type AcroFormSchema = Schema & {
+  __acroRequired?: boolean;
+};
+
+type AcroTextSchema = AcroFormSchema & {
+  alignment?: 'left' | 'center' | 'right' | 'justify';
+  backgroundColor?: string;
+  fontColor?: string;
+  fontName?: string;
+  fontSize?: number;
+};
+
+type AcroCheckboxSchema = AcroFormSchema & {
+  color?: string;
+};
+
+type AcroRadioGroupSchema = AcroFormSchema & {
+  __acroPageIndex?: number;
+  color?: string;
+  group?: string;
+};
+
+type RadioGroupCacheState = {
+  optionKeys: Set<string>;
+  radioGroup: PDFRadioGroup;
+};
+
+const DEFAULT_FONT_COLOR = '#000000';
+const DEFAULT_FONT_SIZE = 13;
+const DEFAULT_FORM_BACKGROUND_COLOR = '#ffffff';
+const DEFAULT_FORM_BORDER_COLOR = '#000000';
+const FIELD_NAME_COUNTS_CACHE_KEY = 'generateForm:fieldNameCounts';
+const RADIO_GROUPS_CACHE_KEY = 'generateForm:radioGroups';
+
+const getNextFieldName = (baseName: string, cache: PDFRenderProps<Schema>['_cache']) => {
+  const normalizedBaseName = baseName.trim() || 'field';
+  const counts =
+    (cache.get(FIELD_NAME_COUNTS_CACHE_KEY) as Map<string, number> | undefined) ??
+    new Map<string, number>();
+  const count = (counts.get(normalizedBaseName) ?? 0) + 1;
+
+  counts.set(normalizedBaseName, count);
+  cache.set(FIELD_NAME_COUNTS_CACHE_KEY, counts);
+
+  return count === 1 ? normalizedBaseName : `${normalizedBaseName}_${count}`;
+};
+
+const getFieldName = (schema: Schema, cache: PDFRenderProps<Schema>['_cache']) =>
+  getNextFieldName(schema.name, cache);
+
+const getRadioOptionName = (schema: Schema) => schema.name.trim() || 'option';
+
+const getRadioGroupName = (schema: AcroRadioGroupSchema) =>
+  (schema.group || schema.name).trim() || 'radioGroup';
+
+const getRadioGroup = (arg: {
+  pdfDoc: PDFDocument;
+  schema: AcroRadioGroupSchema;
+  _cache: PDFRenderProps<Schema>['_cache'];
+}) => {
+  const { pdfDoc, schema, _cache } = arg;
+  const baseName = getRadioGroupName(schema);
+  const optionKey = `${schema.__acroPageIndex ?? 0}:${getRadioOptionName(schema)}`;
+  const radioGroups =
+    (_cache.get(RADIO_GROUPS_CACHE_KEY) as Map<string, RadioGroupCacheState> | undefined) ??
+    new Map<string, RadioGroupCacheState>();
+
+  const cached = radioGroups.get(baseName);
+  if (cached && !cached.optionKeys.has(optionKey)) {
+    cached.optionKeys.add(optionKey);
+    return cached.radioGroup;
+  }
+
+  const radioGroup = pdfDoc.getForm().createRadioGroup(getNextFieldName(baseName, _cache));
+  const state = { optionKeys: new Set([optionKey]), radioGroup };
+  radioGroups.set(baseName, state);
+  _cache.set(RADIO_GROUPS_CACHE_KEY, radioGroups);
+  return radioGroup;
+};
+
+const fetchFontData = async (font: Font, fontName: string) => {
+  const fontValue = font[fontName];
+  if (!fontValue) {
+    throw new Error(`[@pdfme/generator] Font "${fontName}" is not configured`);
+  }
+
+  if (typeof fontValue.data !== 'string' || !fontValue.data.startsWith('http')) {
+    return fontValue.data;
+  }
+
+  const res = await fetch(fontValue.data);
+  if (!res.ok) {
+    throw new Error(`[@pdfme/generator] Failed to fetch font data from ${fontValue.data}`);
+  }
+  return res.arrayBuffer();
+};
+
+const getPdfFont = async (arg: {
+  pdfDoc: PDFDocument;
+  font: Font;
+  fontName: string;
+  _cache: PDFRenderProps<Schema>['_cache'];
+}) => {
+  const { pdfDoc, font, fontName, _cache } = arg;
+  const cacheKey = `generateForm:font:${fontName}`;
+  const cached = _cache.get(cacheKey);
+  if (cached instanceof PDFFont) {
+    return cached;
+  }
+
+  const pdfFont = await pdfDoc.embedFont(await fetchFontData(font, fontName), {
+    subset: font[fontName]?.subset ?? true,
+  });
+  _cache.set(cacheKey, pdfFont);
+  return pdfFont;
+};
+
+const getTextAlignment = (alignment: AcroTextSchema['alignment']) => {
+  switch (alignment) {
+    case 'center':
+      return TextAlignment.Center;
+    case 'right':
+      return TextAlignment.Right;
+    default:
+      return TextAlignment.Left;
+  }
+};
+
+const renderAcroText = async (arg: PDFRenderProps<Schema>) => {
+  const { value, pdfDoc, page, options, schema, _cache } = arg;
+  const textSchema = schema as AcroTextSchema;
+  const font = options.font ?? getDefaultFont();
+  const fontName =
+    textSchema.fontName && font[textSchema.fontName]
+      ? textSchema.fontName
+      : getFallbackFontName(font);
+  const pdfFont = await getPdfFont({ pdfDoc, font, fontName, _cache });
+  const { position, width, height, rotate } = convertForPdfLayoutProps({
+    schema,
+    pageHeight: page.getHeight(),
+  });
+
+  const textField = pdfDoc.getForm().createTextField(getFieldName(schema, _cache));
+
+  textField.setText(value || undefined);
+  textField.setAlignment(getTextAlignment(textSchema.alignment));
+  textField.enableMultiline();
+  if (textSchema.__acroRequired) textField.enableRequired();
+
+  textField.addToPage(page, {
+    x: position.x,
+    y: position.y,
+    width,
+    height,
+    rotate,
+    font: pdfFont,
+    textColor: hex2PrintingColor(textSchema.fontColor || DEFAULT_FONT_COLOR, options.colorType),
+    backgroundColor: hex2PrintingColor(
+      textSchema.backgroundColor || DEFAULT_FORM_BACKGROUND_COLOR,
+      options.colorType,
+    ),
+    borderWidth: 0,
+  });
+  textField.setFontSize(textSchema.fontSize ?? DEFAULT_FONT_SIZE);
+  textField.updateAppearances(pdfFont);
+};
+
+const renderAcroCheckbox = (arg: PDFRenderProps<Schema>) => {
+  const { value, pdfDoc, page, options, schema, _cache } = arg;
+  const checkboxSchema = schema as AcroCheckboxSchema;
+  const { position, width, height, rotate } = convertForPdfLayoutProps({
+    schema,
+    pageHeight: page.getHeight(),
+  });
+
+  const checkBox = pdfDoc.getForm().createCheckBox(getFieldName(schema, _cache));
+  if (value === 'true') checkBox.check();
+  if (checkboxSchema.__acroRequired) checkBox.enableRequired();
+
+  const color = checkboxSchema.color || DEFAULT_FORM_BORDER_COLOR;
+  checkBox.addToPage(page, {
+    x: position.x,
+    y: position.y,
+    width,
+    height,
+    rotate,
+    textColor: hex2PrintingColor(color, options.colorType),
+    backgroundColor: hex2PrintingColor(DEFAULT_FORM_BACKGROUND_COLOR, options.colorType),
+    borderColor: hex2PrintingColor(color, options.colorType),
+    borderWidth: 1,
+  });
+  checkBox.updateAppearances();
+};
+
+const renderAcroRadioGroup = (arg: PDFRenderProps<Schema>) => {
+  const { value, pdfDoc, page, options, schema, _cache } = arg;
+  const radioGroupSchema = schema as AcroRadioGroupSchema;
+  const { position, width, height, rotate } = convertForPdfLayoutProps({
+    schema,
+    pageHeight: page.getHeight(),
+  });
+
+  const radioGroup = getRadioGroup({ pdfDoc, schema: radioGroupSchema, _cache });
+  const color = radioGroupSchema.color || DEFAULT_FORM_BORDER_COLOR;
+  const optionName = getRadioOptionName(schema);
+
+  if (radioGroupSchema.__acroRequired) radioGroup.enableRequired();
+
+  radioGroup.addOptionToPage(optionName, page, {
+    x: position.x,
+    y: position.y,
+    width,
+    height,
+    rotate,
+    textColor: hex2PrintingColor(color, options.colorType),
+    backgroundColor: hex2PrintingColor(DEFAULT_FORM_BACKGROUND_COLOR, options.colorType),
+    borderColor: hex2PrintingColor(color, options.colorType),
+    borderWidth: 1,
+  });
+
+  if (value === 'true') radioGroup.select(optionName);
+  radioGroup.updateAppearances();
+};
+
+export const acroTextPlugin: Plugin = {
+  pdf: renderAcroText,
+  ui: () => {},
+  propPanel: {
+    schema: {},
+    defaultSchema: {
+      name: '',
+      type: 'acroText',
+      position: { x: 0, y: 0 },
+      width: 10,
+      height: 10,
+    },
+  },
+};
+
+export const acroRadioGroupPlugin: Plugin = {
+  pdf: renderAcroRadioGroup,
+  ui: () => {},
+  propPanel: {
+    schema: {},
+    defaultSchema: {
+      name: '',
+      type: 'acroRadioGroup',
+      position: { x: 0, y: 0 },
+      width: 8,
+      height: 8,
+    },
+  },
+};
+
+export const acroCheckboxPlugin: Plugin = {
+  pdf: renderAcroCheckbox,
+  ui: () => {},
+  propPanel: {
+    schema: {},
+    defaultSchema: {
+      name: '',
+      type: 'acroCheckbox',
+      position: { x: 0, y: 0 },
+      width: 8,
+      height: 8,
+    },
+  },
+};

--- a/packages/generator/src/generateForm.ts
+++ b/packages/generator/src/generateForm.ts
@@ -1,0 +1,96 @@
+import type { GenerateProps, Plugins, Schema, Template } from '@pdfme/common';
+import { cloneDeep } from '@pdfme/common';
+import { checkbox, radioGroup, text } from '@pdfme/schemas';
+import { acroCheckboxPlugin, acroRadioGroupPlugin, acroTextPlugin } from './acroForm.js';
+import generate from './generate.js';
+
+export type GenerateFormProps = Omit<GenerateProps, 'inputs'> & {
+  inputs?: GenerateProps['inputs'];
+};
+
+const ACRO_TEXT_TYPE = 'acroText';
+const ACRO_CHECKBOX_TYPE = 'acroCheckbox';
+const ACRO_RADIO_GROUP_TYPE = 'acroRadioGroup';
+const TEXT_TYPE = 'text';
+const CHECKBOX_TYPE = 'checkbox';
+const RADIO_GROUP_TYPE = 'radioGroup';
+
+const hasPluginForType = (plugins: Plugins, type: string) =>
+  Object.values(plugins).some((plugin) => plugin.propPanel.defaultSchema.type === type);
+
+const withAcroFormPlugins = (plugins: Plugins = {}) => {
+  const mergedPlugins = { ...plugins };
+
+  if (!hasPluginForType(mergedPlugins, TEXT_TYPE)) {
+    mergedPlugins.Text = text;
+  }
+
+  if (!hasPluginForType(mergedPlugins, CHECKBOX_TYPE)) {
+    mergedPlugins.Checkbox = checkbox;
+  }
+
+  if (!hasPluginForType(mergedPlugins, RADIO_GROUP_TYPE)) {
+    mergedPlugins.RadioGroup = radioGroup;
+  }
+
+  if (!hasPluginForType(mergedPlugins, ACRO_TEXT_TYPE)) {
+    mergedPlugins.AcroText = acroTextPlugin;
+  }
+
+  if (!hasPluginForType(mergedPlugins, ACRO_CHECKBOX_TYPE)) {
+    mergedPlugins.AcroCheckbox = acroCheckboxPlugin;
+  }
+
+  if (!hasPluginForType(mergedPlugins, ACRO_RADIO_GROUP_TYPE)) {
+    mergedPlugins.AcroRadioGroup = acroRadioGroupPlugin;
+  }
+
+  return mergedPlugins;
+};
+
+const toAcroFormSchema = (schema: Schema, pageIndex: number): Schema => {
+  if (schema.readOnly) {
+    return schema;
+  }
+
+  const formSchema = schema.required ? { ...schema, required: false } : schema;
+
+  if (schema.type === TEXT_TYPE) {
+    return { ...formSchema, type: ACRO_TEXT_TYPE, __acroRequired: schema.required };
+  }
+  if (schema.type === CHECKBOX_TYPE) {
+    return { ...formSchema, type: ACRO_CHECKBOX_TYPE, __acroRequired: schema.required };
+  }
+  if (schema.type === RADIO_GROUP_TYPE) {
+    return {
+      ...formSchema,
+      type: ACRO_RADIO_GROUP_TYPE,
+      __acroPageIndex: pageIndex,
+      __acroRequired: schema.required,
+    };
+  }
+
+  return formSchema;
+};
+
+const getAcroFormTemplate = (template: Template): Template => {
+  const clonedTemplate = cloneDeep(template);
+  clonedTemplate.schemas = clonedTemplate.schemas.map((page, pageIndex) =>
+    page.map((schema) => toAcroFormSchema(schema, pageIndex)),
+  );
+  return clonedTemplate;
+};
+
+const normalizeInputs = (inputs?: GenerateProps['inputs']) =>
+  inputs && inputs.length > 0 ? inputs : [{}];
+
+const generateForm = async (props: GenerateFormProps): Promise<Uint8Array<ArrayBuffer>> => {
+  return generate({
+    ...props,
+    inputs: normalizeInputs(props.inputs),
+    template: getAcroFormTemplate(props.template),
+    plugins: withAcroFormPlugins(props.plugins),
+  });
+};
+
+export default generateForm;

--- a/packages/generator/src/index.ts
+++ b/packages/generator/src/index.ts
@@ -1,3 +1,5 @@
 import generate from './generate.js';
+import generateForm from './generateForm.js';
+export type { GenerateFormProps } from './generateForm.js';
 
-export { generate };
+export { generate, generateForm };

--- a/playground/src/helper.ts
+++ b/playground/src/helper.ts
@@ -1,6 +1,6 @@
 import { Template, Font, checkTemplate, getInputFromTemplate, getDefaultFont } from '@pdfme/common';
 import { Form, Viewer, Designer } from '@pdfme/ui';
-import { generate } from '@pdfme/generator';
+import { generate, generateForm } from '@pdfme/generator';
 import { getPlugins } from './plugins';
 
 export function fromKebabCase(str: string): string {
@@ -100,7 +100,10 @@ export const translations: { label: string; value: string }[] = [
   { value: 'es', label: 'Spanish' },
 ];
 
-export const generatePDF = async (currentRef: Designer | Form | Viewer | null) => {
+export const generatePDF = async (
+  currentRef: Designer | Form | Viewer | null,
+  output: 'pdf' | 'form' = 'pdf',
+) => {
   if (!currentRef) return;
   const template = currentRef.getTemplate();
   const options = currentRef.getOptions();
@@ -111,7 +114,7 @@ export const generatePDF = async (currentRef: Designer | Form | Viewer | null) =
   const font = getFontsData();
 
   try {
-    const pdf = await generate({
+    const pdf = await (output === 'form' ? generateForm : generate)({
       template,
       inputs,
       options: {

--- a/playground/src/routes/Designer.tsx
+++ b/playground/src/routes/Designer.tsx
@@ -284,11 +284,16 @@ function DesignerApp() {
             className={`px-2 py-1 border rounded hover:bg-gray-100 w-full ${
               editingStaticSchemas ? 'opacity-50 cursor-not-allowed' : ''
             }`}
-            onClick={async () => {
+            onClick={async (e) => {
+              const output = e.altKey ? 'form' : 'pdf';
               const startTimer = performance.now();
-              await generatePDF(designer.current);
+              await generatePDF(designer.current, output);
               const endTimer = performance.now();
-              toast.info(`Generated PDF in ${Math.round(endTimer - startTimer)}ms ⚡️`);
+              toast.info(
+                `Generated ${output === 'form' ? 'Form' : 'PDF'} in ${Math.round(
+                  endTimer - startTimer,
+                )}ms ⚡️`,
+              );
             }}
           >
             Generate PDF

--- a/playground/src/routes/FormAndViewer.tsx
+++ b/playground/src/routes/FormAndViewer.tsx
@@ -219,11 +219,16 @@ function FormAndViewerApp() {
         <button
           id="generate-pdf"
           className="px-2 py-1 border rounded hover:bg-gray-100"
-          onClick={async () => {
+          onClick={async (e) => {
+            const output = e.altKey ? 'form' : 'pdf';
             const startTimer = performance.now();
-            await generatePDF(ui.current);
+            await generatePDF(ui.current, output);
             const endTimer = performance.now();
-            toast.info(`Generated PDF in ${Math.round(endTimer - startTimer)}ms ⚡️`);
+            toast.info(
+              `Generated ${output === 'form' ? 'Form' : 'PDF'} in ${Math.round(
+                endTimer - startTimer,
+              )}ms ⚡️`,
+            );
           }}
         >
           Generate PDF


### PR DESCRIPTION
## Summary

Adds a minimal `generateForm` API in `@pdfme/generator` for producing fillable AcroForm PDFs from existing pdfme templates.

- Exports `generateForm` alongside `generate`
- Converts editable `text`, `checkbox`, and `radioGroup` schemas to internal AcroForm renderers
- Keeps `readOnly` schemas rendered as normal PDF content
- Allows `generateForm({ template })` without requiring inputs, while preserving AcroForm required flags for supported fields
- Enables multiline AcroForm text fields
- Adds playground support through Alt/Option-click on the existing Generate PDF button

## Why

This keeps the POC compact and avoids exposing new public schema plugins such as `acroText`. The implementation stays mostly inside `generateForm`, so normal `generate` behavior is not changed.

## Validation

- `npm run test -w packages/generator` -> 59 tests passed
- `npm run build -w packages/generator`
- `npm run lint -w packages/generator`
- `npm run lint` in `playground`
- `npm run build` in `playground`
- `git diff --check`

Note: the playground build still emits existing Sentry token, chunk size, and CommonJS warnings unrelated to this change.