### PR TITLE
[codex] Add JSX layout margins and alignment

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -26,7 +26,8 @@ pdfme `Template` と `inputs` を生成できるようにする。
 
 - main にはリンク基盤、`@pdfme/jsx` MVP、text / MVT dynamic layout、split metadata 共通化、
   custom `basePdf` 制御、dynamic layout docs、MVT split chunk 編集、`MultiVariableText`
-  component、visual components、editable `Text` の inline-markdown guard まで入っている。
+  component、visual components、editable `Text` の inline-markdown guard、MVT split chunk の
+  連続編集検証まで入っている。
 - `Barcode`, `Date`, Form 系 schema は md2pdf でのユースケースがまだ薄いため一旦スキップする。
 - 次の主な判断軸は、`@pdfme/jsx` の layout 品質、`md2pdf` MVP の写像範囲、GFM と pdfme
   独自拡張の境界。
@@ -36,7 +37,9 @@ pdfme `Template` と `inputs` を生成できるようにする。
 ### 1. `@pdfme/jsx` layout 品質
 
 - CSS/Flexbox 互換を目指さず、flexbox の使いやすさだけを `Stack` / `Row` に取り込む。
-- 優先候補は `justifyContent`, `alignItems`, `flex` / `flexGrow`, `margin`。
+- まず `margin` と `alignItems` を小さく入れ、Markdown block の余白と cross-axis の揃えを
+  表現しやすくする。
+- 次の候補は `justifyContent`, `flex` / `flexGrow`。複雑な flexbox 互換に寄せすぎない。
 - `flexWrap`, `flexShrink`, media query, full `style` prop, CSS parser は当面対象外。
 - `%` width は将来検討でよい。まずは `flex` / `flexGrow` で比率指定を表現できるか見る。
 - `Absolute` は stacking layout から外れた補助配置として必要になりうるが、乱用されると JSX の
@@ -118,6 +121,7 @@ pdfme `Template` と `inputs` を生成できるようにする。
 - PR #1475: `@pdfme/jsx` `MultiVariableText` component。
 - PR #1476: `@pdfme/jsx` `Image`, `Svg`, `Rectangle`, `Ellipse`, `Line` visual components。
 - PR #1477: `@pdfme/jsx` editable `Text` で `textFormat: "inline-markdown"` を禁止。
+- PR #1478: MVT split chunk の連続編集を plain / inline-markdown ともに回帰テストで固定。
 
 ## 参考
 

--- a/packages/jsx/README.md
+++ b/packages/jsx/README.md
@@ -42,6 +42,9 @@ it provides its own `jsx-runtime` and `jsx-dev-runtime`.
   shapes.
 - Layout children can use `margin`. `Stack` and `Row` support `alignItems` for simple cross-axis
   alignment without trying to implement full CSS/Flexbox.
+- `Stack` defaults to `alignItems="stretch"` to preserve full-width stacking. Use an explicit child
+  `width` when you want `alignItems="center"` or `"end"` to visibly move that child.
+- `Row` defaults to `alignItems="start"` and intentionally does not support cross-axis stretch yet.
 - `PageBreak` is supported only along a `Page` / `Stack` / `Box` layout path. It is rejected inside
   `Row`, leaf schemas, `List`, and `Table`.
 - All `Page` nodes in one `renderToTemplate` call must use the same page size, orientation, and

--- a/packages/jsx/README.md
+++ b/packages/jsx/README.md
@@ -40,6 +40,8 @@ it provides its own `jsx-runtime` and `jsx-dev-runtime`.
   content.
 - `Rectangle`, `Ellipse`, and `Line` are static visual schemas for backgrounds, dividers, and simple
   shapes.
+- Layout children can use `margin`. `Stack` and `Row` support `alignItems` for simple cross-axis
+  alignment without trying to implement full CSS/Flexbox.
 - `PageBreak` is supported only along a `Page` / `Stack` / `Box` layout path. It is rejected inside
   `Row`, leaf schemas, `List`, and `Table`.
 - All `Page` nodes in one `renderToTemplate` call must use the same page size, orientation, and

--- a/packages/jsx/src/__tests__/render.test.tsx
+++ b/packages/jsx/src/__tests__/render.test.tsx
@@ -252,6 +252,21 @@ describe('@pdfme/jsx renderToTemplate', () => {
     expect(second?.position.y).toBe(11);
   });
 
+  it('accounts for Spacer margins in Stack layout', async () => {
+    const result = await renderToTemplate(
+      <Page size={{ width: 100, height: 100 }} margin={0}>
+        <Stack gap={1}>
+          <Text height={4}>A</Text>
+          <Spacer height={3} margin={{ top: 2, bottom: 5 }} />
+          <Text height={4}>B</Text>
+        </Stack>
+      </Page>,
+    );
+
+    const [, second] = result.template.schemas[0] ?? [];
+    expect(second?.position.y).toBe(16);
+  });
+
   it('aligns fixed-width Stack children on the cross axis', async () => {
     const result = await renderToTemplate(
       <Page size={{ width: 100, height: 100 }} margin={0}>

--- a/packages/jsx/src/__tests__/render.test.tsx
+++ b/packages/jsx/src/__tests__/render.test.tsx
@@ -232,6 +232,43 @@ describe('@pdfme/jsx renderToTemplate', () => {
     expect(second?.position.y).toBe(14);
   });
 
+  it('accounts for child margins in Stack layout', async () => {
+    const result = await renderToTemplate(
+      <Page size={{ width: 100, height: 100 }} margin={0}>
+        <Stack gap={2}>
+          <Text height={6} margin={{ top: 1, bottom: 2, left: 3 }}>
+            A
+          </Text>
+          <Text height={6}>B</Text>
+        </Stack>
+      </Page>,
+    );
+
+    const [first, second] = result.template.schemas[0] ?? [];
+    expect(first).toMatchObject({
+      position: { x: 3, y: 1 },
+      width: 97,
+    });
+    expect(second?.position.y).toBe(11);
+  });
+
+  it('aligns fixed-width Stack children on the cross axis', async () => {
+    const result = await renderToTemplate(
+      <Page size={{ width: 100, height: 100 }} margin={0}>
+        <Stack alignItems="center">
+          <Text width={40} height={6}>
+            Centered
+          </Text>
+        </Stack>
+      </Page>,
+    );
+
+    expect(result.template.schemas[0]?.[0]).toMatchObject({
+      position: { x: 30, y: 0 },
+      width: 40,
+    });
+  });
+
   it('measures Text auto height with pdfme text wrapping', async () => {
     const singleLine = await renderToTemplate(
       <Page margin={0}>
@@ -265,6 +302,67 @@ describe('@pdfme/jsx renderToTemplate', () => {
     expect(flex1?.width).toBe(36);
     expect(flex2?.position.x).toBe(64);
     expect(flex2?.width).toBe(36);
+  });
+
+  it('accounts for child margins when distributing Row width', async () => {
+    const result = await renderToTemplate(
+      <Page size={{ width: 100, height: 100 }} margin={0}>
+        <Row gap={4}>
+          <Text width={20} margin={{ right: 2 }}>
+            Fixed
+          </Text>
+          <Text margin={{ left: 2 }}>Flex 1</Text>
+          <Text>Flex 2</Text>
+        </Row>
+      </Page>,
+    );
+
+    const [, flex1, flex2] = result.template.schemas[0] ?? [];
+    expect(flex1).toMatchObject({
+      position: { x: 28, y: 0 },
+      width: 34,
+    });
+    expect(flex2).toMatchObject({
+      position: { x: 66, y: 0 },
+      width: 34,
+    });
+  });
+
+  it('aligns Row children on the cross axis', async () => {
+    const result = await renderToTemplate(
+      <Page size={{ width: 100, height: 100 }} margin={0}>
+        <Row alignItems="center">
+          <Text width={20} height={6}>
+            Small
+          </Text>
+          <Text width={20} height={14}>
+            Tall
+          </Text>
+        </Row>
+      </Page>,
+    );
+
+    const [small, tall] = result.template.schemas[0] ?? [];
+    expect(small?.position.y).toBe(4);
+    expect(tall?.position.y).toBe(0);
+  });
+
+  it('uses explicit Row height for Stack advancement', async () => {
+    const result = await renderToTemplate(
+      <Page size={{ width: 100, height: 100 }} margin={0}>
+        <Stack>
+          <Row height={20}>
+            <Text width={20} height={6}>
+              Row item
+            </Text>
+          </Row>
+          <Text height={6}>After row</Text>
+        </Stack>
+      </Page>,
+    );
+
+    const [, after] = result.template.schemas[0] ?? [];
+    expect(after?.position.y).toBe(20);
   });
 
   it('renders Box background before its children', async () => {

--- a/packages/jsx/src/render.ts
+++ b/packages/jsx/src/render.ts
@@ -43,6 +43,9 @@ import type {
 } from './types.js';
 
 type Rect = { x: number; y: number; width: number; height: number };
+type Box = ReturnType<typeof resolveBoxSides>;
+type LayoutMode = 'stack' | 'row';
+type LayoutAlignItems = 'start' | 'center' | 'end' | 'stretch';
 
 type RenderCtx = {
   schemas: Schema[];
@@ -111,7 +114,7 @@ export const renderToTemplate = async (
       font,
       _cache,
     };
-    await layoutChildren(page.children, frame, 'stack', { gap: 0 }, ctx);
+    await layoutChildren(page.children, frame, 'stack', { gap: 0, alignItems: 'stretch' }, ctx);
     pageSchemas.push(ctx.schemas);
   }
 
@@ -191,36 +194,71 @@ const expandPageBreaks = (node: PdfJsxChild): PdfJsxChild[] =>
 const layoutChildren = async (
   children: PdfJsxChild | PdfJsxChild[],
   frame: Rect,
-  mode: 'stack' | 'row',
-  opts: { gap: number },
+  mode: LayoutMode,
+  opts: { gap: number; alignItems: LayoutAlignItems; crossSize?: number },
   ctx: RenderCtx,
 ): Promise<{ width: number; height: number }> => {
   const items = flattenChildren(children);
   const widths = mode === 'row' ? resolveRowWidths(items, frame.width, opts.gap) : undefined;
   let cursor = 0;
   let crossMax = 0;
+  const rowItems: { schemaStart: number; schemaEnd: number; outerHeight: number }[] = [];
 
   for (let i = 0; i < items.length; i += 1) {
     const child = items[i];
-    const width = mode === 'row' ? (widths?.[i] ?? 0) : frame.width;
+    const margin = getChildMargin(child);
+    const width =
+      mode === 'row' ? (widths?.[i] ?? 0) : resolveStackChildWidth(child, frame.width, margin);
     const childFrame =
       mode === 'stack'
         ? { x: frame.x, y: frame.y + cursor, width, height: Math.max(0, frame.height - cursor) }
         : { x: frame.x + cursor, y: frame.y, width, height: frame.height };
+    childFrame.x += margin.left;
+    childFrame.y += margin.top;
+    childFrame.height = Math.max(0, childFrame.height - margin.top - margin.bottom);
 
+    const schemaStart = ctx.schemas.length;
     const size =
       typeof child === 'string' || typeof child === 'number'
         ? await renderText({ children: String(child) }, childFrame, ctx)
         : await renderElement(child, childFrame, mode, ctx);
+    const schemaEnd = ctx.schemas.length;
 
-    const advance = mode === 'stack' ? size.height : width;
+    if (mode === 'stack') {
+      const outerWidth = margin.left + size.width + margin.right;
+      const dx = resolveAlignOffset(frame.width, outerWidth, opts.alignItems);
+      if (dx !== 0) shiftSchemas(ctx.schemas, schemaStart, schemaEnd, dx, 0);
+    } else {
+      rowItems.push({
+        schemaStart,
+        schemaEnd,
+        outerHeight: margin.top + size.height + margin.bottom,
+      });
+    }
+
+    const advance =
+      mode === 'stack'
+        ? margin.top + size.height + margin.bottom
+        : margin.left + width + margin.right;
     cursor += advance + (i < items.length - 1 ? opts.gap : 0);
-    crossMax = Math.max(crossMax, mode === 'stack' ? size.width : size.height);
+    crossMax = Math.max(
+      crossMax,
+      mode === 'stack'
+        ? margin.left + size.width + margin.right
+        : margin.top + size.height + margin.bottom,
+    );
   }
 
-  return mode === 'stack'
-    ? { width: crossMax, height: cursor }
-    : { width: cursor, height: crossMax };
+  if (mode === 'row') {
+    const rowHeight = opts.crossSize ?? crossMax;
+    for (const item of rowItems) {
+      const dy = resolveAlignOffset(rowHeight, item.outerHeight, opts.alignItems);
+      if (dy !== 0) shiftSchemas(ctx.schemas, item.schemaStart, item.schemaEnd, 0, dy);
+    }
+    return { width: cursor, height: rowHeight };
+  }
+
+  return { width: crossMax, height: cursor };
 };
 
 const resolveRowWidths = (
@@ -231,16 +269,19 @@ const resolveRowWidths = (
   let fixedWidth = 0;
   let flexCount = 0;
   const widths = items.map((item) => {
+    const margin = getChildMargin(item);
     if (typeof item === 'string' || typeof item === 'number') {
       flexCount += 1;
+      fixedWidth += margin.left + margin.right;
       return undefined;
     }
     const width = (item.props as { width?: number }).width;
     if (typeof width === 'number') {
-      fixedWidth += width;
+      fixedWidth += width + margin.left + margin.right;
       return width;
     }
     flexCount += 1;
+    fixedWidth += margin.left + margin.right;
     return undefined;
   });
 
@@ -249,10 +290,48 @@ const resolveRowWidths = (
   return widths.map((width) => width ?? flexWidth);
 };
 
+const getChildMargin = (child: PdfJsxElement | string | number): Box => {
+  if (typeof child === 'string' || typeof child === 'number') return resolveBoxSides();
+  return resolveBoxSides((child.props as { margin?: number | BoxSides }).margin);
+};
+
+const resolveStackChildWidth = (
+  child: PdfJsxElement | string | number,
+  frameWidth: number,
+  margin: Box,
+) => {
+  if (typeof child !== 'string' && typeof child !== 'number') {
+    const width = (child.props as { width?: number }).width;
+    if (typeof width === 'number') return width;
+  }
+  return Math.max(0, frameWidth - margin.left - margin.right);
+};
+
+const resolveAlignOffset = (
+  containerSize: number,
+  itemSize: number,
+  alignItems: LayoutAlignItems,
+) => {
+  if (alignItems === 'center') return Math.max(0, (containerSize - itemSize) / 2);
+  if (alignItems === 'end') return Math.max(0, containerSize - itemSize);
+  return 0;
+};
+
+const shiftSchemas = (schemas: Schema[], start: number, end: number, dx: number, dy: number) => {
+  for (let i = start; i < end; i += 1) {
+    const schema = schemas[i];
+    if (!schema) continue;
+    schema.position = {
+      x: schema.position.x + dx,
+      y: schema.position.y + dy,
+    };
+  }
+};
+
 const renderElement = async (
   element: PdfJsxElement,
   frame: Rect,
-  parentMode: 'stack' | 'row',
+  parentMode: LayoutMode,
   ctx: RenderCtx,
 ): Promise<{ width: number; height: number }> => {
   switch (element.kind) {
@@ -311,6 +390,7 @@ const renderStack = (
     'stack',
     {
       gap: props.gap ?? 0,
+      alignItems: props.alignItems ?? 'stretch',
     },
     ctx,
   );
@@ -325,7 +405,7 @@ const renderRow = (
     children,
     { ...frame, width: props.width ?? frame.width, height: props.height ?? frame.height },
     'row',
-    { gap: props.gap ?? 0 },
+    { gap: props.gap ?? 0, alignItems: props.alignItems ?? 'start', crossSize: props.height },
     ctx,
   );
 
@@ -333,7 +413,7 @@ const renderBox = async (
   props: BoxProps,
   children: PdfJsxChild[],
   frame: Rect,
-  _parentMode: 'stack' | 'row',
+  _parentMode: LayoutMode,
   ctx: RenderCtx,
 ): Promise<{ width: number; height: number }> => {
   const width = props.width ?? frame.width;
@@ -364,7 +444,13 @@ const renderBox = async (
     width: width - padding.left - padding.right,
     height: (props.height ?? frame.height) - padding.top - padding.bottom,
   };
-  const childSize = await layoutChildren(children, innerFrame, 'stack', { gap: 0 }, ctx);
+  const childSize = await layoutChildren(
+    children,
+    innerFrame,
+    'stack',
+    { gap: 0, alignItems: 'stretch' },
+    ctx,
+  );
   const height = props.height ?? childSize.height + padding.top + padding.bottom;
 
   if (needsRect) {

--- a/packages/jsx/src/render.ts
+++ b/packages/jsx/src/render.ts
@@ -25,6 +25,7 @@ import type {
   EllipseProps,
   ImageProps,
   LineProps,
+  LayoutAlignItems,
   ListProps,
   MultiVariableTextProps,
   MultiVariableTextValues,
@@ -45,7 +46,6 @@ import type {
 type Rect = { x: number; y: number; width: number; height: number };
 type Box = ReturnType<typeof resolveBoxSides>;
 type LayoutMode = 'stack' | 'row';
-type LayoutAlignItems = 'start' | 'center' | 'end' | 'stretch';
 
 type RenderCtx = {
   schemas: Schema[];
@@ -312,6 +312,7 @@ const resolveAlignOffset = (
   itemSize: number,
   alignItems: LayoutAlignItems,
 ) => {
+  // Overflowing children stay pinned to start instead of being pulled outside the frame.
   if (alignItems === 'center') return Math.max(0, (containerSize - itemSize) / 2);
   if (alignItems === 'end') return Math.max(0, containerSize - itemSize);
   return 0;

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -74,7 +74,13 @@ export type BoxSides = {
   y?: number;
 };
 
-export type CommonProps = Partial<Pick<Schema, 'rotate' | 'opacity'>>;
+export type LayoutAlignItems = 'start' | 'center' | 'end' | 'stretch';
+
+export type LayoutProps = {
+  margin?: number | BoxSides;
+};
+
+export type CommonProps = LayoutProps & Partial<Pick<Schema, 'rotate' | 'opacity'>>;
 
 export type PageProps = {
   size?: PageSize;
@@ -84,16 +90,18 @@ export type PageProps = {
   children?: PdfJsxChild;
 };
 
-export type StackProps = {
+export type StackProps = LayoutProps & {
   gap?: number;
   width?: number;
+  alignItems?: LayoutAlignItems;
   children?: PdfJsxChild;
 };
 
-export type RowProps = {
+export type RowProps = LayoutProps & {
   gap?: number;
   width?: number;
   height?: number;
+  alignItems?: Exclude<LayoutAlignItems, 'stretch'>;
   children?: PdfJsxChild;
 };
 
@@ -108,7 +116,7 @@ export type BoxProps = CommonProps & {
   children?: PdfJsxChild;
 };
 
-export type SpacerProps = {
+export type SpacerProps = LayoutProps & {
   width?: number;
   height?: number;
 };


### PR DESCRIPTION
## Summary

This PR improves the `@pdfme/jsx` stacking layout primitives without turning them into a full CSS/Flexbox implementation.

- Add shared `margin` support for JSX layout children.
- Add cross-axis `alignItems` support to `Stack` and `Row`.
- Make explicit `Row height` participate in parent `Stack` advancement.
- Update `PLAN.md` and the `@pdfme/jsx` README with the current layout direction.

## Notes

- `justifyContent`, `flex`, and `flexGrow` are intentionally left for follow-up PRs.
- This keeps `@pdfme/jsx` as a compact authoring DSL for pdfme templates, not a general CSS layout engine.

## Tests

- `npm run fmt -w packages/jsx`
- `npm run test -w packages/jsx`
- `npm run lint -w packages/jsx`
- `npm run build -w packages/jsx`
- `git diff --check`