### PR TITLE
[codex] Disable text expand for custom basePdf

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -85,6 +85,10 @@ layout/builder の考え方を `converter` package の `md2pdf` に応用し、M
 - この排他制御は仕様として扱い、将来の docs / website / schema API docs では
   `overflow: "expand"` と `dynamicFontSize` は同時利用できないこと、expand では通常の
   `fontSize` を使って高さを広げることを明記する。
+- custom `basePdf` では dynamic template による reflow / page split が適用されないため、
+  Designer では `overflow: "expand"` を選択不可にする。既存テンプレートで `expand` が残っている
+  場合も Designer 上では `visible` に戻し、効かない `expand` が `dynamicFontSize` まで無効化する
+  中途半端な状態を避ける。この制約も docs に明記する。
 - `multiVariableText` は変数置換後の実描画テキストで高さを測る。
 - ページ末尾を超える場合、text / `multiVariableText` は行単位で `__textLineRange` を持つ
   split schema に分割し、次ページへ続ける。plain text と inline-markdown は同じ line layout を
@@ -101,7 +105,6 @@ layout/builder の考え方を `converter` package の `md2pdf` に応用し、M
 
 - `text`, `multiVariableText`, `list`, `table` の dynamic layout contract を共通化できるか。
 - 長文 text / MVT の段落単位 keep-together や widow/orphan 制御をどこまで扱うか。
-- blank PDF と custom `basePdf` で挙動を分ける必要があるか。
 - 既存テンプレートへの互換性リスクをどう抑えるか。
 
 初回スコープ案:

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -147,6 +147,7 @@ export type UIRenderProps<T extends Schema> = {
  * @property {HTMLElement[]} activeElements - Array of currently active HTML elements in the UI.
  * @property {ChangeSchemas} changeSchemas - Function to change multiple schemas simultaneously.
  * @property {SchemaForUI[]} schemas - Array of schemas for UI rendering.
+ * @property {BasePdf} basePdf - The base PDF used by the current template.
  * @property {Size} pageSize - The size of the page being edited.
  * @property {UIOptions} options - UI options for the property panel.
  * @property {UITheme} theme - The theme token used in the UI.
@@ -158,6 +159,7 @@ type PropPanelProps = {
   activeElements: HTMLElement[];
   changeSchemas: ChangeSchemas;
   schemas: SchemaForUI[];
+  basePdf?: BasePdf;
   options: UIOptions;
   theme: UITheme;
   i18n: (key: string) => string;

--- a/packages/schemas/__tests__/text.test.ts
+++ b/packages/schemas/__tests__/text.test.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { Font as FontKitFont } from 'fontkit';
 import { Font, getDefaultFont, mm2pt } from '@pdfme/common';
+import type { BasePdf, PropPanelSchema, PropPanelWidgetProps } from '@pdfme/common';
 import {
   calculateDynamicFontSize,
   getBrowserVerticalFontAdjustments,
@@ -26,10 +27,16 @@ import {
   resolveFontVariant,
   type ResolvedRichTextRun,
 } from '../src/text/richText.js';
-import { LINE_START_FORBIDDEN_CHARS, LINE_END_FORBIDDEN_CHARS } from '../src/text/constants.js';
+import {
+  LINE_START_FORBIDDEN_CHARS,
+  LINE_END_FORBIDDEN_CHARS,
+  TEXT_OVERFLOW_EXPAND,
+  TEXT_OVERFLOW_VISIBLE,
+} from '../src/text/constants.js';
 import { getDynamicLayoutForText } from '../src/text/dynamicTemplate.js';
 import { mergeTextLineRangeValue } from '../src/text/measure.js';
 import { shouldUseDynamicFontSize } from '../src/text/overflow.js';
+import { propPanel as textPropPanel } from '../src/text/propPanel.js';
 import { getDynamicLayoutForMultiVariableText } from '../src/multiVariableText/dynamicTemplate.js';
 
 import { FontWidthCalcValues, TextSchema } from '../src/text/types.js';
@@ -76,6 +83,40 @@ const getTextSchema = () => {
     fontSize: 14,
   };
   return textSchema;
+};
+
+const getTextPropPanelSchema = ({
+  basePdf,
+  activeSchema,
+}: {
+  basePdf?: BasePdf;
+  activeSchema?: Partial<TextSchema>;
+} = {}) => {
+  if (typeof textPropPanel.schema !== 'function') {
+    throw new Error('Text propPanel schema should be a function.');
+  }
+
+  return textPropPanel.schema({
+    activeSchema: {
+      ...getTextSchema(),
+      id: 'text-id',
+      ...activeSchema,
+    },
+    activeElements: [],
+    changeSchemas: () => undefined,
+    schemas: [],
+    basePdf,
+    options: { font: getSampleFont() },
+    theme: {},
+    i18n: (key: string) => key,
+  } as unknown as Omit<PropPanelWidgetProps, 'rootElement'>);
+};
+
+const getOverflowOptionValues = (schema: Record<string, PropPanelSchema>) => {
+  const overflow = schema.overflow as PropPanelSchema & {
+    props: { options: Array<{ value: string }> };
+  };
+  return overflow.props.options.map((option) => option.value);
 };
 
 describe('parseInlineMarkdown', () => {
@@ -253,6 +294,41 @@ describe('isInlineMarkdownTextSchema', () => {
   });
 });
 
+describe('text prop panel', () => {
+  it('offers overflow expand for blank basePdf', () => {
+    const schema = getTextPropPanelSchema({
+      basePdf: { width: 210, height: 297, padding: [10, 10, 10, 10] },
+    });
+
+    expect(getOverflowOptionValues(schema)).toEqual([
+      TEXT_OVERFLOW_VISIBLE,
+      TEXT_OVERFLOW_EXPAND,
+    ]);
+  });
+
+  it('hides overflow expand for custom basePdf', () => {
+    const schema = getTextPropPanelSchema({
+      basePdf: 'data:application/pdf;base64,AA==' as BasePdf,
+    });
+
+    expect(getOverflowOptionValues(schema)).toEqual([TEXT_OVERFLOW_VISIBLE]);
+  });
+
+  it('keeps dynamic font size controls enabled when custom basePdf has stale overflow expand', () => {
+    const schema = getTextPropPanelSchema({
+      basePdf: 'data:application/pdf;base64,AA==' as BasePdf,
+      activeSchema: {
+        overflow: TEXT_OVERFLOW_EXPAND,
+        dynamicFontSize: { min: 20, max: 30, fit: 'vertical' },
+      },
+    });
+    const dynamicFontSize = schema.dynamicFontSize as PropPanelSchema;
+    const minFontSize = dynamicFontSize.properties?.min;
+
+    expect(minFontSize?.hidden).toBe(false);
+  });
+});
+
 describe('text dynamic layout', () => {
   const baseArgs = {
     basePdf: { width: 100, height: 100, padding: [10, 10, 10, 10] },
@@ -410,6 +486,18 @@ describe('text dynamic layout', () => {
         overflow: 'expand',
       }),
     ).toBe(false);
+  });
+
+  it('treats overflow expand as visible for custom basePdf dynamic font sizing', () => {
+    expect(
+      shouldUseDynamicFontSize(
+        {
+          dynamicFontSize: { min: 20, max: 30, fit: 'vertical' },
+          overflow: 'expand',
+        },
+        'data:application/pdf;base64,AA==' as BasePdf,
+      ),
+    ).toBe(true);
   });
 
   it('expands multiVariableText after substituting variables', async () => {

--- a/packages/schemas/__tests__/text.test.ts
+++ b/packages/schemas/__tests__/text.test.ts
@@ -314,6 +314,18 @@ describe('text prop panel', () => {
     expect(getOverflowOptionValues(schema)).toEqual([TEXT_OVERFLOW_VISIBLE]);
   });
 
+  it('keeps overflow expand available for text-derived schemas that do not use text expand', () => {
+    const schema = getTextPropPanelSchema({
+      basePdf: 'data:application/pdf;base64,AA==' as BasePdf,
+      activeSchema: { type: 'select' },
+    });
+
+    expect(getOverflowOptionValues(schema)).toEqual([
+      TEXT_OVERFLOW_VISIBLE,
+      TEXT_OVERFLOW_EXPAND,
+    ]);
+  });
+
   it('keeps dynamic font size controls enabled when custom basePdf has stale overflow expand', () => {
     const schema = getTextPropPanelSchema({
       basePdf: 'data:application/pdf;base64,AA==' as BasePdf,
@@ -492,6 +504,7 @@ describe('text dynamic layout', () => {
     expect(
       shouldUseDynamicFontSize(
         {
+          type: 'text',
           dynamicFontSize: { min: 20, max: 30, fit: 'vertical' },
           overflow: 'expand',
         },

--- a/packages/schemas/src/text/overflow.ts
+++ b/packages/schemas/src/text/overflow.ts
@@ -1,9 +1,14 @@
+import { isBlankPdf, type BasePdf } from '@pdfme/common';
 import { TEXT_OVERFLOW_EXPAND } from './constants.js';
 import type { TextSchema } from './types.js';
 
-export const isTextOverflowExpand = (schema: Pick<TextSchema, 'overflow'>) =>
-  schema.overflow === TEXT_OVERFLOW_EXPAND;
+export const canUseTextOverflowExpand = (basePdf?: BasePdf) =>
+  basePdf === undefined || isBlankPdf(basePdf);
+
+export const isTextOverflowExpand = (schema: Pick<TextSchema, 'overflow'>, basePdf?: BasePdf) =>
+  canUseTextOverflowExpand(basePdf) && schema.overflow === TEXT_OVERFLOW_EXPAND;
 
 export const shouldUseDynamicFontSize = (
   schema: Pick<TextSchema, 'dynamicFontSize' | 'overflow'>,
-) => Boolean(schema.dynamicFontSize) && !isTextOverflowExpand(schema);
+  basePdf?: BasePdf,
+) => Boolean(schema.dynamicFontSize) && !isTextOverflowExpand(schema, basePdf);

--- a/packages/schemas/src/text/overflow.ts
+++ b/packages/schemas/src/text/overflow.ts
@@ -2,13 +2,22 @@ import { isBlankPdf, type BasePdf } from '@pdfme/common';
 import { TEXT_OVERFLOW_EXPAND } from './constants.js';
 import type { TextSchema } from './types.js';
 
-export const canUseTextOverflowExpand = (basePdf?: BasePdf) =>
-  basePdf === undefined || isBlankPdf(basePdf);
+const TEXT_OVERFLOW_EXPAND_SCHEMA_TYPES = new Set(['text', 'multiVariableText']);
 
-export const isTextOverflowExpand = (schema: Pick<TextSchema, 'overflow'>, basePdf?: BasePdf) =>
-  canUseTextOverflowExpand(basePdf) && schema.overflow === TEXT_OVERFLOW_EXPAND;
+type TextOverflowSchema = Pick<TextSchema, 'overflow'> & Partial<Pick<TextSchema, 'type'>>;
+
+const isTextOverflowExpandSchema = (schema: Partial<Pick<TextSchema, 'type'>>) =>
+  schema.type === undefined || TEXT_OVERFLOW_EXPAND_SCHEMA_TYPES.has(schema.type);
+
+export const canUseTextOverflowExpand = (
+  schema: Partial<Pick<TextSchema, 'type'>>,
+  basePdf?: BasePdf,
+) => !isTextOverflowExpandSchema(schema) || basePdf === undefined || isBlankPdf(basePdf);
+
+export const isTextOverflowExpand = (schema: TextOverflowSchema, basePdf?: BasePdf) =>
+  canUseTextOverflowExpand(schema, basePdf) && schema.overflow === TEXT_OVERFLOW_EXPAND;
 
 export const shouldUseDynamicFontSize = (
-  schema: Pick<TextSchema, 'dynamicFontSize' | 'overflow'>,
+  schema: Pick<TextSchema, 'dynamicFontSize' | 'overflow'> & Partial<Pick<TextSchema, 'type'>>,
   basePdf?: BasePdf,
 ) => Boolean(schema.dynamicFontSize) && !isTextOverflowExpand(schema, basePdf);

--- a/packages/schemas/src/text/pdfRender.ts
+++ b/packages/schemas/src/text/pdfRender.ts
@@ -86,6 +86,7 @@ const getFontProp = ({
   value,
   fontKitFont,
   schema,
+  basePdf,
   colorType,
   fontSize: resolvedFontSize,
 }: {
@@ -93,11 +94,12 @@ const getFontProp = ({
   fontKitFont: FontKitFont;
   colorType?: ColorType;
   schema: TextSchema;
+  basePdf: PDFRenderProps<TextSchema>['basePdf'];
   fontSize?: number;
 }) => {
   const fontSize =
     resolvedFontSize ??
-    (shouldUseDynamicFontSize(schema)
+    (shouldUseDynamicFontSize(schema, basePdf)
       ? calculateDynamicFontSize({ textSchema: schema, fontKitFont, value })
       : (schema.fontSize ?? DEFAULT_FONT_SIZE));
   const color = hex2PrintingColor(schema.fontColor || DEFAULT_FONT_COLOR, colorType);
@@ -120,7 +122,7 @@ const getGraphemeSegmenter = () => {
 };
 
 export const pdfRender = async (arg: PDFRenderProps<TextSchema>) => {
-  const { value, pdfDoc, pdfLib, page, options, schema, _cache } = arg;
+  const { value, pdfDoc, pdfLib, page, options, schema, basePdf, _cache } = arg;
   if (!value) return;
 
   const { font = getDefaultFont(), colorType } = options;
@@ -142,13 +144,14 @@ export const pdfRender = async (arg: PDFRenderProps<TextSchema>) => {
   );
   const displayValue = enableInlineMarkdown ? stripInlineMarkdown(value) : value;
   const dynamicRichTextFontSize =
-    enableInlineMarkdown && shouldUseDynamicFontSize(schema)
+    enableInlineMarkdown && shouldUseDynamicFontSize(schema, basePdf)
       ? await calculateDynamicRichTextFontSize({ value, schema, font, _cache })
       : undefined;
   const fontProp = getFontProp({
     value: displayValue,
     fontKitFont,
     schema,
+    basePdf,
     colorType,
     fontSize: dynamicRichTextFontSize,
   });

--- a/packages/schemas/src/text/propPanel.ts
+++ b/packages/schemas/src/text/propPanel.ts
@@ -31,11 +31,11 @@ import {
 } from './constants.js';
 import { DEFAULT_OPACITY, HEX_COLOR_PATTERN } from '../constants.js';
 import { getExtraFormatterSchema } from './extraFormatter.js';
-import { isTextOverflowExpand } from './overflow.js';
+import { canUseTextOverflowExpand, isTextOverflowExpand } from './overflow.js';
 
 const UseDynamicFontSize = (props: PropPanelWidgetProps) => {
-  const { rootElement, changeSchemas, activeSchema, i18n } = props;
-  const isExpand = isTextOverflowExpand(activeSchema as unknown as TextSchema);
+  const { rootElement, changeSchemas, activeSchema, i18n, basePdf } = props;
+  const isExpand = isTextOverflowExpand(activeSchema as unknown as TextSchema, basePdf);
 
   const checkbox = document.createElement('input');
   checkbox.type = 'checkbox';
@@ -87,13 +87,14 @@ const UseInlineMarkdown = (props: PropPanelWidgetProps) => {
 };
 
 export const propPanel: PropPanel<TextSchema> = {
-  schema: ({ options, activeSchema, i18n }) => {
+  schema: ({ options, activeSchema, i18n, basePdf }) => {
     const font = options.font || { [DEFAULT_FONT_NAME]: { data: '', fallback: true } };
     const fontNames = Object.keys(font);
     const fallbackFontName = getFallbackFontName(font);
 
     const activeTextSchema = activeSchema as unknown as TextSchema;
-    const isExpand = isTextOverflowExpand(activeTextSchema);
+    const canExpandOverflow = canUseTextOverflowExpand(basePdf);
+    const isExpand = isTextOverflowExpand(activeTextSchema, basePdf);
     const enableDynamicFont =
       !isExpand && Boolean((activeSchema as { dynamicFontSize?: unknown })?.dynamicFontSize);
     const hideTextFormat = activeTextSchema.type === 'text' && activeTextSchema.readOnly !== true;
@@ -108,6 +109,12 @@ export const propPanel: PropPanel<TextSchema> = {
       ...fontNames
         .filter((name) => name !== baseFontName)
         .map((name) => ({ label: name, value: name })),
+    ];
+    const overflowOptions = [
+      { label: i18n('schemas.text.overflowVisible'), value: TEXT_OVERFLOW_VISIBLE },
+      ...(canExpandOverflow
+        ? [{ label: i18n('schemas.text.overflowExpand'), value: TEXT_OVERFLOW_EXPAND }]
+        : []),
     ];
 
     const textSchema: Record<string, PropPanelSchema> = {
@@ -149,10 +156,7 @@ export const propPanel: PropPanel<TextSchema> = {
         widget: 'select',
         default: DEFAULT_TEXT_OVERFLOW,
         props: {
-          options: [
-            { label: i18n('schemas.text.overflowVisible'), value: TEXT_OVERFLOW_VISIBLE },
-            { label: i18n('schemas.text.overflowExpand'), value: TEXT_OVERFLOW_EXPAND },
-          ],
+          options: overflowOptions,
         },
         span: 8,
       },

--- a/packages/schemas/src/text/propPanel.ts
+++ b/packages/schemas/src/text/propPanel.ts
@@ -93,7 +93,7 @@ export const propPanel: PropPanel<TextSchema> = {
     const fallbackFontName = getFallbackFontName(font);
 
     const activeTextSchema = activeSchema as unknown as TextSchema;
-    const canExpandOverflow = canUseTextOverflowExpand(basePdf);
+    const canExpandOverflow = canUseTextOverflowExpand(activeTextSchema, basePdf);
     const isExpand = isTextOverflowExpand(activeTextSchema, basePdf);
     const enableDynamicFont =
       !isExpand && Boolean((activeSchema as { dynamicFontSize?: unknown })?.dynamicFontSize);

--- a/packages/schemas/src/text/uiRender.ts
+++ b/packages/schemas/src/text/uiRender.ts
@@ -75,8 +75,18 @@ const replaceUnsupportedChars = (text: string, fontKitFont: FontKitFont): string
 };
 
 export const uiRender = async (arg: UIRenderProps<TextSchema>) => {
-  const { value, schema, mode, onChange, stopEditing, tabIndex, placeholder, options, _cache } =
-    arg;
+  const {
+    value,
+    schema,
+    basePdf,
+    mode,
+    onChange,
+    stopEditing,
+    tabIndex,
+    placeholder,
+    options,
+    _cache,
+  } = arg;
   const hasInlineMarkdownFormat = schema.textFormat === TEXT_FORMAT_INLINE_MARKDOWN;
   const enableInlineMarkdown = isInlineMarkdownTextSchema(schema);
   const isReadOnlySplitInlineMarkdownFormChunk =
@@ -99,7 +109,7 @@ export const uiRender = async (arg: UIRenderProps<TextSchema>) => {
     font,
     _cache as Map<string, import('fontkit').Font>,
   );
-  const enableDynamicFontSize = shouldUseDynamicFontSize(schema);
+  const enableDynamicFontSize = shouldUseDynamicFontSize(schema, basePdf);
   const displayValue = enableInlineMarkdown ? stripInlineMarkdown(value) : value;
   const dynamicRichTextFontSize =
     enableInlineMarkdown && enableDynamicFontSize
@@ -343,7 +353,7 @@ export const buildStyledTextContainer = (
 
   let dynamicFontSize: undefined | number = resolvedDynamicFontSize;
 
-  if (dynamicFontSize === undefined && shouldUseDynamicFontSize(schema) && value) {
+  if (dynamicFontSize === undefined && shouldUseDynamicFontSize(schema, arg.basePdf) && value) {
     dynamicFontSize = calculateDynamicFontSize({
       textSchema: schema,
       fontKitFont,

--- a/packages/schemas/src/texts.ts
+++ b/packages/schemas/src/texts.ts
@@ -1,4 +1,4 @@
-export { TEXT_OVERFLOW_EXPAND } from './text/constants.js';
+export { TEXT_OVERFLOW_EXPAND, TEXT_OVERFLOW_VISIBLE } from './text/constants.js';
 export { getDynamicLayoutForText } from './text/dynamicTemplate.js';
 export { mergeTextLineRangeValue } from './text/measure.js';
 export { getDynamicLayoutForMultiVariableText } from './multiVariableText/dynamicTemplate.js';

--- a/packages/ui/src/components/Designer/RightSidebar/DetailView/index.tsx
+++ b/packages/ui/src/components/Designer/RightSidebar/DetailView/index.tsx
@@ -28,7 +28,7 @@ import FormRenderComponent from 'form-render';
 
 const { Text } = Typography;
 
-const TEXT_OVERFLOW_SCHEMA_TYPES = new Set(['text', 'multiVariableText', 'list', 'select']);
+const TEXT_OVERFLOW_EXPAND_SCHEMA_TYPES = new Set(['text', 'multiVariableText']);
 
 type DetailViewProps = Pick<
   SidebarProps,
@@ -109,7 +109,7 @@ const DetailView = (props: DetailViewProps) => {
   }, [activeSchema, form]);
 
   useEffect(() => {
-    if (isBlankPdf(basePdf) || !TEXT_OVERFLOW_SCHEMA_TYPES.has(activeSchema.type)) return;
+    if (isBlankPdf(basePdf) || !TEXT_OVERFLOW_EXPAND_SCHEMA_TYPES.has(activeSchema.type)) return;
     if ((activeSchema as Record<string, unknown>).overflow !== TEXT_OVERFLOW_EXPAND) return;
 
     changeSchemas([{ key: 'overflow', value: TEXT_OVERFLOW_VISIBLE, schemaId: activeSchema.id }]);

--- a/packages/ui/src/components/Designer/RightSidebar/DetailView/index.tsx
+++ b/packages/ui/src/components/Designer/RightSidebar/DetailView/index.tsx
@@ -10,7 +10,7 @@ import type {
   Schema,
 } from '@pdfme/common';
 import { isBlankPdf } from '@pdfme/common';
-import { TEXT_OVERFLOW_EXPAND } from '@pdfme/schemas/texts';
+import { TEXT_OVERFLOW_EXPAND, TEXT_OVERFLOW_VISIBLE } from '@pdfme/schemas/texts';
 import type { SidebarProps } from '../../../../types.js';
 import { Menu } from 'lucide-react';
 import { I18nContext, PluginsRegistry, OptionsContext } from '../../../../contexts.js';
@@ -27,6 +27,8 @@ import { SidebarBody, SidebarFrame, SidebarHeader, SIDEBAR_H_PADDING_PX } from '
 import FormRenderComponent from 'form-render';
 
 const { Text } = Typography;
+
+const TEXT_OVERFLOW_SCHEMA_TYPES = new Set(['text', 'multiVariableText', 'list', 'select']);
 
 type DetailViewProps = Pick<
   SidebarProps,
@@ -105,6 +107,13 @@ const DetailView = (props: DetailViewProps) => {
     values.editable = !readOnly;
     form.setValues(values);
   }, [activeSchema, form]);
+
+  useEffect(() => {
+    if (isBlankPdf(basePdf) || !TEXT_OVERFLOW_SCHEMA_TYPES.has(activeSchema.type)) return;
+    if ((activeSchema as Record<string, unknown>).overflow !== TEXT_OVERFLOW_EXPAND) return;
+
+    changeSchemas([{ key: 'overflow', value: TEXT_OVERFLOW_VISIBLE, schemaId: activeSchema.id }]);
+  }, [activeSchema, basePdf, changeSchemas]);
 
   useEffect(() => {
     uniqueSchemaName.current = (value: string): boolean => {
@@ -393,12 +402,21 @@ const DetailView = (props: DetailViewProps) => {
 
   if (typeof activePropPanelSchema === 'function') {
     // Create a new object without the schemasList property
-    const { size, schemas, pageSize, changeSchemas, activeElements, deselectSchema, activeSchema } =
-      props;
+    const {
+      size,
+      schemas,
+      pageSize,
+      basePdf,
+      changeSchemas,
+      activeElements,
+      deselectSchema,
+      activeSchema,
+    } = props;
     const propPanelProps = {
       size,
       schemas,
       pageSize,
+      basePdf,
       changeSchemas,
       activeElements,
       deselectSchema,


### PR DESCRIPTION
## Summary

- Pass `basePdf` into plugin prop panel schema props so field configuration can react to blank vs custom base PDFs.
- Hide the `overflow: "expand"` option for text-derived schemas when the template uses a custom `basePdf`.
- Normalize stale `overflow: "expand"` values back to `visible` in Designer for custom `basePdf` templates.
- Treat `overflow: "expand"` as effective `visible` for dynamic font sizing when rendering against a custom `basePdf`.
- Record the blank/custom basePdf constraint in `PLAN.md`.

## Why

Dynamic template reflow and page splitting only run for blank PDFs. Allowing `overflow: "expand"` on a custom `basePdf` makes the option look supported even though it cannot move following elements or add pages. Worse, a stale `expand` value can disable `dynamicFontSize` despite expand being ineffective. This keeps Designer and runtime behavior aligned.

## Validation

- `npm run fmt -w packages/common`
- `npm run fmt -w packages/schemas`
- `npm run fmt -w packages/ui`
- `npm run lint -w packages/common`
- `npm run lint -w packages/schemas`
- `npm run lint -w packages/ui`
- `npm run test -w packages/schemas -- text.test.ts`
- `npm run test -w packages/ui -- components/Designer.test.tsx components/Preview.test.tsx`
- `npm run build -w packages/common`
- `npm run build -w packages/schemas`
- `npm run build -w packages/ui`
- `npm run fmt:check`
- `git diff --check`
