### PR TITLE
[codex] Add generic split range metadata

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -99,9 +99,8 @@ layout/builder の考え方を `converter` package の `md2pdf` に応用し、M
 
 残りの検討事項:
 
-- `text`, `multiVariableText`, `list`, `table` の dynamic layout contract は、まず split chunk の
-  範囲表現を `__splitRange: { unit, start, end }` に寄せる。既存の `__bodyRange` /
-  `__itemRange` / `__textLineRange` は renderer の fallback として残し、段階的に移行する。
+- `text`, `multiVariableText`, `list`, `table` の dynamic layout contract は、split chunk の
+  範囲表現を `__splitRange: { unit, start, end }` に一本化する。
 - 長文 text / MVT の段落単位 keep-together や widow/orphan 制御をどこまで扱うか。
 - blank PDF と custom `basePdf` で挙動を分ける必要があるか。
 - 既存テンプレートへの互換性リスクをどう抑えるか。

--- a/PLAN.md
+++ b/PLAN.md
@@ -86,9 +86,10 @@ layout/builder の考え方を `converter` package の `md2pdf` に応用し、M
   `overflow: "expand"` と `dynamicFontSize` は同時利用できないこと、expand では通常の
   `fontSize` を使って高さを広げることを明記する。
 - `multiVariableText` は変数置換後の実描画テキストで高さを測る。
-- ページ末尾を超える場合、text / `multiVariableText` は行単位で `__textLineRange` を持つ
-  split schema に分割し、次ページへ続ける。plain text と inline-markdown は同じ line layout を
-  使い、PDF / UI preview で split chunk が同じ input 全体を重複描画しないようにする。
+- ページ末尾を超える場合、text / `multiVariableText` は行単位で
+  `__splitRange: { unit: "textLine", start, end }` を持つ split schema に分割し、次ページへ続ける。
+  plain text と inline-markdown は同じ line layout を使い、PDF / UI preview で split chunk が
+  同じ input 全体を重複描画しないようにする。
 - `multiVariableText` の split chunk は、変数入力の一部だけを安全に編集・復元する設計が必要なため、
   初回は Form 上では resolved text の read-only 表示にする。変数単位の編集をページ分割後も維持する
   かどうかは、MVT の variable-aware layout と合わせて別途検討する。

--- a/PLAN.md
+++ b/PLAN.md
@@ -99,7 +99,9 @@ layout/builder の考え方を `converter` package の `md2pdf` に応用し、M
 
 残りの検討事項:
 
-- `text`, `multiVariableText`, `list`, `table` の dynamic layout contract を共通化できるか。
+- `text`, `multiVariableText`, `list`, `table` の dynamic layout contract は、まず split chunk の
+  範囲表現を `__splitRange: { unit, start, end }` に寄せる。既存の `__bodyRange` /
+  `__itemRange` / `__textLineRange` は renderer の fallback として残し、段階的に移行する。
 - 長文 text / MVT の段落単位 keep-together や widow/orphan 制御をどこまで扱うか。
 - blank PDF と custom `basePdf` で挙動を分ける必要があるか。
 - 既存テンプレートへの互換性リスクをどう抑えるか。

--- a/packages/common/__tests__/dynamicTemplate.test.ts
+++ b/packages/common/__tests__/dynamicTemplate.test.ts
@@ -336,6 +336,7 @@ describe('getDynamicTemplate', () => {
         getDynamicHeights: async () => ({
           heights: [20, 20, 20],
           patchSplitSchema: ({ start, end, isSplit }) => ({
+            __splitRange: { unit: 'listItem', start, end },
             __itemRange: { start, end },
             __isSplit: isSplit,
             height: 999,
@@ -348,10 +349,20 @@ describe('getDynamicTemplate', () => {
       expect(dynamicTemplate.schemas.length).toBe(2);
       expect(dynamicTemplate.schemas[0][0].height).toBe(20);
       expect(dynamicTemplate.schemas[0][0].position).toEqual({ x: 10, y: 60 });
+      expect(dynamicTemplate.schemas[0][0].__splitRange).toEqual({
+        unit: 'listItem',
+        start: 0,
+        end: 1,
+      });
       expect(dynamicTemplate.schemas[0][0].__itemRange).toEqual({ start: 0, end: 1 });
       expect(dynamicTemplate.schemas[0][0].__isSplit).toBe(false);
       expect(dynamicTemplate.schemas[1][0].height).toBe(40);
       expect(dynamicTemplate.schemas[1][0].position).toEqual({ x: 10, y: 10 });
+      expect(dynamicTemplate.schemas[1][0].__splitRange).toEqual({
+        unit: 'listItem',
+        start: 1,
+        end: 3,
+      });
       expect(dynamicTemplate.schemas[1][0].__itemRange).toEqual({ start: 1, end: 3 });
       expect(dynamicTemplate.schemas[1][0].__isSplit).toBe(true);
     });

--- a/packages/common/__tests__/dynamicTemplate.test.ts
+++ b/packages/common/__tests__/dynamicTemplate.test.ts
@@ -337,7 +337,6 @@ describe('getDynamicTemplate', () => {
           heights: [20, 20, 20],
           patchSplitSchema: ({ start, end, isSplit }) => ({
             __splitRange: { unit: 'listItem', start, end },
-            __itemRange: { start, end },
             __isSplit: isSplit,
             height: 999,
             position: { x: 999, y: 999 },
@@ -354,7 +353,6 @@ describe('getDynamicTemplate', () => {
         start: 0,
         end: 1,
       });
-      expect(dynamicTemplate.schemas[0][0].__itemRange).toEqual({ start: 0, end: 1 });
       expect(dynamicTemplate.schemas[0][0].__isSplit).toBe(false);
       expect(dynamicTemplate.schemas[1][0].height).toBe(40);
       expect(dynamicTemplate.schemas[1][0].position).toEqual({ x: 10, y: 10 });
@@ -363,7 +361,6 @@ describe('getDynamicTemplate', () => {
         start: 1,
         end: 3,
       });
-      expect(dynamicTemplate.schemas[1][0].__itemRange).toEqual({ start: 1, end: 3 });
       expect(dynamicTemplate.schemas[1][0].__isSplit).toBe(true);
     });
 

--- a/packages/common/__tests__/splitRange.test.ts
+++ b/packages/common/__tests__/splitRange.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'vitest';
+import { createDynamicLayoutSplitRange, getDynamicLayoutSplitRange } from '../src/index.js';
+
+describe('dynamic layout split range', () => {
+  test('creates a generic split range', () => {
+    expect(createDynamicLayoutSplitRange('textLine', 1, 3)).toEqual({
+      unit: 'textLine',
+      start: 1,
+      end: 3,
+    });
+  });
+
+  test('reads matching ranges and falls back for non-matching units', () => {
+    const schema = {
+      __splitRange: { unit: 'textLine', start: 2, end: 4 },
+    };
+    const fallback = { start: 0, end: 1 };
+
+    expect(getDynamicLayoutSplitRange(schema, 'textLine', fallback)).toEqual({
+      start: 2,
+      end: 4,
+    });
+    expect(getDynamicLayoutSplitRange(schema, 'listItem', fallback)).toEqual(fallback);
+  });
+});

--- a/packages/common/__tests__/splitRange.test.ts
+++ b/packages/common/__tests__/splitRange.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { createDynamicLayoutSplitRange, getDynamicLayoutSplitRange } from '../src/index.js';
+import { Schema } from '../src/schema.js';
 
 describe('dynamic layout split range', () => {
   test('creates a generic split range', () => {
@@ -10,16 +11,29 @@ describe('dynamic layout split range', () => {
     });
   });
 
-  test('reads matching ranges and falls back for non-matching units', () => {
+  test('reads matching ranges and ignores non-matching units', () => {
     const schema = {
       __splitRange: { unit: 'textLine', start: 2, end: 4 },
     };
-    const fallback = { start: 0, end: 1 };
 
-    expect(getDynamicLayoutSplitRange(schema, 'textLine', fallback)).toEqual({
+    expect(getDynamicLayoutSplitRange(schema, 'textLine')).toEqual({
       start: 2,
       end: 4,
     });
-    expect(getDynamicLayoutSplitRange(schema, 'listItem', fallback)).toEqual(fallback);
+    expect(getDynamicLayoutSplitRange(schema, 'listItem')).toBeUndefined();
+  });
+
+  test('requires non-empty split range units', () => {
+    const result = Schema.safeParse({
+      name: 'field',
+      type: 'text',
+      content: '',
+      position: { x: 0, y: 0 },
+      width: 10,
+      height: 10,
+      __splitRange: { unit: '', start: 0 },
+    });
+
+    expect(result.success).toBe(false);
   });
 });

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -27,6 +27,8 @@ import type {
   SchemaForUI,
   Font,
   ColorType,
+  DynamicLayoutRange,
+  DynamicLayoutSplitRange,
   BasePdf,
   BlankPdf,
   CustomPdf,
@@ -81,6 +83,7 @@ import {
 } from './helper.js';
 import { PAGE_SIZE_PRESETS, detectPaperSize, resolvePageSize } from './pageSize.js';
 import { getDynamicTemplate } from './dynamicTemplate.js';
+import { createDynamicLayoutSplitRange, getDynamicLayoutSplitRange } from './splitRange.js';
 import { replacePlaceholders } from './expression.js';
 import { pluginRegistry } from './pluginRegistry.js';
 
@@ -129,6 +132,8 @@ export {
   PAGE_SIZE_PRESETS,
   detectPaperSize,
   resolvePageSize,
+  createDynamicLayoutSplitRange,
+  getDynamicLayoutSplitRange,
 };
 
 export type {
@@ -139,6 +144,8 @@ export type {
   SchemaForUI,
   Font,
   ColorType,
+  DynamicLayoutRange,
+  DynamicLayoutSplitRange,
   BasePdf,
   BlankPdf,
   CustomPdf,

--- a/packages/common/src/schema.ts
+++ b/packages/common/src/schema.ts
@@ -143,9 +143,6 @@ export const Schema = z
     readOnly: z.boolean().optional(),
     required: z.boolean().optional(),
     __splitRange: DynamicLayoutSplitRange.optional(),
-    __bodyRange: z.object({ start: z.number(), end: z.number().optional() }).optional(),
-    __itemRange: z.object({ start: z.number(), end: z.number().optional() }).optional(),
-    __textLineRange: z.object({ start: z.number(), end: z.number().optional() }).optional(),
     __isSplit: z.boolean().optional(),
   })
   .passthrough();

--- a/packages/common/src/schema.ts
+++ b/packages/common/src/schema.ts
@@ -125,7 +125,7 @@ export const ColorType = z.enum(['rgb', 'cmyk']).optional();
 export const Size = z.object({ height: z.number(), width: z.number() });
 
 export const DynamicLayoutSplitRange = z.object({
-  unit: z.string(),
+  unit: z.string().min(1),
   start: z.number(),
   end: z.number().optional(),
 });

--- a/packages/common/src/schema.ts
+++ b/packages/common/src/schema.ts
@@ -124,6 +124,12 @@ export const ColorType = z.enum(['rgb', 'cmyk']).optional();
 
 export const Size = z.object({ height: z.number(), width: z.number() });
 
+export const DynamicLayoutSplitRange = z.object({
+  unit: z.string(),
+  start: z.number(),
+  end: z.number().optional(),
+});
+
 export const Schema = z
   .object({
     name: z.string(),
@@ -136,6 +142,7 @@ export const Schema = z
     opacity: z.number().optional(),
     readOnly: z.boolean().optional(),
     required: z.boolean().optional(),
+    __splitRange: DynamicLayoutSplitRange.optional(),
     __bodyRange: z.object({ start: z.number(), end: z.number().optional() }).optional(),
     __itemRange: z.object({ start: z.number(), end: z.number().optional() }).optional(),
     __textLineRange: z.object({ start: z.number(), end: z.number().optional() }).optional(),

--- a/packages/common/src/splitRange.ts
+++ b/packages/common/src/splitRange.ts
@@ -13,10 +13,9 @@ export const createDynamicLayoutSplitRange = (
 export const getDynamicLayoutSplitRange = (
   schema: { __splitRange?: DynamicLayoutSplitRange },
   unit: string,
-  fallback?: DynamicLayoutRange,
 ): DynamicLayoutRange | undefined => {
   const range = schema.__splitRange;
-  if (range?.unit !== unit) return fallback;
+  if (range?.unit !== unit) return undefined;
 
   return {
     start: range.start,

--- a/packages/common/src/splitRange.ts
+++ b/packages/common/src/splitRange.ts
@@ -1,0 +1,25 @@
+import type { DynamicLayoutRange, DynamicLayoutSplitRange } from './types.js';
+
+export const createDynamicLayoutSplitRange = (
+  unit: string,
+  start: number,
+  end?: number,
+): DynamicLayoutSplitRange => ({
+  unit,
+  start,
+  ...(end === undefined ? {} : { end }),
+});
+
+export const getDynamicLayoutSplitRange = (
+  schema: { __splitRange?: DynamicLayoutSplitRange },
+  unit: string,
+  fallback?: DynamicLayoutRange,
+): DynamicLayoutRange | undefined => {
+  const range = schema.__splitRange;
+  if (range?.unit !== unit) return fallback;
+
+  return {
+    start: range.start,
+    ...(range.end === undefined ? {} : { end: range.end }),
+  };
+};

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -5,6 +5,7 @@ import {
   Dict,
   Mode,
   Size,
+  DynamicLayoutSplitRange,
   Schema,
   Font,
   SchemaForUI,
@@ -223,6 +224,8 @@ export type Lang = z.infer<typeof Lang>;
 export type Dict = z.infer<typeof Dict>;
 export type Mode = z.infer<typeof Mode>;
 export type Size = z.infer<typeof Size>;
+export type DynamicLayoutSplitRange = z.infer<typeof DynamicLayoutSplitRange>;
+export type DynamicLayoutRange = Omit<DynamicLayoutSplitRange, 'unit'>;
 export type Schema = z.infer<typeof Schema>;
 export type SchemaForUI = z.infer<typeof SchemaForUI>;
 

--- a/packages/generator/__tests__/generate.test.ts
+++ b/packages/generator/__tests__/generate.test.ts
@@ -205,12 +205,13 @@ describe('generate integrate test', () => {
       });
 
       const bodySchemas = renderedSchemas.filter((schema) => schema.name === 'body');
-      const firstRange = bodySchemas[0].__textLineRange;
+      const firstRange = bodySchemas[0].__splitRange;
       expect(bodySchemas.length).toBeGreaterThan(1);
+      expect(firstRange?.unit).toBe('textLine');
       expect(firstRange?.start).toBe(0);
       expect(firstRange?.end).toBeGreaterThan(0);
       expect(bodySchemas[0].__isSplit).toBe(false);
-      expect(bodySchemas[1].__textLineRange?.start).toBe(firstRange?.end);
+      expect(bodySchemas[1].__splitRange?.start).toBe(firstRange?.end);
       expect(bodySchemas[1].__isSplit).toBe(true);
       expect(bodySchemas[1].position.y).toBe(10);
     });

--- a/packages/schemas/__tests__/list.test.ts
+++ b/packages/schemas/__tests__/list.test.ts
@@ -161,7 +161,6 @@ describe('list schema helpers', () => {
       }),
     ).toEqual({
       __splitRange: { unit: 'listItem', start: 1, end: 3 },
-      __itemRange: { start: 1, end: 3 },
       __isSplit: true,
     });
   });

--- a/packages/schemas/__tests__/list.test.ts
+++ b/packages/schemas/__tests__/list.test.ts
@@ -160,6 +160,7 @@ describe('list schema helpers', () => {
         chunkHeight: 10,
       }),
     ).toEqual({
+      __splitRange: { unit: 'listItem', start: 1, end: 3 },
       __itemRange: { start: 1, end: 3 },
       __isSplit: true,
     });

--- a/packages/schemas/__tests__/list.ui.test.ts
+++ b/packages/schemas/__tests__/list.ui.test.ts
@@ -106,7 +106,7 @@ describe('list UI rendering', () => {
 
     await uiRender({
       value: listValue(['One', 'Two', 'Three', 'Four']),
-      schema: getListSchema({ __itemRange: { start: 1, end: 3 } }),
+      schema: getListSchema({ __splitRange: { unit: 'listItem', start: 1, end: 3 } }),
       rootElement,
       mode: 'form',
       onChange,

--- a/packages/schemas/__tests__/list.ui.test.ts
+++ b/packages/schemas/__tests__/list.ui.test.ts
@@ -83,7 +83,7 @@ describe('list UI rendering', () => {
 
     await uiRender({
       value: listValue(['One', 'Two', 'Three', 'Four']),
-      schema: getListSchema({ __itemRange: { start: 1, end: 3 } }),
+      schema: getListSchema({ __splitRange: { unit: 'listItem', start: 1, end: 3 } }),
       rootElement,
       mode: 'viewer',
       options: { font },

--- a/packages/schemas/__tests__/multiVariableText.ui.test.ts
+++ b/packages/schemas/__tests__/multiVariableText.ui.test.ts
@@ -128,7 +128,7 @@ describe('multiVariableText inline markdown UI rendering', () => {
       variables: ['name'],
       textFormat: 'plain',
       width: 100,
-      __textLineRange: { start: 0, end: 1 },
+      __splitRange: { unit: 'textLine', start: 0, end: 1 },
     };
 
     await uiRender({

--- a/packages/schemas/__tests__/splitRange.test.ts
+++ b/packages/schemas/__tests__/splitRange.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'vitest';
+import {
+  BUILT_IN_DYNAMIC_LAYOUT_SPLIT_UNITS,
+  LIST_ITEM_SPLIT_UNIT,
+  TABLE_BODY_SPLIT_UNIT,
+  TEXT_LINE_SPLIT_UNIT,
+  createListItemSplitRange,
+  createTableBodySplitRange,
+  createTextLineSplitRange,
+  getListItemRange,
+  getTableBodyRange,
+  getTextLineRange,
+} from '../src/splitRange.js';
+
+const getSchema = (__splitRange: ReturnType<typeof createTextLineSplitRange>) => ({
+  name: 'field',
+  type: 'text',
+  content: '',
+  position: { x: 0, y: 0 },
+  width: 10,
+  height: 10,
+  __splitRange,
+});
+
+describe('schema split range helpers', () => {
+  test('exposes typed built-in split units', () => {
+    expect(BUILT_IN_DYNAMIC_LAYOUT_SPLIT_UNITS).toEqual({
+      tableBody: TABLE_BODY_SPLIT_UNIT,
+      listItem: LIST_ITEM_SPLIT_UNIT,
+      textLine: TEXT_LINE_SPLIT_UNIT,
+    });
+  });
+
+  test('creates split ranges with schema-specific units', () => {
+    expect(createTableBodySplitRange(1, 3)).toEqual({
+      unit: TABLE_BODY_SPLIT_UNIT,
+      start: 1,
+      end: 3,
+    });
+    expect(createListItemSplitRange(2, 4)).toEqual({
+      unit: LIST_ITEM_SPLIT_UNIT,
+      start: 2,
+      end: 4,
+    });
+    expect(createTextLineSplitRange(5)).toEqual({
+      unit: TEXT_LINE_SPLIT_UNIT,
+      start: 5,
+    });
+  });
+
+  test('reads only matching split range units', () => {
+    const tableSchema = getSchema(createTableBodySplitRange(1, 3));
+    const listSchema = getSchema(createListItemSplitRange(2, 4));
+    const textSchema = getSchema(createTextLineSplitRange(5, 8));
+
+    expect(getTableBodyRange(tableSchema)).toEqual({ start: 1, end: 3 });
+    expect(getListItemRange(listSchema)).toEqual({ start: 2, end: 4 });
+    expect(getTextLineRange(textSchema)).toEqual({ start: 5, end: 8 });
+    expect(getTableBodyRange(textSchema)).toBeUndefined();
+    expect(getTextLineRange(listSchema)).toBeUndefined();
+  });
+});

--- a/packages/schemas/__tests__/text.test.ts
+++ b/packages/schemas/__tests__/text.test.ts
@@ -349,6 +349,7 @@ describe('text dynamic layout', () => {
       }),
     ).toEqual({
       dynamicFontSize: undefined,
+      __splitRange: { unit: 'textLine', start: 0, end: 1 },
       __textLineRange: { start: 0, end: 1 },
       __isSplit: false,
     });
@@ -378,6 +379,7 @@ describe('text dynamic layout', () => {
       }),
     ).toEqual({
       dynamicFontSize: undefined,
+      __splitRange: { unit: 'textLine', start: 1, end: 3 },
       __textLineRange: { start: 1, end: 3 },
       __isSplit: true,
     });
@@ -388,7 +390,7 @@ describe('text dynamic layout', () => {
       ...getTextSchema(),
       width: 20,
       overflow: 'expand',
-      __textLineRange: { start: 1, end: 3 },
+      __splitRange: { unit: 'textLine', start: 1, end: 3 },
     } as TextSchema;
 
     const result = await mergeTextLineRangeValue({

--- a/packages/schemas/__tests__/text.test.ts
+++ b/packages/schemas/__tests__/text.test.ts
@@ -350,7 +350,6 @@ describe('text dynamic layout', () => {
     ).toEqual({
       dynamicFontSize: undefined,
       __splitRange: { unit: 'textLine', start: 0, end: 1 },
-      __textLineRange: { start: 0, end: 1 },
       __isSplit: false,
     });
   });
@@ -380,7 +379,6 @@ describe('text dynamic layout', () => {
     ).toEqual({
       dynamicFontSize: undefined,
       __splitRange: { unit: 'textLine', start: 1, end: 3 },
-      __textLineRange: { start: 1, end: 3 },
       __isSplit: true,
     });
   });

--- a/packages/schemas/__tests__/text.ui.test.ts
+++ b/packages/schemas/__tests__/text.ui.test.ts
@@ -162,7 +162,7 @@ describe('text inline markdown UI rendering', () => {
       ...getTextSchema(),
       readOnly: false,
       width: 20,
-      __textLineRange: { start: 0, end: 1 },
+      __splitRange: { unit: 'textLine', start: 0, end: 1 },
     };
     const font = {
       Base: { data: new Uint8Array(), fallback: true },

--- a/packages/schemas/src/dynamicLayout.ts
+++ b/packages/schemas/src/dynamicLayout.ts
@@ -5,6 +5,20 @@ import { getDynamicLayoutForTable } from './tables/dynamicTemplate.js';
 import { TEXT_OVERFLOW_EXPAND } from './text/constants.js';
 import { getDynamicLayoutForText } from './text/dynamicTemplate.js';
 
+export {
+  BUILT_IN_DYNAMIC_LAYOUT_SPLIT_UNITS,
+  LIST_ITEM_SPLIT_UNIT,
+  TABLE_BODY_SPLIT_UNIT,
+  TEXT_LINE_SPLIT_UNIT,
+  createListItemSplitRange,
+  createTableBodySplitRange,
+  createTextLineSplitRange,
+  getListItemRange,
+  getTableBodyRange,
+  getTextLineRange,
+  type BuiltInDynamicLayoutSplitUnit,
+} from './splitRange.js';
+
 const isExpandableTextSchema = (schema: Schema) =>
   (schema.type === 'text' || schema.type === 'multiVariableText') &&
   (schema as { overflow?: unknown }).overflow === TEXT_OVERFLOW_EXPAND;

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -40,3 +40,16 @@ export {
 // Export utility functions
 export { getDynamicHeightsForTable, getDynamicLayoutForTable } from './tables.js';
 export { getDynamicLayoutForList } from './lists.js';
+export {
+  BUILT_IN_DYNAMIC_LAYOUT_SPLIT_UNITS,
+  LIST_ITEM_SPLIT_UNIT,
+  TABLE_BODY_SPLIT_UNIT,
+  TEXT_LINE_SPLIT_UNIT,
+  createListItemSplitRange,
+  createTableBodySplitRange,
+  createTextLineSplitRange,
+  getListItemRange,
+  getTableBodyRange,
+  getTextLineRange,
+  type BuiltInDynamicLayoutSplitUnit,
+} from './splitRange.js';

--- a/packages/schemas/src/list/dynamicTemplate.ts
+++ b/packages/schemas/src/list/dynamicTemplate.ts
@@ -1,6 +1,7 @@
 import type { DynamicLayoutArgs, DynamicLayoutResult } from '@pdfme/common';
 import type { ListSchema } from './types.js';
 import { calculateListLayout, normalizeListItems } from './helper.js';
+import { createListItemSplitRange } from '../splitRange.js';
 
 export const getDynamicLayoutForList = async (
   value: string,
@@ -24,6 +25,7 @@ export const getDynamicLayoutForList = async (
     heights: layout.items.map((item) => item.height),
     avoidFirstUnitOnly: false,
     patchSplitSchema: ({ start, end, isSplit }) => ({
+      __splitRange: createListItemSplitRange(start, end),
       __itemRange: { start, end },
       __isSplit: isSplit,
     }),

--- a/packages/schemas/src/list/dynamicTemplate.ts
+++ b/packages/schemas/src/list/dynamicTemplate.ts
@@ -26,7 +26,6 @@ export const getDynamicLayoutForList = async (
     avoidFirstUnitOnly: false,
     patchSplitSchema: ({ start, end, isSplit }) => ({
       __splitRange: createListItemSplitRange(start, end),
-      __itemRange: { start, end },
       __isSplit: isSplit,
     }),
   };

--- a/packages/schemas/src/list/pdfRender.ts
+++ b/packages/schemas/src/list/pdfRender.ts
@@ -3,13 +3,14 @@ import type { ListSchema } from './types.js';
 import { pdfRender as textPdfRender } from '../text/pdfRender.js';
 import { rectangle } from '../shapes/rectAndEllipse.js';
 import { calculateListLayout, normalizeListItems } from './helper.js';
+import { getListItemRange } from '../splitRange.js';
 
 const rectanglePdfRender = rectangle.pdf;
 
 export const pdfRender = async (arg: PDFRenderProps<ListSchema>) => {
   const { schema, value } = arg;
   const items = normalizeListItems(value);
-  const range = schema.__itemRange ?? { start: 0, end: items.length };
+  const range = getListItemRange(schema) ?? { start: 0, end: items.length };
   const visibleItems = items.slice(range.start, range.end);
 
   if (visibleItems.length === 0) return;

--- a/packages/schemas/src/list/types.ts
+++ b/packages/schemas/src/list/types.ts
@@ -1,9 +1,6 @@
-import type { DynamicLayoutRange } from '@pdfme/common';
 import type { TextSchema } from '../text/types.js';
 
 export type LIST_STYLE = 'bullet' | 'ordered';
-
-export type ListRange = DynamicLayoutRange;
 
 export type ListSchema = TextSchema & {
   listStyle: LIST_STYLE;
@@ -11,7 +8,6 @@ export type ListSchema = TextSchema & {
   markerGap: number;
   indentSize?: number;
   itemSpacing: number;
-  __itemRange?: ListRange;
 };
 
 export type ListItem = {

--- a/packages/schemas/src/list/types.ts
+++ b/packages/schemas/src/list/types.ts
@@ -1,11 +1,9 @@
+import type { DynamicLayoutRange } from '@pdfme/common';
 import type { TextSchema } from '../text/types.js';
 
 export type LIST_STYLE = 'bullet' | 'ordered';
 
-export type ListRange = {
-  start: number;
-  end?: number;
-};
+export type ListRange = DynamicLayoutRange;
 
 export type ListSchema = TextSchema & {
   listStyle: LIST_STYLE;

--- a/packages/schemas/src/list/uiRender.ts
+++ b/packages/schemas/src/list/uiRender.ts
@@ -1,6 +1,7 @@
 import type * as CSS from 'csstype';
 import { UIRenderProps } from '@pdfme/common';
 import { isEditable } from '../utils.js';
+import { getListItemRange } from '../splitRange.js';
 import { uiRender as textUiRender } from '../text/uiRender.js';
 import {
   DEFAULT_ALIGNMENT,
@@ -179,7 +180,7 @@ export const uiRender = async (arg: UIRenderProps<ListSchema>) => {
   const sourceValue = usePlaceholder ? placeholder || '' : value;
   const items = normalizeListItems(sourceValue);
   const originalItems = normalizeListItemEntries(value);
-  const range = schema.__itemRange ?? { start: 0, end: items.length };
+  const range = getListItemRange(schema) ?? { start: 0, end: items.length };
   const visibleItems = items.slice(range.start, range.end);
   const renderItems = visibleItems;
 

--- a/packages/schemas/src/lists.ts
+++ b/packages/schemas/src/lists.ts
@@ -1,4 +1,5 @@
 export { getDynamicLayoutForList } from './list/dynamicTemplate.js';
+export { createListItemSplitRange, getListItemRange, LIST_ITEM_SPLIT_UNIT } from './splitRange.js';
 export {
   normalizeListItems,
   normalizeListItemEntries,

--- a/packages/schemas/src/lists.ts
+++ b/packages/schemas/src/lists.ts
@@ -6,11 +6,4 @@ export {
   getListMarkers,
   calculateListLayout,
 } from './list/helper.js';
-export type {
-  ListItem,
-  ListSchema,
-  ListLayout,
-  ListItemLayout,
-  ListRange,
-  LIST_STYLE,
-} from './list/types.js';
+export type { ListItem, ListSchema, ListLayout, ListItemLayout, LIST_STYLE } from './list/types.js';

--- a/packages/schemas/src/multiVariableText/dynamicTemplate.ts
+++ b/packages/schemas/src/multiVariableText/dynamicTemplate.ts
@@ -54,7 +54,6 @@ export const getDynamicLayoutForMultiVariableText = async (
     patchSplitSchema: ({ start, end, isSplit }) => ({
       dynamicFontSize: undefined,
       __splitRange: lineHeights.length === 1 ? undefined : createTextLineSplitRange(start, end),
-      __textLineRange: lineHeights.length === 1 ? undefined : { start, end },
       __isSplit: isSplit,
     }),
   };

--- a/packages/schemas/src/multiVariableText/dynamicTemplate.ts
+++ b/packages/schemas/src/multiVariableText/dynamicTemplate.ts
@@ -8,6 +8,7 @@ import {
   substituteVariablesAsInlineMarkdownLiterals,
   validateVariables,
 } from './helper.js';
+import { createTextLineSplitRange } from '../splitRange.js';
 
 export const getDynamicLayoutForMultiVariableText = async (
   value: string,
@@ -52,6 +53,7 @@ export const getDynamicLayoutForMultiVariableText = async (
     heights: lineHeights.length === 1 ? [Math.max(schema.height, measuredHeight)] : lineHeights,
     patchSplitSchema: ({ start, end, isSplit }) => ({
       dynamicFontSize: undefined,
+      __splitRange: lineHeights.length === 1 ? undefined : createTextLineSplitRange(start, end),
       __textLineRange: lineHeights.length === 1 ? undefined : { start, end },
       __isSplit: isSplit,
     }),

--- a/packages/schemas/src/multiVariableText/uiRender.ts
+++ b/packages/schemas/src/multiVariableText/uiRender.ts
@@ -13,6 +13,7 @@ import { isInlineMarkdownTextSchema, resolveFontVariant } from '../text/richText
 import type { RichTextRun } from '../text/types.js';
 import { substituteVariables, substituteVariablesAsInlineMarkdownLiterals } from './helper.js';
 import { countUniqueVariableNames, visitVariables } from './variables.js';
+import { getTextLineRange } from '../splitRange.js';
 
 export const uiRender = async (arg: UIRenderProps<MultiVariableTextSchema>) => {
   const { value, schema, rootElement, mode, onChange, ...rest } = arg;
@@ -28,7 +29,7 @@ export const uiRender = async (arg: UIRenderProps<MultiVariableTextSchema>) => {
       : substituteVariables(text, value);
 
   if (mode === 'form' && numVariables > 0 && !renderResolvedValue) {
-    if (schema.__textLineRange) {
+    if (getTextLineRange(schema)) {
       await parentUiRender({
         value: renderValue,
         schema,

--- a/packages/schemas/src/splitRange.ts
+++ b/packages/schemas/src/splitRange.ts
@@ -10,12 +10,6 @@ export const TABLE_BODY_SPLIT_UNIT = 'tableBody';
 export const LIST_ITEM_SPLIT_UNIT = 'listItem';
 export const TEXT_LINE_SPLIT_UNIT = 'textLine';
 
-type SchemaWithLegacyRange = Schema & {
-  __bodyRange?: DynamicLayoutRange;
-  __itemRange?: DynamicLayoutRange;
-  __textLineRange?: DynamicLayoutRange;
-};
-
 export const createTableBodySplitRange = (start: number, end?: number): DynamicLayoutSplitRange =>
   createDynamicLayoutSplitRange(TABLE_BODY_SPLIT_UNIT, start, end);
 
@@ -25,11 +19,11 @@ export const createListItemSplitRange = (start: number, end?: number): DynamicLa
 export const createTextLineSplitRange = (start: number, end?: number): DynamicLayoutSplitRange =>
   createDynamicLayoutSplitRange(TEXT_LINE_SPLIT_UNIT, start, end);
 
-export const getTableBodyRange = (schema: SchemaWithLegacyRange) =>
-  getDynamicLayoutSplitRange(schema, TABLE_BODY_SPLIT_UNIT, schema.__bodyRange);
+export const getTableBodyRange = (schema: Schema): DynamicLayoutRange | undefined =>
+  getDynamicLayoutSplitRange(schema, TABLE_BODY_SPLIT_UNIT);
 
-export const getListItemRange = (schema: SchemaWithLegacyRange) =>
-  getDynamicLayoutSplitRange(schema, LIST_ITEM_SPLIT_UNIT, schema.__itemRange);
+export const getListItemRange = (schema: Schema): DynamicLayoutRange | undefined =>
+  getDynamicLayoutSplitRange(schema, LIST_ITEM_SPLIT_UNIT);
 
-export const getTextLineRange = (schema: SchemaWithLegacyRange) =>
-  getDynamicLayoutSplitRange(schema, TEXT_LINE_SPLIT_UNIT, schema.__textLineRange);
+export const getTextLineRange = (schema: Schema): DynamicLayoutRange | undefined =>
+  getDynamicLayoutSplitRange(schema, TEXT_LINE_SPLIT_UNIT);

--- a/packages/schemas/src/splitRange.ts
+++ b/packages/schemas/src/splitRange.ts
@@ -1,0 +1,35 @@
+import {
+  createDynamicLayoutSplitRange,
+  getDynamicLayoutSplitRange,
+  type DynamicLayoutRange,
+  type DynamicLayoutSplitRange,
+  type Schema,
+} from '@pdfme/common';
+
+export const TABLE_BODY_SPLIT_UNIT = 'tableBody';
+export const LIST_ITEM_SPLIT_UNIT = 'listItem';
+export const TEXT_LINE_SPLIT_UNIT = 'textLine';
+
+type SchemaWithLegacyRange = Schema & {
+  __bodyRange?: DynamicLayoutRange;
+  __itemRange?: DynamicLayoutRange;
+  __textLineRange?: DynamicLayoutRange;
+};
+
+export const createTableBodySplitRange = (start: number, end?: number): DynamicLayoutSplitRange =>
+  createDynamicLayoutSplitRange(TABLE_BODY_SPLIT_UNIT, start, end);
+
+export const createListItemSplitRange = (start: number, end?: number): DynamicLayoutSplitRange =>
+  createDynamicLayoutSplitRange(LIST_ITEM_SPLIT_UNIT, start, end);
+
+export const createTextLineSplitRange = (start: number, end?: number): DynamicLayoutSplitRange =>
+  createDynamicLayoutSplitRange(TEXT_LINE_SPLIT_UNIT, start, end);
+
+export const getTableBodyRange = (schema: SchemaWithLegacyRange) =>
+  getDynamicLayoutSplitRange(schema, TABLE_BODY_SPLIT_UNIT, schema.__bodyRange);
+
+export const getListItemRange = (schema: SchemaWithLegacyRange) =>
+  getDynamicLayoutSplitRange(schema, LIST_ITEM_SPLIT_UNIT, schema.__itemRange);
+
+export const getTextLineRange = (schema: SchemaWithLegacyRange) =>
+  getDynamicLayoutSplitRange(schema, TEXT_LINE_SPLIT_UNIT, schema.__textLineRange);

--- a/packages/schemas/src/splitRange.ts
+++ b/packages/schemas/src/splitRange.ts
@@ -6,9 +6,20 @@ import {
   type Schema,
 } from '@pdfme/common';
 
-export const TABLE_BODY_SPLIT_UNIT = 'tableBody';
-export const LIST_ITEM_SPLIT_UNIT = 'listItem';
-export const TEXT_LINE_SPLIT_UNIT = 'textLine';
+// Keep the common schema open for external plugin units while exposing the built-in units as
+// typed constants for pdfme's bundled dynamic layout schemas.
+export const BUILT_IN_DYNAMIC_LAYOUT_SPLIT_UNITS = {
+  tableBody: 'tableBody',
+  listItem: 'listItem',
+  textLine: 'textLine',
+} as const;
+
+export type BuiltInDynamicLayoutSplitUnit =
+  (typeof BUILT_IN_DYNAMIC_LAYOUT_SPLIT_UNITS)[keyof typeof BUILT_IN_DYNAMIC_LAYOUT_SPLIT_UNITS];
+
+export const TABLE_BODY_SPLIT_UNIT = BUILT_IN_DYNAMIC_LAYOUT_SPLIT_UNITS.tableBody;
+export const LIST_ITEM_SPLIT_UNIT = BUILT_IN_DYNAMIC_LAYOUT_SPLIT_UNITS.listItem;
+export const TEXT_LINE_SPLIT_UNIT = BUILT_IN_DYNAMIC_LAYOUT_SPLIT_UNITS.textLine;
 
 export const createTableBodySplitRange = (start: number, end?: number): DynamicLayoutSplitRange =>
   createDynamicLayoutSplitRange(TABLE_BODY_SPLIT_UNIT, start, end);

--- a/packages/schemas/src/tables.ts
+++ b/packages/schemas/src/tables.ts
@@ -1,1 +1,6 @@
 export { getDynamicHeightsForTable, getDynamicLayoutForTable } from './tables/dynamicTemplate.js';
+export {
+  createTableBodySplitRange,
+  getTableBodyRange,
+  TABLE_BODY_SPLIT_UNIT,
+} from './splitRange.js';

--- a/packages/schemas/src/tables/dynamicTemplate.ts
+++ b/packages/schemas/src/tables/dynamicTemplate.ts
@@ -10,6 +10,7 @@ import {
 import { createSingleTable } from './tableHelper.js';
 import { getBodyWithRange, getBody } from './helper.js';
 import { TableSchema } from './types.js';
+import { createTableBodySplitRange, getTableBodyRange } from '../splitRange.js';
 
 export const getDynamicHeightsForTable = async (
   value: string,
@@ -22,8 +23,8 @@ export const getDynamicHeightsForTable = async (
 ): Promise<number[]> => {
   if (args.schema.type !== 'table') return Promise.resolve([args.schema.height]);
   const schema = args.schema as TableSchema;
-  const body =
-    schema.__bodyRange?.start === 0 ? getBody(value) : getBodyWithRange(value, schema.__bodyRange);
+  const bodyRange = getTableBodyRange(schema);
+  const body = bodyRange?.start === 0 ? getBody(value) : getBodyWithRange(value, bodyRange);
   const table = await createSingleTable(body, args);
 
   const baseHeights = schema.showHead
@@ -104,12 +105,16 @@ export const getDynamicLayoutForTable = async (
   return {
     heights,
     avoidFirstUnitOnly: true,
-    patchSplitSchema: ({ start, end, isSplit }) => ({
-      __bodyRange: {
+    patchSplitSchema: ({ start, end, isSplit }) => {
+      const range = {
         start: start === 0 ? 0 : start - 1,
         end: end - 1,
-      },
-      __isSplit: isSplit,
-    }),
+      };
+      return {
+        __splitRange: createTableBodySplitRange(range.start, range.end),
+        __bodyRange: range,
+        __isSplit: isSplit,
+      };
+    },
   };
 };

--- a/packages/schemas/src/tables/dynamicTemplate.ts
+++ b/packages/schemas/src/tables/dynamicTemplate.ts
@@ -112,7 +112,6 @@ export const getDynamicLayoutForTable = async (
       };
       return {
         __splitRange: createTableBodySplitRange(range.start, range.end),
-        __bodyRange: range,
         __isSplit: isSplit,
       };
     },

--- a/packages/schemas/src/tables/helper.ts
+++ b/packages/schemas/src/tables/helper.ts
@@ -14,6 +14,7 @@ import {
 import { HEX_COLOR_PATTERN } from '../constants.js';
 import type { TableSchema } from './types.js';
 import { getTableBodyRange } from '../splitRange.js';
+import type { DynamicLayoutRange } from '@pdfme/common';
 
 export const getDefaultCellStyles = () => ({
   fontName: undefined,
@@ -208,14 +209,14 @@ export const getBody = (value: string | string[][]): string[][] => {
   return value || [];
 };
 
-export const getBodyWithRange = (
-  value: string | string[][],
-  range?: { start: number; end?: number | undefined },
-) => {
+export const getBodyWithRange = (value: string | string[][], range?: DynamicLayoutRange) => {
   const body = getBody(value);
   if (!range) return body;
   return body.slice(range.start, range.end);
 };
 
-export const getBodyWithSchemaRange = (value: string | string[][], schema: TableSchema) =>
-  getBodyWithRange(value, getTableBodyRange(schema));
+export const getBodyWithSchemaRange = (
+  value: string | string[][],
+  schema: TableSchema,
+  range = getTableBodyRange(schema),
+) => getBodyWithRange(value, range);

--- a/packages/schemas/src/tables/helper.ts
+++ b/packages/schemas/src/tables/helper.ts
@@ -12,6 +12,8 @@ import {
   VERTICAL_ALIGN_BOTTOM,
 } from '../text/constants.js';
 import { HEX_COLOR_PATTERN } from '../constants.js';
+import type { TableSchema } from './types.js';
+import { getTableBodyRange } from '../splitRange.js';
 
 export const getDefaultCellStyles = () => ({
   fontName: undefined,
@@ -214,3 +216,6 @@ export const getBodyWithRange = (
   if (!range) return body;
   return body.slice(range.start, range.end);
 };
+
+export const getBodyWithSchemaRange = (value: string | string[][], schema: TableSchema) =>
+  getBodyWithRange(value, getTableBodyRange(schema));

--- a/packages/schemas/src/tables/pdfRender.ts
+++ b/packages/schemas/src/tables/pdfRender.ts
@@ -3,7 +3,7 @@ import type { PDFRenderProps, Schema, BasePdf, CommonOptions } from '@pdfme/comm
 import { Cell, Table, Row, Column } from './classes.js';
 import { rectangle } from '../shapes/rectAndEllipse.js';
 import cell from './cell.js';
-import { getBodyWithRange } from './helper.js';
+import { getBodyWithSchemaRange } from './helper.js';
 import { createSingleTable } from './tableHelper.js';
 
 // Define the CreateTableArgs interface locally since it's not exported from tableHelper.js
@@ -118,9 +118,9 @@ async function drawTable(arg: PDFRenderProps<TableSchema>, table: Table): Promis
 export const pdfRender = async (arg: PDFRenderProps<TableSchema>) => {
   const { value, schema, basePdf, options, _cache } = arg;
 
-  const body = getBodyWithRange(
+  const body = getBodyWithSchemaRange(
     typeof value !== 'string' ? JSON.stringify(value || '[]') : value,
-    schema.__bodyRange,
+    schema,
   );
 
   // Create a properly typed CreateTableArgs object

--- a/packages/schemas/src/tables/tableHelper.ts
+++ b/packages/schemas/src/tables/tableHelper.ts
@@ -18,6 +18,7 @@ import type {
   Section,
 } from './types.js';
 import { Cell, Column, Row, Table } from './classes.js';
+import { getTableBodyRange } from '../splitRange.js';
 
 type StyleProp = 'styles' | 'headStyles' | 'bodyStyles' | 'alternateRowStyles' | 'columnStyles';
 
@@ -263,7 +264,7 @@ export function createSingleTable(body: string[][], args: CreateTableArgs) {
   }
 
   const schema = cloneDeep(args.schema) as TableSchema;
-  const { start } = schema.__bodyRange || { start: 0 };
+  const { start } = getTableBodyRange(schema) || { start: 0 };
   if (start % 2 === 1) {
     const alternateBackgroundColor = schema.bodyStyles.alternateBackgroundColor;
     schema.bodyStyles.alternateBackgroundColor = schema.bodyStyles.backgroundColor;

--- a/packages/schemas/src/tables/uiRender.ts
+++ b/packages/schemas/src/tables/uiRender.ts
@@ -2,9 +2,10 @@ import type { UIRenderProps, Mode } from '@pdfme/common';
 import type { TableSchema, CellStyle, Styles } from './types.js';
 import { px2mm, ZOOM } from '@pdfme/common';
 import { createSingleTable } from './tableHelper.js';
-import { getBody, getBodyWithRange } from './helper.js';
+import { getBody, getBodyWithSchemaRange } from './helper.js';
 import cell from './cell.js';
 import { Row } from './classes.js';
+import { getTableBodyRange } from '../splitRange.js';
 
 const buttonSize = 18;
 
@@ -189,7 +190,7 @@ const renderRowUi = (args: {
           if (!arg.onChange) return;
           const newValue = (Array.isArray(v) ? v[0].value : v.value) as string;
           if (section === 'body') {
-            const startRange = arg.schema.__bodyRange?.start ?? 0;
+            const startRange = getTableBodyRange(arg.schema)?.start ?? 0;
             value[rowIndex + startRange][colIndex] = newValue;
             arg.onChange({ key: 'content', value: JSON.stringify(value) });
           } else {
@@ -229,7 +230,8 @@ const resetEditingPosition = () => {
 export const uiRender = async (arg: UIRenderProps<TableSchema>) => {
   const { rootElement, onChange, schema, value, mode, scale } = arg;
   const body = getBody(value);
-  const bodyWidthRange = getBodyWithRange(value, schema.__bodyRange);
+  const bodyRange = getTableBodyRange(schema);
+  const bodyWidthRange = getBodyWithSchemaRange(value, schema);
   const table = await createSingleTable(bodyWidthRange, arg);
   const showHead = table.settings.showHead;
 
@@ -291,7 +293,7 @@ export const uiRender = async (arg: UIRenderProps<TableSchema>) => {
         text: '-',
         ariaLabel: 'Remove row',
         onClick: () => {
-          const newTableBody = body.filter((_, j) => j !== i + (schema.__bodyRange?.start ?? 0));
+          const newTableBody = body.filter((_, j) => j !== i + (bodyRange?.start ?? 0));
           if (onChange) onChange({ key: 'content', value: JSON.stringify(newTableBody) });
         },
       });
@@ -301,8 +303,8 @@ export const uiRender = async (arg: UIRenderProps<TableSchema>) => {
 
   if (mode === 'form' && onChange && !schema.readOnly) {
     if (
-      schema.__bodyRange?.end === undefined ||
-      schema.__bodyRange.end >= (JSON.parse(value || '[]') as string[][]).length
+      bodyRange?.end === undefined ||
+      bodyRange.end >= (JSON.parse(value || '[]') as string[][]).length
     ) {
       rootElement.appendChild(createAddRowButton());
     }

--- a/packages/schemas/src/tables/uiRender.ts
+++ b/packages/schemas/src/tables/uiRender.ts
@@ -231,7 +231,7 @@ export const uiRender = async (arg: UIRenderProps<TableSchema>) => {
   const { rootElement, onChange, schema, value, mode, scale } = arg;
   const body = getBody(value);
   const bodyRange = getTableBodyRange(schema);
-  const bodyWidthRange = getBodyWithSchemaRange(value, schema);
+  const bodyWidthRange = getBodyWithSchemaRange(value, schema, bodyRange);
   const table = await createSingleTable(bodyWidthRange, arg);
   const showHead = table.settings.showHead;
 

--- a/packages/schemas/src/text/dynamicTemplate.ts
+++ b/packages/schemas/src/text/dynamicTemplate.ts
@@ -2,6 +2,7 @@ import type { DynamicLayoutArgs, DynamicLayoutResult } from '@pdfme/common';
 import { TEXT_OVERFLOW_EXPAND } from './constants.js';
 import { measureTextLines, sumLineHeights } from './measure.js';
 import type { TextSchema } from './types.js';
+import { createTextLineSplitRange } from '../splitRange.js';
 
 export const getDynamicLayoutForText = async (
   value: string,
@@ -36,6 +37,7 @@ export const getDynamicLayoutForText = async (
     heights: lineHeights.length === 1 ? [Math.max(schema.height, measuredHeight)] : lineHeights,
     patchSplitSchema: ({ start, end, isSplit }) => ({
       dynamicFontSize: undefined,
+      __splitRange: lineHeights.length === 1 ? undefined : createTextLineSplitRange(start, end),
       __textLineRange: lineHeights.length === 1 ? undefined : { start, end },
       __isSplit: isSplit,
     }),

--- a/packages/schemas/src/text/dynamicTemplate.ts
+++ b/packages/schemas/src/text/dynamicTemplate.ts
@@ -38,7 +38,6 @@ export const getDynamicLayoutForText = async (
     patchSplitSchema: ({ start, end, isSplit }) => ({
       dynamicFontSize: undefined,
       __splitRange: lineHeights.length === 1 ? undefined : createTextLineSplitRange(start, end),
-      __textLineRange: lineHeights.length === 1 ? undefined : { start, end },
       __isSplit: isSplit,
     }),
   };

--- a/packages/schemas/src/text/measure.ts
+++ b/packages/schemas/src/text/measure.ts
@@ -15,7 +15,7 @@ import {
   resolveRichTextRuns,
   type RichTextLine,
 } from './richText.js';
-import type { TextLineRange, TextSchema } from './types.js';
+import type { TextSchema } from './types.js';
 import { getTextLineRange } from '../splitRange.js';
 
 type MeasureTextHeightArgs = {
@@ -31,7 +31,7 @@ type MeasureTextLinesResult = {
   lineHeights: number[];
 };
 
-export const applyTextLineRange = <T>(lines: T[], range?: TextLineRange) => {
+export const applyTextLineRange = <T>(lines: T[], range?: { start: number; end?: number }) => {
   if (!range) return lines;
   return lines.slice(range.start, range.end ?? lines.length);
 };

--- a/packages/schemas/src/text/measure.ts
+++ b/packages/schemas/src/text/measure.ts
@@ -1,4 +1,4 @@
-import { getDefaultFont, mm2pt, pt2mm, type Font } from '@pdfme/common';
+import { getDefaultFont, mm2pt, pt2mm, type DynamicLayoutRange, type Font } from '@pdfme/common';
 import type { Font as FontKitFont } from 'fontkit';
 import { DEFAULT_CHARACTER_SPACING, DEFAULT_FONT_SIZE, DEFAULT_LINE_HEIGHT } from './constants.js';
 import {
@@ -31,7 +31,7 @@ type MeasureTextLinesResult = {
   lineHeights: number[];
 };
 
-export const applyTextLineRange = <T>(lines: T[], range?: { start: number; end?: number }) => {
+export const applyTextLineRange = <T>(lines: T[], range?: DynamicLayoutRange) => {
   if (!range) return lines;
   return lines.slice(range.start, range.end ?? lines.length);
 };

--- a/packages/schemas/src/text/measure.ts
+++ b/packages/schemas/src/text/measure.ts
@@ -16,6 +16,7 @@ import {
   type RichTextLine,
 } from './richText.js';
 import type { TextLineRange, TextSchema } from './types.js';
+import { getTextLineRange } from '../splitRange.js';
 
 type MeasureTextHeightArgs = {
   value: string;
@@ -123,7 +124,8 @@ export const mergeTextLineRangeValue = async ({
   font?: Font;
   _cache?: Map<string | number, unknown>;
 }) => {
-  if (!schema.__textLineRange) return replacement;
+  const range = getTextLineRange(schema);
+  if (!range) return replacement;
 
   const { lines } = await measureTextLines({
     value,
@@ -132,7 +134,7 @@ export const mergeTextLineRangeValue = async ({
     _cache,
     ignoreDynamicFontSize: true,
   });
-  const { start, end = lines.length } = schema.__textLineRange;
+  const { start, end = lines.length } = range;
   const nextLines = [...lines];
   nextLines.splice(start, end - start, ...splitReplacementTextToLines(replacement));
   return plainTextLinesToValue(nextLines);

--- a/packages/schemas/src/text/pdfRender.ts
+++ b/packages/schemas/src/text/pdfRender.ts
@@ -35,6 +35,7 @@ import { calculateDynamicRichTextFontSize, isInlineMarkdownTextSchema } from './
 import { renderInlineMarkdownText } from './richTextPdfRender.js';
 import { shouldUseDynamicFontSize } from './overflow.js';
 import { convertForPdfLayoutProps, rotatePoint, hex2PrintingColor } from '../utils.js';
+import { getTextLineRange } from '../splitRange.js';
 
 type PdfFontCache = Record<string, Promise<PDFFont>>;
 
@@ -222,7 +223,7 @@ export const pdfRender = async (arg: PDFRenderProps<TextSchema>) => {
       fontKitFont,
       boxWidthInPt: width,
     }),
-    schema.__textLineRange,
+    getTextLineRange(schema),
   );
   const needsTextWidth = alignment !== 'left' || Boolean(schema.strikethrough || schema.underline);
   const needsTextHeight = Boolean(schema.strikethrough || schema.underline);

--- a/packages/schemas/src/text/richTextPdfRender.ts
+++ b/packages/schemas/src/text/richTextPdfRender.ts
@@ -24,6 +24,7 @@ import {
 } from './richText.js';
 import type { TextSchema } from './types.js';
 import { hex2PrintingColor, rotatePoint } from '../utils.js';
+import { getTextLineRange } from '../splitRange.js';
 
 type TextColor = ReturnType<typeof hex2PrintingColor>;
 
@@ -307,8 +308,9 @@ export const renderInlineMarkdownText = async (arg: {
     characterSpacing,
     boxWidthInPt: width,
   });
-  const lines = applyTextLineRange(allLines, schema.__textLineRange);
-  const lineRangeStart = schema.__textLineRange?.start ?? 0;
+  const lineRange = getTextLineRange(schema);
+  const lines = applyTextLineRange(allLines, lineRange);
+  const lineRangeStart = lineRange?.start ?? 0;
   const pdfFontObj = await embedFontsForRuns(
     lines.flatMap((line) => line.runs),
     embedPdfFont,

--- a/packages/schemas/src/text/types.ts
+++ b/packages/schemas/src/text/types.ts
@@ -1,4 +1,4 @@
-import type { Schema } from '@pdfme/common';
+import type { DynamicLayoutRange, Schema } from '@pdfme/common';
 import type { Font as FontKitFont } from 'fontkit';
 
 export type ALIGNMENT = 'left' | 'center' | 'right' | 'justify';
@@ -31,10 +31,7 @@ export type FontWidthCalcValues = {
   boxWidthInPt: number;
 };
 
-export type TextLineRange = {
-  start: number;
-  end?: number;
-};
+export type TextLineRange = DynamicLayoutRange;
 
 export type TextSchema = Schema & {
   fontName?: string;

--- a/packages/schemas/src/text/types.ts
+++ b/packages/schemas/src/text/types.ts
@@ -1,4 +1,4 @@
-import type { DynamicLayoutRange, Schema } from '@pdfme/common';
+import type { Schema } from '@pdfme/common';
 import type { Font as FontKitFont } from 'fontkit';
 
 export type ALIGNMENT = 'left' | 'center' | 'right' | 'justify';
@@ -31,8 +31,6 @@ export type FontWidthCalcValues = {
   boxWidthInPt: number;
 };
 
-export type TextLineRange = DynamicLayoutRange;
-
 export type TextSchema = Schema & {
   fontName?: string;
   textFormat?: TEXT_FORMAT;
@@ -51,7 +49,6 @@ export type TextSchema = Schema & {
     fit: DYNAMIC_FONT_SIZE_FIT;
   };
   overflow?: TEXT_OVERFLOW;
-  __textLineRange?: TextLineRange;
   fontColor: string;
   backgroundColor: string;
 };

--- a/packages/schemas/src/text/uiRender.ts
+++ b/packages/schemas/src/text/uiRender.ts
@@ -40,6 +40,7 @@ import {
   resolveRichTextRuns,
 } from './richText.js';
 import { isEditable } from '../utils.js';
+import { getTextLineRange } from '../splitRange.js';
 
 const replaceUnsupportedChars = (text: string, fontKitFont: FontKitFont): string => {
   const charSupportCache: { [char: string]: boolean } = {};
@@ -80,7 +81,7 @@ export const uiRender = async (arg: UIRenderProps<TextSchema>) => {
   const hasInlineMarkdownFormat = schema.textFormat === TEXT_FORMAT_INLINE_MARKDOWN;
   const enableInlineMarkdown = isInlineMarkdownTextSchema(schema);
   const isReadOnlySplitInlineMarkdownFormChunk =
-    mode === 'form' && Boolean(schema.__textLineRange) && hasInlineMarkdownFormat;
+    mode === 'form' && Boolean(getTextLineRange(schema)) && hasInlineMarkdownFormat;
   const renderInlineMarkdownReadOnlyChunk =
     enableInlineMarkdown || isReadOnlySplitInlineMarkdownFormChunk;
   const editable = isEditable(mode, schema) && !isReadOnlySplitInlineMarkdownFormChunk;
@@ -235,7 +236,8 @@ const renderInlineMarkdownReadOnly = async (arg: {
     font,
     _cache,
   });
-  if (schema.__textLineRange) {
+  const lineRange = getTextLineRange(schema);
+  if (lineRange) {
     const lines = applyTextLineRange(
       layoutRichTextLines({
         runs,
@@ -243,7 +245,7 @@ const renderInlineMarkdownReadOnly = async (arg: {
         characterSpacing: schema.characterSpacing ?? DEFAULT_CHARACTER_SPACING,
         boxWidthInPt: mm2pt(schema.width),
       }),
-      schema.__textLineRange,
+      lineRange,
     );
 
     textBlock.innerHTML = '';
@@ -318,7 +320,8 @@ const getRangedPlainTextValue = (arg: {
   fontSize: number;
 }) => {
   const { value, schema, fontKitFont, fontSize } = arg;
-  if (!schema.__textLineRange) return value;
+  const lineRange = getTextLineRange(schema);
+  if (!lineRange) return value;
 
   const lines = applyTextLineRange(
     splitTextToSize({
@@ -328,7 +331,7 @@ const getRangedPlainTextValue = (arg: {
       fontKitFont,
       boxWidthInPt: mm2pt(schema.width),
     }),
-    schema.__textLineRange,
+    lineRange,
   );
   return plainTextLinesToValue(lines);
 };

--- a/packages/schemas/src/texts.ts
+++ b/packages/schemas/src/texts.ts
@@ -2,3 +2,4 @@ export { TEXT_OVERFLOW_EXPAND } from './text/constants.js';
 export { getDynamicLayoutForText } from './text/dynamicTemplate.js';
 export { mergeTextLineRangeValue } from './text/measure.js';
 export { getDynamicLayoutForMultiVariableText } from './multiVariableText/dynamicTemplate.js';
+export { getTextLineRange, TEXT_LINE_SPLIT_UNIT } from './splitRange.js';

--- a/packages/schemas/src/texts.ts
+++ b/packages/schemas/src/texts.ts
@@ -2,4 +2,4 @@ export { TEXT_OVERFLOW_EXPAND } from './text/constants.js';
 export { getDynamicLayoutForText } from './text/dynamicTemplate.js';
 export { mergeTextLineRangeValue } from './text/measure.js';
 export { getDynamicLayoutForMultiVariableText } from './multiVariableText/dynamicTemplate.js';
-export { getTextLineRange, TEXT_LINE_SPLIT_UNIT } from './splitRange.js';
+export { createTextLineSplitRange, getTextLineRange, TEXT_LINE_SPLIT_UNIT } from './splitRange.js';

--- a/packages/schemas/src/types.ts
+++ b/packages/schemas/src/types.ts
@@ -33,3 +33,4 @@ export type { ShapeSchema } from './shapes/rectAndEllipse.js';
 export type { SelectSchema } from './select/index.js';
 export type { RadioGroupSchema } from './radioGroup/index.js';
 export type { CheckboxSchema } from './checkbox/index.js';
+export type { BuiltInDynamicLayoutSplitUnit } from './splitRange.js';

--- a/packages/schemas/src/types.ts
+++ b/packages/schemas/src/types.ts
@@ -11,14 +11,7 @@ export type {
   VERTICAL_ALIGNMENT,
 } from './text/types.js';
 export type { MultiVariableTextSchema } from './multiVariableText/types.js';
-export type {
-  LIST_STYLE,
-  ListItem,
-  ListItemLayout,
-  ListLayout,
-  ListRange,
-  ListSchema,
-} from './list/types.js';
+export type { LIST_STYLE, ListItem, ListItemLayout, ListLayout, ListSchema } from './list/types.js';
 export type {
   CellSchema,
   CellStyle,

--- a/packages/ui/src/components/Preview.tsx
+++ b/packages/ui/src/components/Preview.tsx
@@ -9,7 +9,7 @@ import {
   replacePlaceholders,
 } from '@pdfme/common';
 import { getDynamicLayoutForSchema, isDynamicLayoutSchema } from '@pdfme/schemas/dynamicLayout';
-import { mergeTextLineRangeValue } from '@pdfme/schemas/texts';
+import { getTextLineRange, mergeTextLineRangeValue } from '@pdfme/schemas/texts';
 import UnitPager from './UnitPager.js';
 import Root from './Root.js';
 import StaticSchema from './StaticSchema.js';
@@ -168,7 +168,7 @@ const Preview = ({
         const oldValue = (input?.[schema.name] as string) || '';
         const rawNewValue = value as string;
         const newValue =
-          schema.type === 'text' && schema.__textLineRange
+          schema.type === 'text' && getTextLineRange(schema)
             ? await mergeTextLineRangeValue({
                 value: oldValue,
                 replacement: rawNewValue,


### PR DESCRIPTION
## Summary

- Add generic dynamic layout split metadata via `__splitRange: { unit, start, end }` in `@pdfme/common`.
- Replace table/list/text-specific internal range fields with shared helpers for table body, list item, and text line splits.
- Update generator, UI preview, renderers, and tests to use the generic split range contract.
- Remove legacy internal fields: `__bodyRange`, `__itemRange`, and `__textLineRange`.

## Why

Dynamic layout currently has schema-specific split metadata even though table, list, text, and multiVariableText all share the same conceptual contract: a split unit plus a start/end range. This PR makes that contract explicit and easier to extend for future dynamic layout schemas.

## Validation

- `npm run fmt -w packages/common`
- `npm run fmt -w packages/schemas`
- `npm run fmt -w packages/ui`
- `npm run lint -w packages/common`
- `npm run lint -w packages/schemas`
- `npm run lint -w packages/ui`
- `npm run test -w packages/common -- dynamicTemplate.test.ts splitRange.test.ts`
- `npm run test -w packages/schemas -- list.test.ts list.ui.test.ts text.test.ts text.ui.test.ts multiVariableText.ui.test.ts`
- `npm run test -w packages/generator -- generate.test.ts -t "text schemas|expanded text"`
- `npm run test -w packages/ui`
- `npm run build -w packages/common`
- `npm run build -w packages/schemas`
- `npm run build -w packages/generator`
- `npm run build -w packages/ui`
- `npm run fmt:check`
- `git diff --check`
