### PR TITLE
fix(schemas): correct CMYK conversion for zero channels

### DIFF
--- a/packages/schemas/__tests__/utils.test.ts
+++ b/packages/schemas/__tests__/utils.test.ts
@@ -1,5 +1,12 @@
 import { Schema, mm2pt, pt2mm } from '@pdfme/common';
-import { convertForPdfLayoutProps, rotatePoint, hex2RgbColor, createSvgStr } from '../src/utils.js';
+import type { CMYK } from '@pdfme/pdf-lib';
+import {
+  convertForPdfLayoutProps,
+  rotatePoint,
+  hex2RgbColor,
+  hex2PrintingColor,
+  createSvgStr,
+} from '../src/utils.js';
 import { SquareCheck, IconNode } from 'lucide';
 
 describe('hex2RgbColor', () => {
@@ -29,6 +36,44 @@ describe('hex2RgbColor', () => {
   it('should throw an error if hex is invalid', () => {
     const hex = '#fffee';
     expect(() => hex2RgbColor(hex)).toThrow('Invalid hex color value #ff');
+  });
+});
+
+describe('hex2PrintingColor (CMYK)', () => {
+  const expectCmyk = (hex: string, cyan: number, magenta: number, yellow: number, key: number) => {
+    const result = hex2PrintingColor(hex, 'cmyk');
+
+    expect(result?.type).toBe('CMYK');
+    const color = result as CMYK;
+    expect(color.cyan).toBeCloseTo(cyan, 5);
+    expect(color.magenta).toBeCloseTo(magenta, 5);
+    expect(color.yellow).toBeCloseTo(yellow, 5);
+    expect(color.key).toBeCloseTo(key, 5);
+  };
+
+  it('should convert black to full key', () => {
+    expectCmyk('#000000', 0, 0, 0, 1);
+  });
+
+  it('should convert white to no ink', () => {
+    expectCmyk('#ffffff', 0, 0, 0, 0);
+  });
+
+  it('should convert RGB primary colors with zero channels', () => {
+    expectCmyk('#ff0000', 0, 1, 1, 0);
+    expectCmyk('#00ff00', 1, 0, 1, 0);
+    expectCmyk('#0000ff', 1, 1, 0, 0);
+  });
+
+  it('should convert CMY secondary colors with zero channels', () => {
+    expectCmyk('#ffff00', 0, 0, 1, 0);
+    expectCmyk('#ff00ff', 0, 1, 0, 0);
+    expectCmyk('#00ffff', 1, 0, 0, 0);
+  });
+
+  it('should convert mixed and gray colors', () => {
+    expectCmyk('#ff8000', 0, 0.498039, 1, 0);
+    expectCmyk('#808080', 0, 0, 0, 0.498039);
   });
 });
 

--- a/packages/schemas/src/utils.ts
+++ b/packages/schemas/src/utils.ts
@@ -136,9 +136,9 @@ const hex2CmykColor = (hexString: string | undefined) => {
 
     // Calculate the CMYK values
     const k = 1 - Math.max(r, g, b);
-    const c = r === 0 ? 0 : (1 - r - k) / (1 - k);
-    const m = g === 0 ? 0 : (1 - g - k) / (1 - k);
-    const y = b === 0 ? 0 : (1 - b - k) / (1 - k);
+    const c = k === 1 ? 0 : (1 - r - k) / (1 - k);
+    const m = k === 1 ? 0 : (1 - g - k) / (1 - k);
+    const y = k === 1 ? 0 : (1 - b - k) / (1 - k);
 
     return cmyk(c, m, y, k);
   }


### PR DESCRIPTION
## Summary
- fix CMYK conversion so the division-by-zero guard checks k === 1 instead of individual RGB channels
- add regression coverage for black, white, RGB primary colors, CMY secondary colors, orange, and gray
- reapply the fix from #1425 on the current main branch because the original PR is failing an unrelated outdated-base CLI manifest check

Refs #1425

## Test
- npm run test -w packages/schemas