### PR TITLE
[codex] Add JSX Absolute placement helper

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -35,16 +35,16 @@ pdfme `Template` と `inputs` を生成できるようにする。
 
 ## 次に進めること
 
-### 1. `@pdfme/jsx` Absolute / manual placement 補助の判断
+### 1. `@pdfme/jsx` Absolute / manual placement 補助の初期実装
 
 - stacking layout では表現しにくい watermark、badge、右上固定ラベル、ページ上の細かい手動調整の
   逃げ道として `Absolute` / manual placement helper を検討する。
 - ただし `@pdfme/jsx` の主軸は stacking layout に置く。通常の本文、Markdown 由来の文書、
   AI template authoring は `Stack` / `Row` / `Box` / `Text` などで組む前提にする。
-- `Absolute` を入れる場合は flow に参加しない overlay として扱い、子要素の高さで後続要素を
+- `Absolute` は flow に参加しない overlay として扱い、子要素の高さで後続要素を
   押し出さない。乱用すると絶対座標 JSON と同じ難しさに戻るため、API と docs で用途を絞る。
-- 座標は親の layout frame 基準を基本にする。`Page` body 内では page margin 内、`Static` 内では
-  page 全体、`Box` 内では box content frame のように、親によって自然な基準を決める。
+- 初期実装では `Page`, `Static`, `Box` の直下で許可する。座標は親の layout frame 基準にする。
+  `Page` body 内では page margin 内、`Static` 内では page 全体、`Box` 内では box content frame。
 - 初期 API は `x`, `y`, `width`, `height` 程度に留め、CSS `position` / `style` 互換は目指さない。
 
 ### 2. `@pdfme/jsx` layout 品質フォローアップ

--- a/packages/jsx/README.md
+++ b/packages/jsx/README.md
@@ -62,6 +62,19 @@ it provides its own `jsx-runtime` and `jsx-dev-runtime`.
 - Static content currently accepts read-only `Stack`, `Row`, `Box`, `Spacer`, `Text`, `Image`, `Svg`,
   `Rectangle`, `Ellipse`, and `Line` content. `MultiVariableText`, `List`, `Table`, input-backed
   schemas, and `PageBreak` are rejected.
+- `Absolute` can be used inside `Page`, `Static`, or `Box` as a small manual placement escape hatch.
+  It uses the parent layout frame as its coordinate origin and does not advance the surrounding
+  stack/row flow.
+
+```tsx
+<Page margin={12}>
+  <Text height={8}>Body starts here</Text>
+  <Absolute x={120} y={0} width={60}>
+    <Text height={6}>Top-right note</Text>
+  </Absolute>
+</Page>
+```
+
 - Layout children can use `margin`. `Stack` and `Row` support `alignItems` for simple cross-axis
   alignment without trying to implement full CSS/Flexbox.
 - `Stack` and `Row` support `justifyContent="start" | "center" | "end" | "space-between"` for

--- a/packages/jsx/README.md
+++ b/packages/jsx/README.md
@@ -62,9 +62,11 @@ it provides its own `jsx-runtime` and `jsx-dev-runtime`.
 - Static content currently accepts read-only `Stack`, `Row`, `Box`, `Spacer`, `Text`, `Image`, `Svg`,
   `Rectangle`, `Ellipse`, and `Line` content. `MultiVariableText`, `List`, `Table`, input-backed
   schemas, and `PageBreak` are rejected.
-- `Absolute` can be used inside `Page`, `Static`, or `Box` as a small manual placement escape hatch.
-  It uses the parent layout frame as its coordinate origin and does not advance the surrounding
-  stack/row flow.
+- `Absolute` can be used inside `Page`, top `Static`, or `Box` as a small manual placement escape
+  hatch. It uses the parent layout frame as its coordinate origin and does not advance the
+  surrounding stack/row flow. When `width` or `height` is omitted, it uses the remaining parent
+  frame size from `x` / `y`. Direct `Stack` / `Row` support is intentionally left for later; wrap
+  with an explicit-size `Box` when you need a local manual-placement frame inside flow content.
 
 ```tsx
 <Page margin={12}>

--- a/packages/jsx/src/__tests__/render.test.tsx
+++ b/packages/jsx/src/__tests__/render.test.tsx
@@ -740,6 +740,42 @@ describe('@pdfme/jsx renderToTemplate', () => {
     expect(after).toMatchObject({ content: 'After', position: { x: 10, y: 15 } });
   });
 
+  it('uses the full parent frame for Absolute when placement props are omitted', async () => {
+    const result = await renderToTemplate(
+      <Page size={{ width: 100, height: 100 }} margin={10}>
+        <Absolute>
+          <Text height={6}>Overlay</Text>
+        </Absolute>
+      </Page>,
+    );
+
+    expect(result.template.schemas[0]?.[0]).toMatchObject({
+      content: 'Overlay',
+      position: { x: 10, y: 10 },
+      width: 80,
+    });
+  });
+
+  it('renders multiple Absolute siblings independently in declaration order', async () => {
+    const result = await renderToTemplate(
+      <Page size={{ width: 100, height: 100 }} margin={0}>
+        <Absolute x={10} y={5} width={20}>
+          <Text height={6}>First</Text>
+        </Absolute>
+        <Absolute x={50} y={8} width={30}>
+          <Text height={6}>Second</Text>
+        </Absolute>
+      </Page>,
+    );
+
+    expect(result.template.schemas[0]?.map((schema) => schema.content)).toEqual([
+      'First',
+      'Second',
+    ]);
+    expect(result.template.schemas[0]?.[0]).toMatchObject({ position: { x: 10, y: 5 } });
+    expect(result.template.schemas[0]?.[1]).toMatchObject({ position: { x: 50, y: 8 } });
+  });
+
   it('uses the Box content frame as the Absolute coordinate origin', async () => {
     const result = await renderToTemplate(
       <Page size={{ width: 100, height: 100 }} margin={0}>
@@ -770,6 +806,30 @@ describe('@pdfme/jsx renderToTemplate', () => {
               <Text>Pin</Text>
             </Absolute>
           </Stack>
+        </Page>,
+      ),
+    ).rejects.toThrow('<Absolute> can only be used inside <Page>, <Static>, or <Box>');
+
+    await expect(
+      renderToTemplate(
+        <Page>
+          <Row>
+            <Absolute>
+              <Text>Pin</Text>
+            </Absolute>
+          </Row>
+        </Page>,
+      ),
+    ).rejects.toThrow('<Absolute> can only be used inside <Page>, <Static>, or <Box>');
+
+    await expect(
+      renderToTemplate(
+        <Page>
+          <Absolute>
+            <Absolute>
+              <Text>Pin</Text>
+            </Absolute>
+          </Absolute>
         </Page>,
       ),
     ).rejects.toThrow('<Absolute> can only be used inside <Page>, <Static>, or <Box>');
@@ -994,6 +1054,36 @@ describe('@pdfme/jsx renderToTemplate', () => {
       position: { x: 80, y: 90 },
       width: 15,
     });
+  });
+
+  it('rejects Absolute inside bottom Static', async () => {
+    await expect(
+      renderToTemplate(
+        <Page size={{ width: 100, height: 100 }} margin={10}>
+          <Static placement="bottom">
+            <Absolute x={10} y={10}>
+              <Text>Stamp</Text>
+            </Absolute>
+          </Static>
+          <Text height={6}>Body</Text>
+        </Page>,
+      ),
+    ).rejects.toThrow('<Absolute> is not supported inside bottom <Static>');
+  });
+
+  it('rejects input-backed Static children inside Absolute', async () => {
+    await expect(
+      renderToTemplate(
+        <Page size={{ width: 100, height: 100 }} margin={10}>
+          <Static>
+            <Absolute x={10} y={10}>
+              <Text name="editable">Stamp</Text>
+            </Absolute>
+          </Static>
+          <Text height={6}>Body</Text>
+        </Page>,
+      ),
+    ).rejects.toThrow('<Static> children must be read-only');
   });
 
   it('renders Header and Footer aliases as top and bottom static content', async () => {

--- a/packages/jsx/src/__tests__/render.test.tsx
+++ b/packages/jsx/src/__tests__/render.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { isBlankPdf, PAGE_SIZE_PRESETS } from '@pdfme/common';
 
 import {
+  Absolute,
   Box,
   Ellipse,
   Footer,
@@ -717,6 +718,63 @@ describe('@pdfme/jsx renderToTemplate', () => {
     ).rejects.toThrow('duplicate schema name "mark"');
   });
 
+  it('renders Absolute children without advancing Page flow', async () => {
+    const result = await renderToTemplate(
+      <Page size={{ width: 100, height: 100 }} margin={10}>
+        <Text height={5}>Before</Text>
+        <Absolute x={20} y={30} width={40}>
+          <Text height={6}>Pinned</Text>
+        </Absolute>
+        <Text height={5}>After</Text>
+      </Page>,
+    );
+
+    const [before, pinned, after] = result.template.schemas[0] ?? [];
+    expect(before).toMatchObject({ content: 'Before', position: { x: 10, y: 10 } });
+    expect(pinned).toMatchObject({
+      content: 'Pinned',
+      position: { x: 30, y: 40 },
+      width: 40,
+      height: 6,
+    });
+    expect(after).toMatchObject({ content: 'After', position: { x: 10, y: 15 } });
+  });
+
+  it('uses the Box content frame as the Absolute coordinate origin', async () => {
+    const result = await renderToTemplate(
+      <Page size={{ width: 100, height: 100 }} margin={0}>
+        <Box padding={5}>
+          <Absolute x={10} y={8} width={20}>
+            <Text height={6}>Badge</Text>
+          </Absolute>
+          <Text height={6}>Flow</Text>
+        </Box>
+      </Page>,
+    );
+
+    const [badge, flow] = result.template.schemas[0] ?? [];
+    expect(badge).toMatchObject({
+      content: 'Badge',
+      position: { x: 15, y: 13 },
+      width: 20,
+    });
+    expect(flow).toMatchObject({ content: 'Flow', position: { x: 5, y: 5 } });
+  });
+
+  it('rejects Absolute outside Page, Static, or Box', async () => {
+    await expect(
+      renderToTemplate(
+        <Page>
+          <Stack>
+            <Absolute>
+              <Text>Pin</Text>
+            </Absolute>
+          </Stack>
+        </Page>,
+      ),
+    ).rejects.toThrow('<Absolute> can only be used inside <Page>, <Static>, or <Box>');
+  });
+
   it('splits pages at PageBreak', async () => {
     const result = await renderToTemplate(
       <Page>
@@ -913,6 +971,28 @@ describe('@pdfme/jsx renderToTemplate', () => {
       position: { x: 0, y: 94 },
       width: 100,
       height: 6,
+    });
+  });
+
+  it('uses the full page as the Absolute coordinate origin inside Static', async () => {
+    const result = await renderToTemplate(
+      <Page size={{ width: 100, height: 100 }} margin={10}>
+        <Static>
+          <Absolute x={80} y={90} width={15}>
+            <Text height={4}>Stamp</Text>
+          </Absolute>
+        </Static>
+        <Text height={6}>Body</Text>
+      </Page>,
+    );
+
+    expect(isBlankPdf(result.template.basePdf)).toBe(true);
+    if (!isBlankPdf(result.template.basePdf)) throw new Error('Expected blank basePdf');
+
+    expect(result.template.basePdf.staticSchema?.[0]).toMatchObject({
+      content: 'Stamp',
+      position: { x: 80, y: 90 },
+      width: 15,
     });
   });
 

--- a/packages/jsx/src/components.ts
+++ b/packages/jsx/src/components.ts
@@ -1,5 +1,6 @@
 import { createElementNode } from './node.js';
 import type {
+  AbsoluteProps,
   BoxProps,
   EllipseProps,
   FooterProps,
@@ -33,6 +34,7 @@ export const Header = (props: HeaderProps): ReturnType<typeof createElementNode<
   createElementNode('static', { ...props, placement: 'top' });
 export const Footer = (props: FooterProps): ReturnType<typeof createElementNode<'static'>> =>
   createElementNode('static', { ...props, placement: 'bottom' });
+export const Absolute = makeBuiltin<AbsoluteProps, 'absolute'>('absolute');
 export const Stack = makeBuiltin<StackProps, 'stack'>('stack');
 export const Row = makeBuiltin<RowProps, 'row'>('row');
 export const Box = makeBuiltin<BoxProps, 'box'>('box');

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -1,4 +1,5 @@
 export {
+  Absolute,
   Box,
   Ellipse,
   Footer,
@@ -20,6 +21,7 @@ export {
 } from './components.js';
 export { renderToTemplate } from './render.js';
 export type {
+  AbsoluteProps,
   BoxProps,
   BoxSides,
   CellStyle,

--- a/packages/jsx/src/render.ts
+++ b/packages/jsx/src/render.ts
@@ -19,6 +19,7 @@ import {
 } from '@pdfme/schemas/utils';
 import { cloneElementWithChildren, isPdfJsxElement, isPdfJsxFragment } from './node.js';
 import type {
+  AbsoluteProps,
   BoxProps,
   BoxSides,
   CellStyle,
@@ -86,6 +87,7 @@ export const renderToTemplate = async (
 ): Promise<RenderResult> => {
   validatePageBreakPlacement(node);
   const expanded = expandPageBreaks(node);
+  validateAbsolutePlacement(expanded);
   validateNoTopLevelStatic(expanded);
   const pages = flattenChildren(expanded).filter(
     (child): child is PdfJsxElement<'page'> => isPdfJsxElement(child) && child.kind === 'page',
@@ -319,16 +321,25 @@ const layoutChildren = async (
   ctx: RenderCtx,
 ): Promise<{ width: number; height: number }> => {
   const items = flattenChildren(children);
-  const widths = mode === 'row' ? resolveRowWidths(items, frame.width, opts.gap) : undefined;
+  const flowItems = items.filter((item) => !isAbsoluteElement(item));
+  const widths = mode === 'row' ? resolveRowWidths(flowItems, frame.width, opts.gap) : undefined;
   let cursor = 0;
   let crossMax = 0;
+  let flowIndex = 0;
   const layoutItems: LayoutItem[] = [];
 
   for (let i = 0; i < items.length; i += 1) {
     const child = items[i];
+    if (isAbsoluteElement(child)) {
+      await renderAbsolute(child.props as AbsoluteProps, child.children, frame, ctx);
+      continue;
+    }
+
     const margin = getChildMargin(child);
     const width =
-      mode === 'row' ? (widths?.[i] ?? 0) : resolveStackChildWidth(child, frame.width, margin);
+      mode === 'row'
+        ? (widths?.[flowIndex] ?? 0)
+        : resolveStackChildWidth(child, frame.width, margin);
     const childFrame =
       mode === 'stack'
         ? { x: frame.x, y: frame.y + cursor, width, height: Math.max(0, frame.height - cursor) }
@@ -358,7 +369,8 @@ const layoutChildren = async (
       if (dx !== 0) shiftSchemas(ctx.schemas, schemaStart, schemaEnd, dx, 0);
     }
 
-    cursor += mainSize + (i < items.length - 1 ? opts.gap : 0);
+    cursor += mainSize + (flowIndex < flowItems.length - 1 ? opts.gap : 0);
+    flowIndex += 1;
     crossMax = Math.max(
       crossMax,
       mode === 'stack'
@@ -423,6 +435,10 @@ const getChildFlexGrow = (child: PdfJsxElement | string | number): number | unde
   const flexGrow = props.flexGrow ?? props.flex;
   return typeof flexGrow === 'number' ? Math.max(0, flexGrow) : undefined;
 };
+
+const isAbsoluteElement = (
+  child: PdfJsxElement | string | number,
+): child is PdfJsxElement<'absolute'> => isPdfJsxElement(child) && child.kind === 'absolute';
 
 const getStaticPlacement = (element: PdfJsxElement<'static'>): StaticPlacement => {
   const placement = (element.props as StaticProps).placement ?? 'top';
@@ -549,9 +565,36 @@ const renderElement = async (
       throw new Error(
         '@pdfme/jsx: <Static> can only be used as a direct child of the first <Page>.',
       );
+    case 'absolute':
+      return renderAbsolute(props as AbsoluteProps, element.children, frame, ctx);
     default:
       return { width: 0, height: 0 };
   }
+};
+
+const renderAbsolute = async (
+  props: AbsoluteProps,
+  children: PdfJsxChild[],
+  frame: Rect,
+  ctx: RenderCtx,
+): Promise<{ width: number; height: number }> => {
+  const x = props.x ?? 0;
+  const y = props.y ?? 0;
+  const childFrame = {
+    x: frame.x + x,
+    y: frame.y + y,
+    width: props.width ?? Math.max(0, frame.width - x),
+    height: props.height ?? Math.max(0, frame.height - y),
+  };
+
+  await layoutChildren(
+    children,
+    childFrame,
+    'stack',
+    { gap: 0, alignItems: 'stretch', justifyContent: 'start' },
+    ctx,
+  );
+  return { width: 0, height: 0 };
 };
 
 const renderStack = (
@@ -1169,7 +1212,7 @@ const isSameBoxSides = (
   first.left === second.left;
 
 const PAGE_BREAK_PARENT_KINDS = new Set(['page', 'stack', 'box']);
-const STATIC_CONTAINER_KINDS = new Set(['stack', 'row', 'box']);
+const STATIC_CONTAINER_KINDS = new Set(['absolute', 'stack', 'row', 'box']);
 const STATIC_LEAF_KINDS = new Set([
   'spacer',
   'text',
@@ -1179,6 +1222,7 @@ const STATIC_LEAF_KINDS = new Set([
   'ellipse',
   'line',
 ]);
+const ABSOLUTE_PARENT_KINDS = new Set(['page', 'static', 'box']);
 
 const validatePageBreakPlacement = (
   node: PdfJsxChild | PdfJsxChild[],
@@ -1200,6 +1244,21 @@ const validatePageBreakPlacement = (
     const childCanBreak =
       child.kind === 'page' ? true : canBreak && PAGE_BREAK_PARENT_KINDS.has(child.kind);
     validatePageBreakPlacement(child.children, child.kind, childCanBreak);
+  }
+};
+
+const validateAbsolutePlacement = (
+  node: PdfJsxChild | PdfJsxChild[],
+  parentKind: string | undefined = undefined,
+) => {
+  for (const child of flattenForSplitting(node)) {
+    if (!isPdfJsxElement(child)) continue;
+
+    if (child.kind === 'absolute' && (!parentKind || !ABSOLUTE_PARENT_KINDS.has(parentKind))) {
+      throw new Error('@pdfme/jsx: <Absolute> can only be used inside <Page>, <Static>, or <Box>.');
+    }
+
+    validateAbsolutePlacement(child.children, child.kind);
   }
 };
 

--- a/packages/jsx/src/render.ts
+++ b/packages/jsx/src/render.ts
@@ -369,6 +369,7 @@ const layoutChildren = async (
       if (dx !== 0) shiftSchemas(ctx.schemas, schemaStart, schemaEnd, dx, 0);
     }
 
+    // flowIndex tracks the flow-only list so Absolute siblings do not affect gap accounting.
     cursor += mainSize + (flowIndex < flowItems.length - 1 ? opts.gap : 0);
     flowIndex += 1;
     crossMax = Math.max(
@@ -1273,7 +1274,12 @@ const validateStaticPlacement = (pages: PdfJsxElement<'page'>[]) => {
           );
         }
         // Validate dynamic JavaScript callers before static children are extracted for layout.
-        getStaticPlacement(child as PdfJsxElement<'static'>);
+        const placement = getStaticPlacement(child as PdfJsxElement<'static'>);
+        if (placement === 'bottom' && hasElementKind(child.children, 'absolute')) {
+          throw new Error(
+            '@pdfme/jsx: <Absolute> is not supported inside bottom <Static>. Use top <Static> or <Page> for fixed page coordinates.',
+          );
+        }
         validateStaticChildren(child.children);
         continue;
       }
@@ -1292,6 +1298,14 @@ const validateNoNestedStatic = (node: PdfJsxChild) => {
     }
     validateNoNestedStatic(child);
   }
+};
+
+const hasElementKind = (node: PdfJsxChild | PdfJsxChild[], kind: string): boolean => {
+  for (const child of flattenForSplitting(node)) {
+    if (!isPdfJsxElement(child)) continue;
+    if (child.kind === kind || hasElementKind(child.children, kind)) return true;
+  }
+  return false;
 };
 
 const validateNoTopLevelStatic = (node: PdfJsxChild | PdfJsxChild[]) => {

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -17,6 +17,7 @@ export type { PageOrientation, PageSize, PageSizePreset } from '@pdfme/common';
 export type BuiltinKind =
   | 'page'
   | 'static'
+  | 'absolute'
   | 'stack'
   | 'row'
   | 'box'
@@ -106,6 +107,14 @@ export type StaticProps = {
 
 export type HeaderProps = Omit<StaticProps, 'placement'>;
 export type FooterProps = Omit<StaticProps, 'placement'>;
+
+export type AbsoluteProps = {
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  children?: PdfJsxChild;
+};
 
 export type StackProps = LayoutProps & {
   gap?: number;


### PR DESCRIPTION
## Summary

This PR adds a small `Absolute` escape hatch to `@pdfme/jsx` for manual overlay placement.

- Add `<Absolute x y width height>` and export `AbsoluteProps`.
- Render `Absolute` children relative to the parent layout frame without advancing surrounding flow.
- Allow `Absolute` only inside `Page`, top `Static`, or `Box`.
- Reject `Absolute` inside bottom `Static` to avoid bottom-anchor shifting surprises.
- Keep `Static` validation compatible with read-only `Absolute` children.
- Update `PLAN.md` and the `@pdfme/jsx` README.

## Notes

- `Page` body coordinates are relative to the page margin frame.
- `Static` coordinates are relative to the full page, but only top/default static placement supports `Absolute`.
- `Box` coordinates are relative to the box content frame.
- `Absolute` does not advance flow and does not affect parent measured size.
- Direct `Stack` / `Row` support is intentionally left for later; use an explicit-size `Box` for local manual placement inside flow content.
- This intentionally does not try to emulate CSS `position` or full `style` semantics.

## Tests

- `npm run fmt -w packages/jsx`
- `npm run test -w packages/jsx`
- `npm run lint -w packages/jsx`
- `npm run build -w packages/jsx`
- `npm run typecheck`
- `git diff --check -- PLAN.md packages/jsx/README.md packages/jsx/src`