### PR TITLE
[codex] Add JSX MultiVariableText component

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -37,6 +37,7 @@ layout/builder の考え方を `converter` package の `md2pdf` に応用し、M
 - `multiVariableText` の split chunk は、plain / inline-markdown ともに Form 上で変数値だけ編集できる。
 - Form mode の inline link は、入力要素ではない static text 部分だけ viewer と同じく clickable にする。
   変数 span 自体が link run に含まれる場合は入力を優先し、clickable anchor にはしない。
+- `@pdfme/jsx` component 拡張は `MultiVariableText` から進める。
 - `text` schema の inline-markdown split chunk は Form 上では read-only のまま残す。
 - 次の大きな判断は、dynamic layout の編集体験をどこまで広げるかと、`@pdfme/jsx` / `md2pdf`
   に進む前にどの schema 表現を追加するか。
@@ -167,7 +168,8 @@ layout/builder の考え方を `converter` package の `md2pdf` に応用し、M
 
 `md2pdf` を見据えると、MVP だけでは表現力が足りない。優先度は以下。
 
-- `MultiVariableText`: 固定文の中に入力欄を含む文章のために必要。
+- `MultiVariableText`: 固定文の中に入力欄を含む文章のために必要。`text` / children を template
+  string、`values` を JSON input として扱い、`{name}` placeholder から variables を推論する。
 - `Image`: Markdown image と AI template generation の両方で必要。
 - `Svg`: アイコンや簡単な図形に必要。
 - `Line`: blockquote や区切り線に必要。

--- a/packages/jsx/README.md
+++ b/packages/jsx/README.md
@@ -4,13 +4,19 @@ Small JSX authoring layer for creating pdfme templates from stacking layout prim
 
 ```tsx
 /** @jsxImportSource @pdfme/jsx */
-import { Page, Stack, Text, renderToTemplate } from '@pdfme/jsx';
+import { MultiVariableText, Page, Stack, Text, renderToTemplate } from '@pdfme/jsx';
 
 const { template, inputs } = await renderToTemplate(
   <Page margin={{ x: 12, y: 16 }}>
     <Stack gap={4}>
       <Text size={18}>Invoice</Text>
       <Text name="customerName">Alice</Text>
+      <MultiVariableText
+        name="message"
+        text="Hello **{name}**, status: `{status}`"
+        values={{ name: 'Alice **literal**', status: 'draft' }}
+        textFormat="inline-markdown"
+      />
     </Stack>
   </Page>,
 );
@@ -22,10 +28,13 @@ it provides its own `jsx-runtime` and `jsx-dev-runtime`.
 
 ## MVP constraints
 
-- `Text` height is measured with pdfme's text/rich text wrapping helpers when `height` is omitted.
-  Pass an explicit `height` when you need a fixed field box.
+- `Text` and `MultiVariableText` heights are measured with pdfme's text/rich text wrapping helpers
+  when `height` is omitted. Pass an explicit `height` when you need a fixed field box.
+- `MultiVariableText` uses `text` or children as the template string and stores `values` as the
+  JSON input. Variable names are inferred from `{name}` placeholders and can also be passed with
+  `variables`.
 - `PageBreak` is supported only along a `Page` / `Stack` / `Box` layout path. It is rejected inside
-  `Row`, `Text`, `List`, and `Table`.
+  `Row`, `Text`, `MultiVariableText`, `List`, and `Table`.
 - All `Page` nodes in one `renderToTemplate` call must use the same page size, orientation, and
   margin because a pdfme blank `basePdf` has one shared size and padding.
 - `Table widths` are percentages passed to pdfme `headWidthPercentages`, for example

--- a/packages/jsx/src/__tests__/render.test.tsx
+++ b/packages/jsx/src/__tests__/render.test.tsx
@@ -2,7 +2,18 @@
 import { describe, expect, it } from 'vitest';
 import { PAGE_SIZE_PRESETS } from '@pdfme/common';
 
-import { Box, List, Page, PageBreak, Row, Spacer, Stack, Table, Text } from '../components.js';
+import {
+  Box,
+  List,
+  MultiVariableText,
+  Page,
+  PageBreak,
+  Row,
+  Spacer,
+  Stack,
+  Table,
+  Text,
+} from '../components.js';
 import { renderToTemplate } from '../render.js';
 
 describe('@pdfme/jsx renderToTemplate', () => {
@@ -50,6 +61,124 @@ describe('@pdfme/jsx renderToTemplate', () => {
       content: 'Alice',
     });
     expect(result.inputs[0]).toEqual({ customerName: 'Alice' });
+  });
+
+  it('renders named MultiVariableText as a JSON input-backed schema', async () => {
+    const result = await renderToTemplate(
+      <Page>
+        <MultiVariableText
+          name="message"
+          text="Hello **{name}**, status: `{status}`"
+          values={{ name: 'Alice **literal**', status: 'draft' }}
+          textFormat="inline-markdown"
+          size={12}
+        />
+      </Page>,
+    );
+
+    const schema = result.template.schemas[0]?.[0];
+    const value = JSON.stringify({ name: 'Alice **literal**', status: 'draft' });
+    expect(schema).toMatchObject({
+      name: 'message',
+      type: 'multiVariableText',
+      readOnly: false,
+      content: value,
+      text: 'Hello **{name}**, status: `{status}`',
+      variables: ['name', 'status'],
+      textFormat: 'inline-markdown',
+      fontSize: 12,
+    });
+    expect(schema?.height).toBeGreaterThan(0);
+    expect(result.inputs[0]).toEqual({ message: value });
+  });
+
+  it('renders unnamed MultiVariableText as resolved read-only text', async () => {
+    const result = await renderToTemplate(
+      <Page>
+        <MultiVariableText text="Hello {name}" values={{ name: 'Alice' }} />
+      </Page>,
+    );
+
+    const schema = result.template.schemas[0]?.[0];
+    expect(schema).toMatchObject({
+      type: 'multiVariableText',
+      readOnly: true,
+      content: 'Hello Alice',
+      text: 'Hello {name}',
+      variables: ['name'],
+    });
+    expect(schema?.height).toBeGreaterThan(0);
+    expect(result.inputs[0]).toEqual({});
+  });
+
+  it('orders MultiVariableText variables from props, template placeholders, then values', async () => {
+    const result = await renderToTemplate(
+      <Page>
+        <MultiVariableText
+          name="message"
+          text="Hello {name}, role: {role}"
+          variables={['manual', 'role']}
+          values={{ status: 'draft' }}
+        />
+      </Page>,
+    );
+
+    expect(result.template.schemas[0]?.[0]).toMatchObject({
+      type: 'multiVariableText',
+      variables: ['manual', 'role', 'name', 'status'],
+    });
+  });
+
+  it('escapes read-only MultiVariableText values inside inline-markdown', async () => {
+    const result = await renderToTemplate(
+      <Page>
+        <MultiVariableText
+          text="Hello **{name}**"
+          values={{ name: 'Alice **literal**' }}
+          textFormat="inline-markdown"
+        />
+      </Page>,
+    );
+
+    const schema = result.template.schemas[0]?.[0];
+    expect(schema).toMatchObject({
+      type: 'multiVariableText',
+      readOnly: true,
+      textFormat: 'inline-markdown',
+    });
+    expect(schema?.content).toContain('Alice \\*\\*literal\\*\\*');
+    expect(schema?.content).not.toContain('Alice **literal**');
+  });
+
+  it('uses MultiVariableText children as the template string', async () => {
+    const result = await renderToTemplate(
+      <Page>
+        <MultiVariableText values={{ name: 'Alice' }}>{'Hello {name}'}</MultiVariableText>
+      </Page>,
+    );
+
+    expect(result.template.schemas[0]?.[0]).toMatchObject({
+      type: 'multiVariableText',
+      readOnly: true,
+      text: 'Hello {name}',
+      content: 'Hello Alice',
+      variables: ['name'],
+    });
+  });
+
+  it('removes missing MultiVariableText placeholder values from read-only content', async () => {
+    const result = await renderToTemplate(
+      <Page>
+        <MultiVariableText text="Hello {name}, {missing}" values={{ name: 'Alice' }} />
+      </Page>,
+    );
+
+    expect(result.template.schemas[0]?.[0]).toMatchObject({
+      type: 'multiVariableText',
+      readOnly: true,
+      content: 'Hello Alice, ',
+      variables: ['name', 'missing'],
+    });
   });
 
   it('uses Page font as the default fontName', async () => {

--- a/packages/jsx/src/components.ts
+++ b/packages/jsx/src/components.ts
@@ -2,6 +2,7 @@ import { createElementNode } from './node.js';
 import type {
   BoxProps,
   ListProps,
+  MultiVariableTextProps,
   PageBreakProps,
   PageProps,
   RowProps,
@@ -24,6 +25,9 @@ export const Row = makeBuiltin<RowProps, 'row'>('row');
 export const Box = makeBuiltin<BoxProps, 'box'>('box');
 export const Spacer = makeBuiltin<SpacerProps, 'spacer'>('spacer');
 export const Text = makeBuiltin<TextProps, 'text'>('text');
+export const MultiVariableText = makeBuiltin<MultiVariableTextProps, 'multiVariableText'>(
+  'multiVariableText',
+);
 export const List = makeBuiltin<ListProps, 'list'>('list');
 export const Table = makeBuiltin<TableProps, 'table'>('table');
 export const PageBreak = (props?: PageBreakProps) => createElementNode('pagebreak', props);

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -1,4 +1,15 @@
-export { Box, List, Page, PageBreak, Row, Spacer, Stack, Table, Text } from './components.js';
+export {
+  Box,
+  List,
+  MultiVariableText,
+  Page,
+  PageBreak,
+  Row,
+  Spacer,
+  Stack,
+  Table,
+  Text,
+} from './components.js';
 export { renderToTemplate } from './render.js';
 export type {
   BoxProps,
@@ -6,6 +17,8 @@ export type {
   CellStyle,
   ListItem,
   ListProps,
+  MultiVariableTextProps,
+  MultiVariableTextValues,
   PageBreakProps,
   PageOrientation,
   PageProps,

--- a/packages/jsx/src/render.ts
+++ b/packages/jsx/src/render.ts
@@ -3,16 +3,24 @@ import type { Font, Schema, Template } from '@pdfme/common';
 import type {
   CellStyle as SchemaCellStyle,
   ListSchema,
+  MultiVariableTextSchema,
   TableSchema,
   TextSchema,
 } from '@pdfme/schemas/types';
-import { measureTextHeight } from '@pdfme/schemas/utils';
+import {
+  escapeInlineMarkdown,
+  getVariableNames,
+  measureTextHeight,
+  visitVariables,
+} from '@pdfme/schemas/utils';
 import { cloneElementWithChildren, isPdfJsxElement, isPdfJsxFragment } from './node.js';
 import type {
   BoxProps,
   BoxSides,
   CellStyle,
   ListProps,
+  MultiVariableTextProps,
+  MultiVariableTextValues,
   PageProps,
   PdfJsxChild,
   PdfJsxElement,
@@ -249,6 +257,12 @@ const renderElement = async (
         frame,
         ctx,
       );
+    case 'multiVariableText':
+      return renderMultiVariableText(
+        { ...(element.props as MultiVariableTextProps), children: element.children },
+        frame,
+        ctx,
+      );
     case 'list':
       return renderList(
         { ...(element.props as ListProps), children: element.children },
@@ -397,6 +411,77 @@ const renderText = async (
   return { width, height: schema.height };
 };
 
+const renderMultiVariableText = async (
+  props: MultiVariableTextProps,
+  frame: Rect,
+  ctx: RenderCtx,
+): Promise<{ width: number; height: number }> => {
+  const fontSize = props.size ?? DEFAULT_FONT_SIZE;
+  const lineHeight = props.lineHeight ?? DEFAULT_LINE_HEIGHT;
+  const width = props.width ?? frame.width;
+  const templateText = props.text ?? childrenToString(props.children);
+  const values = normalizeMultiVariableTextValues(props.values);
+  const variables = resolveMultiVariableTextVariables(templateText, props.variables, values);
+  const name = resolveName(ctx, 'multiVariableText', props.name);
+  const readOnly = props.readOnly ?? props.name == null;
+  const textFormat = props.textFormat ?? 'plain';
+  const content = readOnly
+    ? substituteMultiVariableText(templateText, values, textFormat === 'inline-markdown')
+    : JSON.stringify(values);
+
+  const schema: MultiVariableTextSchema = {
+    name,
+    type: 'multiVariableText',
+    content,
+    position: { x: frame.x, y: frame.y },
+    width,
+    height: props.height ?? 0,
+    rotate: props.rotate ?? 0,
+    opacity: props.opacity ?? 1,
+    readOnly,
+    required: props.required,
+    alignment: props.align ?? 'left',
+    verticalAlignment: props.valign ?? 'top',
+    fontSize,
+    fontName: props.font ?? ctx.defaultFont,
+    lineHeight,
+    characterSpacing: props.spacing ?? DEFAULT_CHARACTER_SPACING,
+    fontColor: props.color ?? DEFAULT_FONT_COLOR,
+    backgroundColor: props.background ?? '',
+    textFormat,
+    overflow: props.overflow,
+    strikethrough: props.strikethrough ?? false,
+    underline: props.underline ?? false,
+    text: templateText,
+    variables,
+  };
+
+  if (props.borderColor) schema.borderColor = props.borderColor;
+  if (props.borderWidth != null) schema.borderWidth = props.borderWidth;
+  if (props.dynamicFontSize) {
+    schema.dynamicFontSize = {
+      min: props.dynamicFontSize.min ?? DEFAULT_DYNAMIC_FONT_SIZE.min,
+      max: props.dynamicFontSize.max ?? DEFAULT_DYNAMIC_FONT_SIZE.max,
+      fit: props.dynamicFontSize.fit ?? DEFAULT_DYNAMIC_FONT_SIZE.fit,
+    };
+  }
+  if (props.height == null) {
+    const measureValue = readOnly
+      ? content
+      : substituteMultiVariableText(templateText, values, textFormat === 'inline-markdown');
+    schema.height = await measureTextHeight({
+      value: measureValue,
+      schema,
+      font: ctx.font,
+      _cache: ctx._cache,
+    });
+  }
+  if (!readOnly) ctx.inputs[name] = content;
+  ctx.schemas.push(schema);
+
+  return { width, height: schema.height };
+};
+
 const renderList = (
   props: ListProps,
   frame: Rect,
@@ -518,6 +603,56 @@ const normalizeListItems = (props: ListProps): { text: string; level: number }[]
 
 const serializeListItem = (item: { text: string; level: number }) =>
   `${'\t'.repeat(Math.max(0, item.level))}${item.text}`;
+
+const normalizeMultiVariableTextValues = (
+  values: MultiVariableTextValues | undefined,
+): Record<string, string> => {
+  const normalized: Record<string, string> = {};
+  Object.entries(values ?? {}).forEach(([key, value]) => {
+    normalized[key] = value == null ? '' : String(value);
+  });
+  return normalized;
+};
+
+const resolveMultiVariableTextVariables = (
+  templateText: string,
+  variables: string[] | undefined,
+  values: Record<string, string>,
+) => {
+  const result: string[] = [];
+  const seen = new Set<string>();
+  const add = (name: string) => {
+    if (!seen.has(name)) {
+      seen.add(name);
+      result.push(name);
+    }
+  };
+
+  variables?.forEach(add);
+  getVariableNames(templateText).forEach(add);
+  Object.keys(values).forEach(add);
+  return result;
+};
+
+const substituteMultiVariableText = (
+  templateText: string,
+  values: Record<string, string>,
+  escapeMarkdown: boolean,
+) => {
+  let result = '';
+  let lastIndex = 0;
+
+  visitVariables(templateText, ({ name, startIndex, endIndex }) => {
+    result += templateText.slice(lastIndex, startIndex);
+    const value = values[name];
+    if (value != null) {
+      result += escapeMarkdown ? escapeInlineMarkdown(value) : value;
+    }
+    lastIndex = endIndex + 1;
+  });
+
+  return result + templateText.slice(lastIndex);
+};
 
 const normalizeColumnWidths = (widths: number[] | undefined, columnCount: number): number[] => {
   if (widths && widths.length > 0) return widths;

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -6,6 +6,7 @@ import type {
   CellStyle as SchemaCellStyle,
   TableSchema,
   TextSchema,
+  MultiVariableTextSchema,
 } from '@pdfme/schemas/types';
 export type { PageOrientation, PageSize, PageSizePreset } from '@pdfme/common';
 
@@ -16,6 +17,7 @@ export type BuiltinKind =
   | 'box'
   | 'spacer'
   | 'text'
+  | 'multiVariableText'
   | 'list'
   | 'table'
   | 'pagebreak';
@@ -131,6 +133,42 @@ export type TextProps = CommonProps &
     borderColor?: string;
     borderWidth?: number;
     dynamicFontSize?: Partial<NonNullable<TextSchema['dynamicFontSize']>>;
+  };
+
+export type MultiVariableTextValues = Record<string, string | number | boolean | null | undefined>;
+
+type MultiVariableTextSchemaProps = Partial<
+  Pick<
+    MultiVariableTextSchema,
+    | 'name'
+    | 'width'
+    | 'height'
+    | 'lineHeight'
+    | 'strikethrough'
+    | 'underline'
+    | 'readOnly'
+    | 'required'
+    | 'textFormat'
+    | 'overflow'
+  >
+>;
+
+export type MultiVariableTextProps = CommonProps &
+  MultiVariableTextSchemaProps & {
+    children?: PdfJsxChild;
+    text?: string;
+    variables?: string[];
+    values?: MultiVariableTextValues;
+    size?: MultiVariableTextSchema['fontSize'];
+    font?: MultiVariableTextSchema['fontName'];
+    align?: MultiVariableTextSchema['alignment'];
+    valign?: MultiVariableTextSchema['verticalAlignment'];
+    spacing?: MultiVariableTextSchema['characterSpacing'];
+    color?: MultiVariableTextSchema['fontColor'];
+    background?: MultiVariableTextSchema['backgroundColor'];
+    borderColor?: string;
+    borderWidth?: number;
+    dynamicFontSize?: Partial<NonNullable<MultiVariableTextSchema['dynamicFontSize']>>;
   };
 
 export type ListItem = string | { text: SchemaListItem['text']; level?: SchemaListItem['level'] };

--- a/packages/schemas/src/utils.ts
+++ b/packages/schemas/src/utils.ts
@@ -4,6 +4,8 @@ import { Schema, mm2pt, Mode, isHexValid, ColorType } from '@pdfme/common';
 import { IconNode } from 'lucide';
 import { getDynamicHeightsForTable as _getDynamicHeightsForTable } from './tables/dynamicTemplate.js';
 export { measureTextHeight } from './text/measure.js';
+export { escapeInlineMarkdown } from './text/inlineMarkdown.js';
+export { getVariableNames, visitVariables } from './multiVariableText/variables.js';
 export const convertForPdfLayoutProps = ({
   schema,
   pageHeight,


### PR DESCRIPTION
## Summary
- add a JSX <MultiVariableText> component that emits pdfme multiVariableText schemas
- support text/children template strings, values JSON inputs, inferred variables, read-only resolved text, and auto height measurement
- export component/types and document the API in @pdfme/jsx README
- update PLAN.md with the component extension direction

## Tests
- npm run test -w packages/jsx
- npm run lint -w packages/jsx
- npm run build -w packages/jsx
- npm run build
- git diff --check