### PR TITLE
[codex] Add JSX flex grow and justify content

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -27,7 +27,7 @@ pdfme `Template` と `inputs` を生成できるようにする。
 - main にはリンク基盤、`@pdfme/jsx` MVP、text / MVT dynamic layout、split metadata 共通化、
   custom `basePdf` 制御、dynamic layout docs、MVT split chunk 編集、`MultiVariableText`
   component、visual components、editable `Text` の inline-markdown guard、MVT split chunk の
-  連続編集検証まで入っている。
+  連続編集検証、JSX layout の `margin` / `alignItems` まで入っている。
 - `Barcode`, `Date`, Form 系 schema は md2pdf でのユースケースがまだ薄いため一旦スキップする。
 - 次の主な判断軸は、`@pdfme/jsx` の layout 品質、`md2pdf` MVP の写像範囲、GFM と pdfme
   独自拡張の境界。
@@ -37,11 +37,10 @@ pdfme `Template` と `inputs` を生成できるようにする。
 ### 1. `@pdfme/jsx` layout 品質
 
 - CSS/Flexbox 互換を目指さず、flexbox の使いやすさだけを `Stack` / `Row` に取り込む。
-- まず `margin` と `alignItems` を小さく入れ、Markdown block の余白と cross-axis の揃えを
-  表現しやすくする。
-- 次の候補は `justifyContent`, `flex` / `flexGrow`。複雑な flexbox 互換に寄せすぎない。
+- 次は `justifyContent`, `flex` / `flexGrow` を小さく入れ、Markdown block の比率指定と main-axis
+  の余白配分を表現しやすくする。複雑な flexbox 互換に寄せすぎない。
 - `flexWrap`, `flexShrink`, media query, full `style` prop, CSS parser は当面対象外。
-- `%` width は将来検討でよい。まずは `flex` / `flexGrow` で比率指定を表現できるか見る。
+- `%` width は将来検討でよい。まずは `flex` / `flexGrow` で比率指定を表現する。
 - `Absolute` は stacking layout から外れた補助配置として必要になりうるが、乱用されると JSX の
   価値が薄れるため API は慎重にする。
 - header / footer を `staticSchemas` に接続するか検討する。
@@ -122,6 +121,7 @@ pdfme `Template` と `inputs` を生成できるようにする。
 - PR #1476: `@pdfme/jsx` `Image`, `Svg`, `Rectangle`, `Ellipse`, `Line` visual components。
 - PR #1477: `@pdfme/jsx` editable `Text` で `textFormat: "inline-markdown"` を禁止。
 - PR #1478: MVT split chunk の連続編集を plain / inline-markdown ともに回帰テストで固定。
+- PR #1479: `@pdfme/jsx` layout に `margin` と `alignItems` を追加。
 
 ## 参考
 

--- a/packages/jsx/README.md
+++ b/packages/jsx/README.md
@@ -50,6 +50,17 @@ it provides its own `jsx-runtime` and `jsx-dev-runtime`.
 - `Row` defaults to `alignItems="start"` and intentionally does not support cross-axis stretch yet.
 - Row children can use `flexGrow` or `flex` as a grow weight. If `width` is also set, it is used as
   the basis before remaining width is distributed.
+  `flex` is only a short alias for `flexGrow`, not the CSS `flex` shorthand.
+
+```tsx
+<Row width={120}>
+  <Text width={20} flex={1}>A</Text>
+  <Text width={20} flex={3}>B</Text>
+</Row>
+// A width: 40, B width: 80
+```
+
+- `flexGrow={0}` without `width` produces a zero-width Row child.
 - `PageBreak` is supported only along a `Page` / `Stack` / `Box` layout path. It is rejected inside
   `Row`, leaf schemas, `List`, and `Table`.
 - All `Page` nodes in one `renderToTemplate` call must use the same page size, orientation, and

--- a/packages/jsx/README.md
+++ b/packages/jsx/README.md
@@ -42,9 +42,14 @@ it provides its own `jsx-runtime` and `jsx-dev-runtime`.
   shapes.
 - Layout children can use `margin`. `Stack` and `Row` support `alignItems` for simple cross-axis
   alignment without trying to implement full CSS/Flexbox.
+- `Stack` and `Row` support `justifyContent="start" | "center" | "end" | "space-between"` for
+  main-axis spacing. `Stack` uses this most predictably with an explicit `height`; `Row` uses it most
+  predictably with an explicit `width`.
 - `Stack` defaults to `alignItems="stretch"` to preserve full-width stacking. Use an explicit child
   `width` when you want `alignItems="center"` or `"end"` to visibly move that child.
 - `Row` defaults to `alignItems="start"` and intentionally does not support cross-axis stretch yet.
+- Row children can use `flexGrow` or `flex` as a grow weight. If `width` is also set, it is used as
+  the basis before remaining width is distributed.
 - `PageBreak` is supported only along a `Page` / `Stack` / `Box` layout path. It is rejected inside
   `Row`, leaf schemas, `List`, and `Table`.
 - All `Page` nodes in one `renderToTemplate` call must use the same page size, orientation, and

--- a/packages/jsx/src/__tests__/render.test.tsx
+++ b/packages/jsx/src/__tests__/render.test.tsx
@@ -284,6 +284,23 @@ describe('@pdfme/jsx renderToTemplate', () => {
     });
   });
 
+  it('justifies Stack children on the main axis when height is explicit', async () => {
+    const result = await renderToTemplate(
+      <Page size={{ width: 100, height: 100 }} margin={0}>
+        <Stack height={30} justifyContent="end">
+          <Text height={6}>A</Text>
+          <Text height={4}>B</Text>
+        </Stack>
+        <Text height={4}>After</Text>
+      </Page>,
+    );
+
+    const [first, second, after] = result.template.schemas[0] ?? [];
+    expect(first?.position.y).toBe(20);
+    expect(second?.position.y).toBe(26);
+    expect(after?.position.y).toBe(30);
+  });
+
   it('measures Text auto height with pdfme text wrapping', async () => {
     const singleLine = await renderToTemplate(
       <Page margin={0}>
@@ -317,6 +334,46 @@ describe('@pdfme/jsx renderToTemplate', () => {
     expect(flex1?.width).toBe(36);
     expect(flex2?.position.x).toBe(64);
     expect(flex2?.width).toBe(36);
+  });
+
+  it('distributes Row width by flexGrow weights', async () => {
+    const result = await renderToTemplate(
+      <Page size={{ width: 120, height: 100 }} margin={0}>
+        <Row>
+          <Text flexGrow={2}>Wide</Text>
+          <Text flex={1}>Narrow</Text>
+        </Row>
+      </Page>,
+    );
+
+    const [wide, narrow] = result.template.schemas[0] ?? [];
+    expect(wide).toMatchObject({
+      position: { x: 0, y: 0 },
+      width: 80,
+    });
+    expect(narrow).toMatchObject({
+      position: { x: 80, y: 0 },
+      width: 40,
+    });
+  });
+
+  it('uses explicit Row width as flex basis before flexGrow', async () => {
+    const result = await renderToTemplate(
+      <Page size={{ width: 120, height: 100 }} margin={0}>
+        <Row width={120}>
+          <Text width={20} flexGrow={1}>
+            A
+          </Text>
+          <Text width={20} flexGrow={3}>
+            B
+          </Text>
+        </Row>
+      </Page>,
+    );
+
+    const [first, second] = result.template.schemas[0] ?? [];
+    expect(first).toMatchObject({ position: { x: 0, y: 0 }, width: 40 });
+    expect(second).toMatchObject({ position: { x: 40, y: 0 }, width: 80 });
   });
 
   it('accounts for child margins when distributing Row width', async () => {
@@ -360,6 +417,29 @@ describe('@pdfme/jsx renderToTemplate', () => {
     const [small, tall] = result.template.schemas[0] ?? [];
     expect(small?.position.y).toBe(4);
     expect(tall?.position.y).toBe(0);
+  });
+
+  it('justifies fixed-width Row children on the main axis', async () => {
+    const result = await renderToTemplate(
+      <Page size={{ width: 100, height: 100 }} margin={0}>
+        <Row width={100} justifyContent="space-between">
+          <Text width={20} height={6}>
+            A
+          </Text>
+          <Text width={20} height={6}>
+            B
+          </Text>
+          <Text width={20} height={6}>
+            C
+          </Text>
+        </Row>
+      </Page>,
+    );
+
+    const [first, second, third] = result.template.schemas[0] ?? [];
+    expect(first?.position.x).toBe(0);
+    expect(second?.position.x).toBe(40);
+    expect(third?.position.x).toBe(80);
   });
 
   it('uses explicit Row height for Stack advancement', async () => {

--- a/packages/jsx/src/__tests__/render.test.tsx
+++ b/packages/jsx/src/__tests__/render.test.tsx
@@ -301,6 +301,21 @@ describe('@pdfme/jsx renderToTemplate', () => {
     expect(after?.position.y).toBe(30);
   });
 
+  it('returns explicit Stack height even when content overflows', async () => {
+    const result = await renderToTemplate(
+      <Page size={{ width: 100, height: 100 }} margin={0}>
+        <Stack height={5} justifyContent="center">
+          <Text height={10}>Overflow</Text>
+        </Stack>
+        <Text height={4}>After</Text>
+      </Page>,
+    );
+
+    const [overflow, after] = result.template.schemas[0] ?? [];
+    expect(overflow?.position.y).toBe(0);
+    expect(after?.position.y).toBe(5);
+  });
+
   it('measures Text auto height with pdfme text wrapping', async () => {
     const singleLine = await renderToTemplate(
       <Page margin={0}>
@@ -374,6 +389,38 @@ describe('@pdfme/jsx renderToTemplate', () => {
     const [first, second] = result.template.schemas[0] ?? [];
     expect(first).toMatchObject({ position: { x: 0, y: 0 }, width: 40 });
     expect(second).toMatchObject({ position: { x: 40, y: 0 }, width: 80 });
+  });
+
+  it('accounts for margins when distributing Row flexGrow width', async () => {
+    const result = await renderToTemplate(
+      <Page size={{ width: 120, height: 100 }} margin={0}>
+        <Row gap={4}>
+          <Text flexGrow={1} margin={{ left: 5, right: 5 }}>
+            A
+          </Text>
+          <Text flexGrow={1}>B</Text>
+        </Row>
+      </Page>,
+    );
+
+    const [first, second] = result.template.schemas[0] ?? [];
+    expect(first).toMatchObject({ position: { x: 5, y: 0 }, width: 53 });
+    expect(second).toMatchObject({ position: { x: 67, y: 0 }, width: 53 });
+  });
+
+  it('renders zero-width Row child when flexGrow is zero without width', async () => {
+    const result = await renderToTemplate(
+      <Page size={{ width: 120, height: 100 }} margin={0}>
+        <Row>
+          <Text flexGrow={0}>Zero</Text>
+          <Text>B</Text>
+        </Row>
+      </Page>,
+    );
+
+    const [zero, second] = result.template.schemas[0] ?? [];
+    expect(zero).toMatchObject({ position: { x: 0, y: 0 }, width: 0 });
+    expect(second).toMatchObject({ position: { x: 0, y: 0 }, width: 120 });
   });
 
   it('accounts for child margins when distributing Row width', async () => {

--- a/packages/jsx/src/render.ts
+++ b/packages/jsx/src/render.ts
@@ -340,6 +340,7 @@ const applyJustifyContent = (
   containerMainSize: number,
   opts: { justifyContent: LayoutJustifyContent },
 ) => {
+  // Overflowing content has no extra main-axis space to distribute.
   const extraSpace = Math.max(0, containerMainSize - contentMainSize);
   if (extraSpace === 0 || opts.justifyContent === 'start') return;
 
@@ -398,10 +399,10 @@ const renderElement = async (
   parentMode: LayoutMode,
   ctx: RenderCtx,
 ): Promise<{ width: number; height: number }> => {
-  const props =
-    parentMode === 'row' && getChildFlexGrow(element) != null
-      ? { ...element.props, width: frame.width }
-      : element.props;
+  const shouldUseResolvedRowWidth = parentMode === 'row' && getChildFlexGrow(element) != null;
+  const props = shouldUseResolvedRowWidth
+    ? { ...element.props, width: frame.width }
+    : element.props;
 
   switch (element.kind) {
     case 'stack':

--- a/packages/jsx/src/render.ts
+++ b/packages/jsx/src/render.ts
@@ -26,6 +26,7 @@ import type {
   ImageProps,
   LineProps,
   LayoutAlignItems,
+  LayoutJustifyContent,
   ListProps,
   MultiVariableTextProps,
   MultiVariableTextValues,
@@ -46,6 +47,11 @@ import type {
 type Rect = { x: number; y: number; width: number; height: number };
 type Box = ReturnType<typeof resolveBoxSides>;
 type LayoutMode = 'stack' | 'row';
+type LayoutItem = {
+  schemaStart: number;
+  schemaEnd: number;
+  outerHeight: number;
+};
 
 type RenderCtx = {
   schemas: Schema[];
@@ -114,7 +120,13 @@ export const renderToTemplate = async (
       font,
       _cache,
     };
-    await layoutChildren(page.children, frame, 'stack', { gap: 0, alignItems: 'stretch' }, ctx);
+    await layoutChildren(
+      page.children,
+      frame,
+      'stack',
+      { gap: 0, alignItems: 'stretch', justifyContent: 'start' },
+      ctx,
+    );
     pageSchemas.push(ctx.schemas);
   }
 
@@ -195,14 +207,20 @@ const layoutChildren = async (
   children: PdfJsxChild | PdfJsxChild[],
   frame: Rect,
   mode: LayoutMode,
-  opts: { gap: number; alignItems: LayoutAlignItems; crossSize?: number },
+  opts: {
+    gap: number;
+    alignItems: LayoutAlignItems;
+    justifyContent: LayoutJustifyContent;
+    mainSize?: number;
+    crossSize?: number;
+  },
   ctx: RenderCtx,
 ): Promise<{ width: number; height: number }> => {
   const items = flattenChildren(children);
   const widths = mode === 'row' ? resolveRowWidths(items, frame.width, opts.gap) : undefined;
   let cursor = 0;
   let crossMax = 0;
-  const rowItems: { schemaStart: number; schemaEnd: number; outerHeight: number }[] = [];
+  const layoutItems: LayoutItem[] = [];
 
   for (let i = 0; i < items.length; i += 1) {
     const child = items[i];
@@ -224,23 +242,21 @@ const layoutChildren = async (
         : await renderElement(child, childFrame, mode, ctx);
     const schemaEnd = ctx.schemas.length;
 
+    const mainSize =
+      mode === 'stack'
+        ? margin.top + size.height + margin.bottom
+        : margin.left + width + margin.right;
+    const outerHeight = margin.top + size.height + margin.bottom;
+
+    layoutItems.push({ schemaStart, schemaEnd, outerHeight });
+
     if (mode === 'stack') {
       const outerWidth = margin.left + size.width + margin.right;
       const dx = resolveAlignOffset(frame.width, outerWidth, opts.alignItems);
       if (dx !== 0) shiftSchemas(ctx.schemas, schemaStart, schemaEnd, dx, 0);
-    } else {
-      rowItems.push({
-        schemaStart,
-        schemaEnd,
-        outerHeight: margin.top + size.height + margin.bottom,
-      });
     }
 
-    const advance =
-      mode === 'stack'
-        ? margin.top + size.height + margin.bottom
-        : margin.left + width + margin.right;
-    cursor += advance + (i < items.length - 1 ? opts.gap : 0);
+    cursor += mainSize + (i < items.length - 1 ? opts.gap : 0);
     crossMax = Math.max(
       crossMax,
       mode === 'stack'
@@ -249,16 +265,20 @@ const layoutChildren = async (
     );
   }
 
+  const contentMainSize = cursor;
+  const containerMainSize = opts.mainSize ?? contentMainSize;
+  applyJustifyContent(ctx.schemas, layoutItems, mode, contentMainSize, containerMainSize, opts);
+
   if (mode === 'row') {
     const rowHeight = opts.crossSize ?? crossMax;
-    for (const item of rowItems) {
+    for (const item of layoutItems) {
       const dy = resolveAlignOffset(rowHeight, item.outerHeight, opts.alignItems);
       if (dy !== 0) shiftSchemas(ctx.schemas, item.schemaStart, item.schemaEnd, 0, dy);
     }
-    return { width: cursor, height: rowHeight };
+    return { width: containerMainSize, height: rowHeight };
   }
 
-  return { width: crossMax, height: cursor };
+  return { width: crossMax, height: containerMainSize };
 };
 
 const resolveRowWidths = (
@@ -266,28 +286,22 @@ const resolveRowWidths = (
   frameWidth: number,
   gap: number,
 ): number[] => {
-  let fixedWidth = 0;
-  let flexCount = 0;
-  const widths = items.map((item) => {
+  let usedWidth = 0;
+  let totalGrow = 0;
+  const parts = items.map((item) => {
     const margin = getChildMargin(item);
-    if (typeof item === 'string' || typeof item === 'number') {
-      flexCount += 1;
-      fixedWidth += margin.left + margin.right;
-      return undefined;
-    }
-    const width = (item.props as { width?: number }).width;
-    if (typeof width === 'number') {
-      fixedWidth += width + margin.left + margin.right;
-      return width;
-    }
-    flexCount += 1;
-    fixedWidth += margin.left + margin.right;
-    return undefined;
+    const width = getChildWidth(item);
+    const flexGrow = getChildFlexGrow(item);
+    const grow = flexGrow ?? (width == null ? 1 : 0);
+    const basis = width ?? 0;
+    usedWidth += basis + margin.left + margin.right;
+    totalGrow += grow;
+    return { basis, grow };
   });
 
-  const remaining = Math.max(0, frameWidth - fixedWidth - Math.max(0, items.length - 1) * gap);
-  const flexWidth = flexCount > 0 ? remaining / flexCount : 0;
-  return widths.map((width) => width ?? flexWidth);
+  const remaining = Math.max(0, frameWidth - usedWidth - Math.max(0, items.length - 1) * gap);
+  const flexUnit = totalGrow > 0 ? remaining / totalGrow : 0;
+  return parts.map(({ basis, grow }) => basis + grow * flexUnit);
 };
 
 const getChildMargin = (child: PdfJsxElement | string | number): Box => {
@@ -295,16 +309,65 @@ const getChildMargin = (child: PdfJsxElement | string | number): Box => {
   return resolveBoxSides((child.props as { margin?: number | BoxSides }).margin);
 };
 
+const getChildWidth = (child: PdfJsxElement | string | number): number | undefined => {
+  if (typeof child === 'string' || typeof child === 'number') return undefined;
+  const width = (child.props as { width?: number }).width;
+  return typeof width === 'number' ? width : undefined;
+};
+
+const getChildFlexGrow = (child: PdfJsxElement | string | number): number | undefined => {
+  if (typeof child === 'string' || typeof child === 'number') return undefined;
+  const props = child.props as { flex?: number; flexGrow?: number };
+  const flexGrow = props.flexGrow ?? props.flex;
+  return typeof flexGrow === 'number' ? Math.max(0, flexGrow) : undefined;
+};
+
 const resolveStackChildWidth = (
   child: PdfJsxElement | string | number,
   frameWidth: number,
   margin: Box,
 ) => {
-  if (typeof child !== 'string' && typeof child !== 'number') {
-    const width = (child.props as { width?: number }).width;
-    if (typeof width === 'number') return width;
-  }
+  const width = getChildWidth(child);
+  if (width != null) return width;
   return Math.max(0, frameWidth - margin.left - margin.right);
+};
+
+const applyJustifyContent = (
+  schemas: Schema[],
+  items: LayoutItem[],
+  mode: LayoutMode,
+  contentMainSize: number,
+  containerMainSize: number,
+  opts: { justifyContent: LayoutJustifyContent },
+) => {
+  const extraSpace = Math.max(0, containerMainSize - contentMainSize);
+  if (extraSpace === 0 || opts.justifyContent === 'start') return;
+
+  const extraGap =
+    opts.justifyContent === 'space-between' && items.length > 1
+      ? extraSpace / (items.length - 1)
+      : 0;
+  const startOffset =
+    opts.justifyContent === 'center'
+      ? extraSpace / 2
+      : opts.justifyContent === 'end'
+        ? extraSpace
+        : 0;
+
+  let runningExtraGap = 0;
+  for (const item of items) {
+    const offset = startOffset + runningExtraGap;
+    if (offset !== 0) {
+      shiftSchemas(
+        schemas,
+        item.schemaStart,
+        item.schemaEnd,
+        mode === 'row' ? offset : 0,
+        mode === 'stack' ? offset : 0,
+      );
+    }
+    runningExtraGap += extraGap;
+  }
 };
 
 const resolveAlignOffset = (
@@ -335,45 +398,42 @@ const renderElement = async (
   parentMode: LayoutMode,
   ctx: RenderCtx,
 ): Promise<{ width: number; height: number }> => {
+  const props =
+    parentMode === 'row' && getChildFlexGrow(element) != null
+      ? { ...element.props, width: frame.width }
+      : element.props;
+
   switch (element.kind) {
     case 'stack':
-      return renderStack(element.props as StackProps, element.children, frame, ctx);
+      return renderStack(props as StackProps, element.children, frame, ctx);
     case 'row':
-      return renderRow(element.props as RowProps, element.children, frame, ctx);
+      return renderRow(props as RowProps, element.children, frame, ctx);
     case 'box':
-      return renderBox(element.props as BoxProps, element.children, frame, parentMode, ctx);
+      return renderBox(props as BoxProps, element.children, frame, parentMode, ctx);
     case 'spacer':
-      return Promise.resolve(renderSpacer(element.props as SpacerProps));
+      return Promise.resolve(renderSpacer(props as SpacerProps));
     case 'text':
-      return renderText(
-        { ...(element.props as TextProps), children: element.children },
-        frame,
-        ctx,
-      );
+      return renderText({ ...(props as TextProps), children: element.children }, frame, ctx);
     case 'multiVariableText':
       return renderMultiVariableText(
-        { ...(element.props as MultiVariableTextProps), children: element.children },
+        { ...(props as MultiVariableTextProps), children: element.children },
         frame,
         ctx,
       );
     case 'image':
-      return renderImage(element.props as ImageProps, frame, ctx);
+      return renderImage(props as ImageProps, frame, ctx);
     case 'svg':
-      return renderSvg({ ...(element.props as SvgProps), children: element.children }, frame, ctx);
+      return renderSvg({ ...(props as SvgProps), children: element.children }, frame, ctx);
     case 'rectangle':
-      return renderShape('rectangle', element.props as RectangleProps, frame, ctx);
+      return renderShape('rectangle', props as RectangleProps, frame, ctx);
     case 'ellipse':
-      return renderShape('ellipse', element.props as EllipseProps, frame, ctx);
+      return renderShape('ellipse', props as EllipseProps, frame, ctx);
     case 'line':
-      return renderLine(element.props as LineProps, frame, ctx);
+      return renderLine(props as LineProps, frame, ctx);
     case 'list':
-      return renderList(
-        { ...(element.props as ListProps), children: element.children },
-        frame,
-        ctx,
-      );
+      return renderList({ ...(props as ListProps), children: element.children }, frame, ctx);
     case 'table':
-      return renderTable(element.props as TableProps, frame, ctx);
+      return renderTable(props as TableProps, frame, ctx);
     default:
       return { width: 0, height: 0 };
   }
@@ -387,11 +447,13 @@ const renderStack = (
 ): Promise<{ width: number; height: number }> =>
   layoutChildren(
     children,
-    { ...frame, width: props.width ?? frame.width },
+    { ...frame, width: props.width ?? frame.width, height: props.height ?? frame.height },
     'stack',
     {
       gap: props.gap ?? 0,
       alignItems: props.alignItems ?? 'stretch',
+      justifyContent: props.justifyContent ?? 'start',
+      mainSize: props.height,
     },
     ctx,
   );
@@ -406,7 +468,13 @@ const renderRow = (
     children,
     { ...frame, width: props.width ?? frame.width, height: props.height ?? frame.height },
     'row',
-    { gap: props.gap ?? 0, alignItems: props.alignItems ?? 'start', crossSize: props.height },
+    {
+      gap: props.gap ?? 0,
+      alignItems: props.alignItems ?? 'start',
+      justifyContent: props.justifyContent ?? 'start',
+      mainSize: props.width,
+      crossSize: props.height,
+    },
     ctx,
   );
 
@@ -449,7 +517,7 @@ const renderBox = async (
     children,
     innerFrame,
     'stack',
-    { gap: 0, alignItems: 'stretch' },
+    { gap: 0, alignItems: 'stretch', justifyContent: 'start' },
     ctx,
   );
   const height = props.height ?? childSize.height + padding.top + padding.bottom;

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -75,9 +75,14 @@ export type BoxSides = {
 };
 
 export type LayoutAlignItems = 'start' | 'center' | 'end' | 'stretch';
+export type LayoutJustifyContent = 'start' | 'center' | 'end' | 'space-between';
 
 export type LayoutProps = {
   margin?: number | BoxSides;
+  /** Row-only grow weight. Explicit width is used as the basis when present. */
+  flexGrow?: number;
+  /** Short alias for flexGrow. */
+  flex?: number;
 };
 
 export type CommonProps = LayoutProps & Partial<Pick<Schema, 'rotate' | 'opacity'>>;
@@ -93,7 +98,9 @@ export type PageProps = {
 export type StackProps = LayoutProps & {
   gap?: number;
   width?: number;
+  height?: number;
   alignItems?: LayoutAlignItems;
+  justifyContent?: LayoutJustifyContent;
   children?: PdfJsxChild;
 };
 
@@ -102,6 +109,7 @@ export type RowProps = LayoutProps & {
   width?: number;
   height?: number;
   alignItems?: Exclude<LayoutAlignItems, 'stretch'>;
+  justifyContent?: LayoutJustifyContent;
   children?: PdfJsxChild;
 };
 


### PR DESCRIPTION
## Summary

This PR continues the small `@pdfme/jsx` layout work after margin / alignItems. It adds main-axis spacing and simple grow weights without trying to implement full CSS/Flexbox.

- Add `justifyContent` to `Stack` and `Row` with `start`, `center`, `end`, and `space-between`.
- Add Row child `flexGrow` and `flex` grow weights.
- Treat explicit `width` as the flex basis when `flexGrow` / `flex` is present.
- Add `Stack height` so vertical `justifyContent` can be used predictably.
- Update `PLAN.md` and the `@pdfme/jsx` README.

## Notes

- `flex`, `flexGrow`, and `justifyContent` are intentionally compact authoring helpers, not a full Flexbox compatibility layer.
- `Row` children without explicit `width` keep the previous behavior of sharing remaining width equally.

## Tests

- `npm run fmt -w packages/jsx`
- `npm run test -w packages/jsx`
- `npm run lint -w packages/jsx`
- `npm run build -w packages/jsx`
- `git diff --check`