### PR TITLE
[codex] Reject editable JSX inline-markdown Text

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -26,8 +26,9 @@ pdfme `Template` と `inputs` を生成できるようにする。
 
 - main にはリンク基盤、`@pdfme/jsx` MVP、text / MVT dynamic layout、split metadata 共通化、
   custom `basePdf` 制御、dynamic layout docs、MVT split chunk 編集、`MultiVariableText`
-  component まで入っている。
-- PR #1476 では `@pdfme/jsx` に `Image`, `Svg`, `Rectangle`, `Ellipse`, `Line` を追加中。
+  component、visual components まで入っている。
+- 別 PR で、`@pdfme/jsx` の editable `Text` に `textFormat: "inline-markdown"` を指定できない
+  guard を追加中。
 - `Barcode`, `Date`, Form 系 schema は md2pdf でのユースケースがまだ薄いため一旦スキップする。
 - 次の主な判断軸は、`@pdfme/jsx` の layout 品質、`md2pdf` MVP の写像範囲、GFM と pdfme
   独自拡張の境界。
@@ -125,6 +126,7 @@ pdfme `Template` と `inputs` を生成できるようにする。
 - PR #1472: plain MVT split chunk の Form 変数編集。
 - PR #1474: inline-markdown MVT split chunk の Form 変数編集、static link の clickable 表示。
 - PR #1475: `@pdfme/jsx` `MultiVariableText` component。
+- PR #1476: `@pdfme/jsx` `Image`, `Svg`, `Rectangle`, `Ellipse`, `Line` visual components。
 
 ## 参考
 

--- a/packages/jsx/README.md
+++ b/packages/jsx/README.md
@@ -30,6 +30,7 @@ it provides its own `jsx-runtime` and `jsx-dev-runtime`.
 
 - `Text` and `MultiVariableText` heights are measured with pdfme's text/rich text wrapping helpers
   when `height` is omitted. Pass an explicit `height` when you need a fixed field box.
+- `Text textFormat="inline-markdown"` is read-only only. Editable `Text` values use plain content.
 - `MultiVariableText` uses `text` or children as the template string and stores `values` as the
   JSON input. Variable names are inferred from `{name}` placeholders and can also be passed with
   `variables`.

--- a/packages/jsx/src/__tests__/render.test.tsx
+++ b/packages/jsx/src/__tests__/render.test.tsx
@@ -629,4 +629,16 @@ describe('@pdfme/jsx renderToTemplate', () => {
     });
     expect(result.template.schemas[0]?.[0]?.height).toBeGreaterThan(0);
   });
+
+  it('rejects inline-markdown for editable Text', async () => {
+    await expect(
+      renderToTemplate(
+        <Page>
+          <Text name="message" textFormat="inline-markdown">
+            [pdfme](https://pdfme.com)
+          </Text>
+        </Page>,
+      ),
+    ).rejects.toThrow('editable <Text> does not support textFormat="inline-markdown"');
+  });
 });

--- a/packages/jsx/src/render.ts
+++ b/packages/jsx/src/render.ts
@@ -388,8 +388,15 @@ const renderText = async (
   const lineHeight = props.lineHeight ?? DEFAULT_LINE_HEIGHT;
   const width = props.width ?? frame.width;
   const value = childrenToString(props.children);
-  const name = resolveName(ctx, 'text', props.name);
   const readOnly = props.readOnly ?? props.name == null;
+  const textFormat = props.textFormat ?? 'plain';
+
+  if (!readOnly && textFormat === 'inline-markdown') {
+    throw new Error(
+      '@pdfme/jsx: editable <Text> does not support textFormat="inline-markdown". Use read-only <Text> or <MultiVariableText>.',
+    );
+  }
+  const name = resolveName(ctx, 'text', props.name);
 
   const schema: TextSchema = {
     name,
@@ -410,7 +417,7 @@ const renderText = async (
     characterSpacing: props.spacing ?? DEFAULT_CHARACTER_SPACING,
     fontColor: props.color ?? DEFAULT_FONT_COLOR,
     backgroundColor: props.background ?? '',
-    textFormat: props.textFormat ?? 'plain',
+    textFormat,
     overflow: props.overflow,
     strikethrough: props.strikethrough ?? false,
     underline: props.underline ?? false,


### PR DESCRIPTION
## Summary
- reject @pdfme/jsx editable <Text> when textFormat is inline-markdown
- keep read-only inline-markdown Text supported
- document the constraint in the JSX README and update PLAN.md

## Tests
- npm run test -w packages/jsx
- npm run lint -w packages/jsx
- npm run build -w packages/jsx
- npm run build
- git diff --check