### PR TITLE
[codex] Refresh JSX md2pdf roadmap

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -30,6 +30,15 @@ layout/builder の考え方を `converter` package の `md2pdf` に応用し、M
 - GFM 準拠だけにこだわりすぎない。PDF 生成として自然で便利な表現は、GFM にないものでも
   pdfme の拡張として扱ってよい。ただし、その差分はドキュメントに明記する。
 
+## 現在地
+
+- リンク基盤、`@pdfme/jsx` MVP、text / MVT の `overflow: "expand"`、行単位 page split、
+  custom `basePdf` 制御、dynamic layout docs は main に入った。
+- plain `multiVariableText` の split chunk は Form 上でも編集できる。
+- inline-markdown の split chunk は、plain text / MVT ともに Form 上では read-only のまま残す。
+- 次の大きな判断は、dynamic layout の編集体験をどこまで広げるかと、`@pdfme/jsx` / `md2pdf`
+  に進む前にどの schema 表現を追加するか。
+
 ## 完了済み
 
 ### PR #1463: リンク基盤
@@ -85,8 +94,6 @@ layout/builder の考え方を `converter` package の `md2pdf` に応用し、M
   `__splitRange: { unit: "textLine", start, end }` を持つ split schema に分割し、次ページへ続ける。
   plain text と inline-markdown は同じ line layout を使い、PDF / UI preview で split chunk が
   同じ input 全体を重複描画しないようにする。
-- plain `multiVariableText` の split chunk は、Form 上で表示範囲内の変数 span を編集できるようにする。
-  編集結果は JSON input の該当変数へ戻し、別ページに分割された同じ input の内容を消さない。
 - inline-markdown の split chunk は markdown 記法が行境界で分断される可能性があるため、Form 上では
   初回は read-only 表示に寄せる。将来的に編集可能にする場合は rich text AST と selection/editing
   model を合わせて設計する。
@@ -117,19 +124,36 @@ layout/builder の考え方を `converter` package の `md2pdf` に応用し、M
 - `__splitRange` は内部 dynamic layout metadata であり、通常テンプレート authoring API では
   直接触らないことを説明する。
 
+### PR #1472: plain `multiVariableText` split chunk の Form 編集
+
+- plain `multiVariableText` の split chunk は、Form 上で表示範囲内の変数 span を編集できるようにする。
+- 編集結果は JSON input の該当変数範囲へ戻し、別ページに分割された同じ input の内容を消さない。
+- soft-wrap、同じ変数の複数参照、空白を含む値、空値のケースをテストで固定する。
+- inline-markdown の split chunk は、rich text AST / selection editing の設計が必要なため read-only
+  のまま残す。
+
 ## 次 PR 候補
 
-### 1. dynamic layout の品質改善
+### 1. inline-markdown split chunk 編集方針
+
+直近で一番悩ましい残論点。すぐ実装するより、先に仕様を固定した方がよい。
+
+- split 後の inline-markdown text / MVT を Form 上でも編集可能にするか、read-only 表示に限定するか決める。
+- 編集可能にする場合は、markdown source string を直接編集するのか、rich text AST / run model を編集して
+  source へ戻すのか決める。
+- link / bold / italic / inline code が行境界で分断された場合の selection / blur / input merge 方針を決める。
+- md2pdf を見据えると、strict GFM AST と pdfme inline-markdown の軽量記法を混ぜすぎないことに注意する。
+
+### 2. dynamic layout pagination 品質
 
 - 長文 text / MVT の段落単位 keep-together や widow/orphan 制御をどこまで扱うか決める。
 - Form 編集中の live pagination を入れるか、Preview / generate 時のみ reflow する仕様で固定するか決める。
-- split 後の `multiVariableText` は plain text では Form 編集できる。inline-markdown MVT も編集可能にするか、
-  read-only chunk のままにするか決める。
-- split 後の inline-markdown を将来的に編集可能にする場合は、rich text AST と selection/editing
-  model を合わせて設計する。
+- split chunk 内の複数 variable span を連続編集した場合、blur の順序と reflow 後の最新 input を
+  どう同期するか決める。
+- `table`, `list`, `text`, `multiVariableText` 以外の schema に dynamic layout contract を広げるか検討する。
 - 既存テンプレートに旧 dynamic metadata が残っている場合の扱いを docs / migration note に書く。
 
-### 2. `@pdfme/jsx` component 拡張
+### 3. `@pdfme/jsx` component 拡張
 
 `md2pdf` を見据えると、MVP だけでは表現力が足りない。優先度は以下。
 
@@ -140,7 +164,7 @@ layout/builder の考え方を `converter` package の `md2pdf` に応用し、M
 - `Absolute`: stacking layout から外れた補助配置に必要。ただし乱用されると JSX の価値が
   薄れるため、API は慎重にする。
 
-### 3. `@pdfme/jsx` layout 品質の改善
+### 4. `@pdfme/jsx` layout 品質の改善
 
 - CSS/Flexbox 互換を目指すのではなく、flexbox の使いやすさだけを `Stack` / `Row`
   の authoring API に取り込む。
@@ -154,7 +178,7 @@ layout/builder の考え方を `converter` package の `md2pdf` に応用し、M
 - header / footer を `basePdf.staticSchema` に接続するか検討する。
 - row/stack/box の layout core を Markdown frontend から使えるように切り出せるか検討する。
 
-### 4. `md2pdf` / GFM MVP
+### 5. `md2pdf` / GFM MVP
 
 - `converter` package に `md2pdf` の入口を追加する。
 - Markdown parser は `remark-gfm` / `micromark` 系を候補にする。
@@ -209,16 +233,26 @@ layout/builder の考え方を `converter` package の `md2pdf` に応用し、M
 
 ## 未決事項
 
+Dynamic layout / editing:
+
 - inline-markdown の `multiVariableText` split chunk を Form 上で編集可能にするべきか、read-only chunk のままでよいか。
 - split 後の inline-markdown 編集をサポートするか、read-only 表示に限定するか。
 - split chunk 内の複数 variable span を連続編集した場合、blur の順序と reflow 後の最新 input を
   どう同期するか。必要なら live pagination / editing session の設計と合わせて扱う。
+- custom `basePdf` では dynamic layout を無効にする現行方針で固定するか、将来的に限定的な reflow
+  支援を検討するか。
+- 既存テンプレートに旧 dynamic metadata が残っている場合の migration / docs をどう扱うか。
+
+Rich content / link:
+
 - MVT の inline link 対応をどのタイミングで入れるか。
 - table cell / list item の rich inline content を schema 拡張で扱うか、複数 schema に分解するか。
 - link の見た目をデフォルトで青 + 下線にするか、明示的 styling に任せるか。
 - Designer で通常のテキスト編集を難しくせずにリンク編集 UI をどう出すか。
 - 独立 `link` schema をクリック領域用の補助として追加するべきか。
-- custom `basePdf` で dynamic layout を一切無効にする現行方針を docs にどう説明するか。
+
+JSX / md2pdf:
+
 - `@pdfme/jsx` の `Absolute` をどこまで推奨するか。
 - `md2pdf` の出力 API を `Template` のみにするか、`Template` + `inputs` + assets metadata にするか。
 


### PR DESCRIPTION
## Summary

- add a current-status section after #1472
- move plain MVT split editing into its own completed PR entry
- reprioritize next work around inline-markdown split editing, dynamic pagination quality, JSX component/layout work, and md2pdf MVP
- reorganize unresolved items by dynamic layout, rich content/link, and JSX/md2pdf

## Validation

- `git diff --check`
