### PR TITLE
[codex] Add md2pdf playground lab

### DIFF
--- a/packages/converter/__tests__/index.test.ts
+++ b/packages/converter/__tests__/index.test.ts
@@ -200,8 +200,26 @@ describe('img2pdf tests', () => {
     const pdf2 = await img2pdf([jpegImage], {
       margin: [0, 0, 0, 0] as [number, number, number, number],
     });
-    // Both PDFs should have the same size
-    expect(pdf1.byteLength).toBe(pdf2.byteLength);
+
+    const [rendered1] = await nodePdf2Img(pdf1, { imageType: 'png' });
+    const [rendered2] = await nodePdf2Img(pdf2, { imageType: 'png' });
+    const image1 = await loadImage(Buffer.from(new Uint8Array(rendered1)));
+    const image2 = await loadImage(Buffer.from(new Uint8Array(rendered2)));
+
+    expect(image1.width).toBe(image2.width);
+    expect(image1.height).toBe(image2.height);
+
+    const canvas1 = createCanvas(image1.width, image1.height);
+    const context1 = canvas1.getContext('2d');
+    context1.drawImage(image1, 0, 0);
+    const pixels1 = context1.getImageData(0, 0, image1.width, image1.height).data;
+
+    const canvas2 = createCanvas(image2.width, image2.height);
+    const context2 = canvas2.getContext('2d');
+    context2.drawImage(image2, 0, 0);
+    const pixels2 = context2.getImageData(0, 0, image2.width, image2.height).data;
+
+    expect(Buffer.compare(Buffer.from(pixels1), Buffer.from(pixels2))).toBe(0);
   });
 });
 

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route, useSearchParams } from 'react-router-dom';
 import { ToastContainer } from 'react-toastify';
 import Designer from './routes/Designer';
 import FormAndViewer from './routes/FormAndViewer';
+import Md2Pdf from './routes/Md2Pdf';
 import Templates from './routes/Templates';
 import Header from './components/Header';
 
@@ -16,6 +17,7 @@ export default function App() {
         <Route path={'/'} element={<Designer />} />
         <Route path={'/designer'} element={<Designer />} />
         <Route path="/form-viewer" element={<FormAndViewer />} />
+        <Route path="/md2pdf" element={<Md2Pdf />} />
         <Route path="/templates" element={<Templates isEmbedded={isEmbedded} />} />
       </Routes>
       <ToastContainer />

--- a/playground/src/components/Header.tsx
+++ b/playground/src/components/Header.tsx
@@ -111,6 +111,7 @@ export default function Navigation() {
     { id: 'templates-nav', to: '/templates', label: 'Templates' },
     { id: 'designer-nav', to: '/designer', label: 'Designer' },
     { id: 'form-viewer-nav', to: '/form-viewer', label: 'Form/Viewer' },
+    { id: 'md2pdf-nav', to: '/md2pdf', label: 'md2pdf' },
   ];
 
   const linkClass = ({ isActive }: { isActive: boolean }) =>

--- a/playground/src/routes/Designer.tsx
+++ b/playground/src/routes/Designer.tsx
@@ -16,7 +16,6 @@ import {
 } from '../helper';
 import { getPlugins } from '../plugins';
 import { NavBar, NavItem } from '../components/NavBar';
-import ExternalButton from '../components/ExternalButton';
 import TemplateJsonDialog from '../components/TemplateJsonDialog';
 
 function DesignerApp() {
@@ -333,13 +332,6 @@ function DesignerApp() {
           </button>
         </div>
       ),
-    },
-    {
-      label: '',
-      content: React.createElement(ExternalButton, {
-        href: 'https://github.com/pdfme/pdfme/issues/new?template=template_feedback.yml&title=TEMPLATE_NAME',
-        title: 'Feedback this template',
-      }),
     },
   ];
 

--- a/playground/src/routes/Designer.tsx
+++ b/playground/src/routes/Designer.tsx
@@ -247,7 +247,7 @@ function DesignerApp() {
       label: 'Edit static schema',
       content: (
         <button
-          className={`px-2 py-1 border rounded hover:bg-gray-100 border-gray-300 w-full disabled:opacity-50 disabled:cursor-not-allowed`}
+          className={`px-2 py-1 border rounded hover:bg-gray-100 border-gray-300 w-full whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed`}
           onClick={toggleEditingStaticSchemas}
         >
           {editingStaticSchemas ? 'End editing' : 'Start editing'}
@@ -260,7 +260,7 @@ function DesignerApp() {
         <button
           type="button"
           disabled={editingStaticSchemas}
-          className={`inline-flex items-center justify-center gap-1 px-2 py-1 border rounded hover:bg-gray-100 border-gray-300 w-full ${
+          className={`inline-flex items-center justify-center gap-1 px-2 py-1 border rounded hover:bg-gray-100 border-gray-300 w-full whitespace-nowrap ${
             editingStaticSchemas ? 'opacity-50 cursor-not-allowed' : ''
           }`}
           onClick={onOpenTemplateJson}
@@ -277,7 +277,7 @@ function DesignerApp() {
           <button
             id="save-local"
             disabled={editingStaticSchemas}
-            className={`px-2 py-1 border rounded hover:bg-gray-100 border-gray-300 w-full ${
+            className={`px-2 py-1 border rounded hover:bg-gray-100 border-gray-300 whitespace-nowrap ${
               editingStaticSchemas ? 'opacity-50 cursor-not-allowed' : ''
             }`}
             onClick={() => onSaveTemplate()}
@@ -287,7 +287,7 @@ function DesignerApp() {
           <button
             id="reset-template"
             disabled={editingStaticSchemas}
-            className={`px-2 py-1 border rounded hover:bg-gray-100 border-gray-300 w-full ${
+            className={`px-2 py-1 border rounded hover:bg-gray-100 border-gray-300 whitespace-nowrap ${
               editingStaticSchemas ? 'opacity-50 cursor-not-allowed' : ''
             }`}
             onClick={onResetTemplate}
@@ -303,7 +303,7 @@ function DesignerApp() {
         <div className="flex gap-2">
           <button
             disabled={editingStaticSchemas}
-            className={`px-2 py-1 border rounded hover:bg-gray-100 border-gray-300 w-full ${
+            className={`px-2 py-1 border rounded hover:bg-gray-100 border-gray-300 whitespace-nowrap ${
               editingStaticSchemas ? 'opacity-50 cursor-not-allowed' : ''
             }`}
             onClick={onDownloadTemplate}
@@ -313,7 +313,7 @@ function DesignerApp() {
           <button
             id="generate-pdf"
             disabled={editingStaticSchemas}
-            className={`px-2 py-1 border rounded hover:bg-gray-100 border-gray-300 w-full ${
+            className={`px-2 py-1 border rounded hover:bg-gray-100 border-gray-300 whitespace-nowrap ${
               editingStaticSchemas ? 'opacity-50 cursor-not-allowed' : ''
             }`}
             onClick={async (e) => {

--- a/playground/src/routes/FormAndViewer.tsx
+++ b/playground/src/routes/FormAndViewer.tsx
@@ -14,7 +14,6 @@ import {
 } from '../helper';
 import { getPlugins } from '../plugins';
 import { NavItem, NavBar } from '../components/NavBar';
-import ExternalButton from '../components/ExternalButton';
 
 type Mode = 'form' | 'viewer';
 
@@ -246,13 +245,6 @@ function FormAndViewerApp() {
           Generate PDF
         </button>
       ),
-    },
-    {
-      label: '',
-      content: React.createElement(ExternalButton, {
-        href: 'https://github.com/pdfme/pdfme/issues/new?template=template_feedback.yml&title=TEMPLATE_NAME',
-        title: 'Feedback this template',
-      }),
     },
   ];
 

--- a/playground/src/routes/Md2Pdf.tsx
+++ b/playground/src/routes/Md2Pdf.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import type { Template } from '@pdfme/common';
 import { md2pdf } from '@pdfme/converter/md2pdf';
 import { Viewer } from '@pdfme/ui';
+import { ExternalLink } from 'lucide-react';
 import { toast } from 'react-toastify';
 import { generatePDF, getFontsData } from '../helper';
 import { getPlugins } from '../plugins';
@@ -106,15 +107,34 @@ export default function Md2Pdf() {
   return (
     <main className="flex min-h-0 flex-1 flex-col bg-gray-100">
       <div className="flex items-center justify-between border-b border-gray-200 bg-white px-4 py-3">
-        <h1 className="text-sm font-semibold text-gray-900">md2pdf</h1>
-        <button
-          type="button"
-          disabled={!template || Boolean(error)}
-          onClick={onGeneratePdf}
-          className="rounded border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          Generate PDF
-        </button>
+        <div className="min-w-0">
+          <div className="flex items-center gap-3">
+            <h1 className="text-sm font-semibold text-gray-900">md2pdf</h1>
+            <a
+              href="https://pdfme.com/docs/converter"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-xs font-medium text-green-700 hover:text-green-600"
+            >
+              Docs
+              <ExternalLink className="size-3" />
+            </a>
+          </div>
+          <p className="mt-1 text-xs text-gray-500">
+            GFM support is intentionally partial: complex table/list content and remote images are
+            simplified.
+          </p>
+        </div>
+        <div className="shrink-0 pl-4">
+          <button
+            type="button"
+            disabled={!template || Boolean(error)}
+            onClick={onGeneratePdf}
+            className="rounded border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Generate PDF
+          </button>
+        </div>
       </div>
       <div className="grid min-h-0 flex-1 grid-cols-1 gap-0 lg:grid-cols-2">
         <section className="flex min-h-[45vh] flex-col border-b border-gray-200 bg-white lg:min-h-0 lg:border-b-0 lg:border-r">

--- a/playground/src/routes/Md2Pdf.tsx
+++ b/playground/src/routes/Md2Pdf.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useRef, useState } from 'react';
+import type { Template } from '@pdfme/common';
+import { md2pdf } from '@pdfme/converter/md2pdf';
+import { Viewer } from '@pdfme/ui';
+import { toast } from 'react-toastify';
+import { generatePDF, getFontsData } from '../helper';
+import { getPlugins } from '../plugins';
+
+const initialMarkdown = `# md2pdf playground
+
+Markdownからpdfme Templateを作ります。日本語もフォントを指定すれば表示できます。
+
+## Blocks
+
+- Paragraph
+- **Bold**, *italic*, ~~strike~~, \`inline code\`
+- [pdfme](https://pdfme.com)
+
+---
+
+> Blockquote uses a left rule and padding.
+
+\`\`\`ts
+const template = await md2pdf(markdown);
+\`\`\`
+
+| Feature | Status |
+| --- | --- |
+| Table grid | Supported |
+| Remote image | Link fallback |
+`;
+
+export default function Md2Pdf() {
+  const viewerRootRef = useRef<HTMLDivElement | null>(null);
+  const viewerRef = useRef<Viewer | null>(null);
+  const [markdown, setMarkdown] = useState(initialMarkdown);
+  const [template, setTemplate] = useState<Template | null>(null);
+  const [inputs, setInputs] = useState<Record<string, string>[]>([{}]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const timer = window.setTimeout(async () => {
+      try {
+        const result = await md2pdf(markdown, {
+          style: {
+            fontName: 'NotoSansJP',
+            lineHeight: 1.3,
+          },
+        });
+        if (cancelled) return;
+        setTemplate(result.template);
+        setInputs(result.inputs);
+        setError(null);
+      } catch (error) {
+        if (cancelled) return;
+        setError(error instanceof Error ? error.message : String(error));
+      }
+    }, 250);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [markdown]);
+
+  useEffect(() => {
+    if (!viewerRootRef.current || !template) return;
+
+    viewerRef.current?.destroy();
+    viewerRef.current = new Viewer({
+      domContainer: viewerRootRef.current,
+      template,
+      inputs,
+      options: {
+        font: getFontsData(),
+        lang: 'en',
+        theme: {
+          token: {
+            colorPrimary: '#25c2a0',
+          },
+        },
+      },
+      plugins: getPlugins(),
+    });
+
+    return () => {
+      viewerRef.current?.destroy();
+      viewerRef.current = null;
+    };
+  }, [template, inputs]);
+
+  const onGeneratePdf = async () => {
+    const startTimer = performance.now();
+    await generatePDF(viewerRef.current);
+    toast.info(`Generated PDF in ${Math.round(performance.now() - startTimer)}ms`);
+  };
+
+  return (
+    <main className="flex min-h-0 flex-1 flex-col bg-gray-100">
+      <div className="flex items-center justify-between border-b border-gray-200 bg-white px-4 py-3">
+        <h1 className="text-sm font-semibold text-gray-900">md2pdf</h1>
+        <button
+          type="button"
+          disabled={!template || Boolean(error)}
+          onClick={onGeneratePdf}
+          className="rounded border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Generate PDF
+        </button>
+      </div>
+      <div className="grid min-h-0 flex-1 grid-cols-1 gap-0 lg:grid-cols-2">
+        <section className="flex min-h-[45vh] flex-col border-b border-gray-200 bg-white lg:min-h-0 lg:border-b-0 lg:border-r">
+          <div className="border-b border-gray-200 px-4 py-2 text-xs font-medium uppercase tracking-wide text-gray-500">
+            Markdown
+          </div>
+          <textarea
+            aria-label="Markdown"
+            value={markdown}
+            onChange={(event) => setMarkdown(event.target.value)}
+            spellCheck={false}
+            className="min-h-0 flex-1 resize-none bg-white p-4 font-mono text-sm leading-6 text-gray-900 outline-none focus:ring-2 focus:ring-inset focus:ring-green-500"
+          />
+        </section>
+        <section className="flex min-h-[55vh] flex-col bg-gray-100 lg:min-h-0">
+          <div className="flex items-center justify-between border-b border-gray-200 bg-white px-4 py-2 text-xs font-medium uppercase tracking-wide text-gray-500">
+            <span>Viewer</span>
+            {error && <span className="normal-case tracking-normal text-red-600">{error}</span>}
+          </div>
+          <div ref={viewerRootRef} className="min-h-0 flex-1" />
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/playground/src/routes/Md2Pdf.tsx
+++ b/playground/src/routes/Md2Pdf.tsx
@@ -111,7 +111,7 @@ export default function Md2Pdf() {
           <div className="flex items-center gap-3">
             <h1 className="text-sm font-semibold text-gray-900">md2pdf</h1>
             <a
-              href="https://pdfme.com/docs/converter"
+              href="https://pdfme.com/docs/converter#md2pdf"
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-1 text-xs font-medium text-green-700 hover:text-green-600"

--- a/playground/src/routes/Md2Pdf.tsx
+++ b/playground/src/routes/Md2Pdf.tsx
@@ -109,7 +109,7 @@ export default function Md2Pdf() {
       <div className="flex items-center justify-between border-b border-gray-200 bg-white px-4 py-3">
         <div className="min-w-0">
           <div className="flex items-center gap-3">
-            <h1 className="text-sm font-semibold text-gray-900">md2pdf</h1>
+            <h1 className="text-sm font-semibold text-gray-900">md2pdf (beta)</h1>
             <a
               href="https://pdfme.com/docs/converter#md2pdf"
               target="_blank"

--- a/playground/src/routes/Md2Pdf.tsx
+++ b/playground/src/routes/Md2Pdf.tsx
@@ -7,6 +7,8 @@ import { toast } from 'react-toastify';
 import { generatePDF, getFontsData } from '../helper';
 import { getPlugins } from '../plugins';
 
+const MD2PDF_DOCS_URL = 'https://pdfme.com/docs/converter#md2pdf-beta';
+
 const initialMarkdown = `# md2pdf playground
 
 Markdownからpdfme Templateを作ります。日本語もフォントを指定すれば表示できます。
@@ -40,6 +42,7 @@ export default function Md2Pdf() {
   const [error, setError] = useState<string | null>(null);
   const [renderDuration, setRenderDuration] = useState<number | null>(null);
   const [pdfDuration, setPdfDuration] = useState<number | null>(null);
+  const [isGeneratingPdf, setIsGeneratingPdf] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -57,9 +60,9 @@ export default function Md2Pdf() {
         setInputs(result.inputs);
         setRenderDuration(Math.round(performance.now() - startTimer));
         setError(null);
-      } catch (error) {
+      } catch (err) {
         if (cancelled) return;
-        setError(error instanceof Error ? error.message : String(error));
+        setError(err instanceof Error ? err.message : String(err));
         setRenderDuration(null);
       }
     }, 250);
@@ -73,35 +76,48 @@ export default function Md2Pdf() {
   useEffect(() => {
     if (!viewerRootRef.current || !template) return;
 
-    viewerRef.current?.destroy();
-    viewerRef.current = new Viewer({
-      domContainer: viewerRootRef.current,
-      template,
-      inputs,
-      options: {
-        font: getFontsData(),
-        lang: 'en',
-        theme: {
-          token: {
-            colorPrimary: '#25c2a0',
+    if (viewerRef.current) {
+      viewerRef.current.updateTemplate(template);
+      viewerRef.current.setInputs(inputs);
+    } else {
+      viewerRef.current = new Viewer({
+        domContainer: viewerRootRef.current,
+        template,
+        inputs,
+        options: {
+          font: getFontsData(),
+          lang: 'en',
+          theme: {
+            token: {
+              colorPrimary: '#25c2a0',
+            },
           },
         },
-      },
-      plugins: getPlugins(),
-    });
+        plugins: getPlugins(),
+      });
+    }
+  }, [template, inputs]);
 
+  useEffect(() => {
     return () => {
       viewerRef.current?.destroy();
       viewerRef.current = null;
     };
-  }, [template, inputs]);
+  }, []);
 
   const onGeneratePdf = async () => {
+    if (isGeneratingPdf) return;
+
     const startTimer = performance.now();
-    await generatePDF(viewerRef.current);
-    const duration = Math.round(performance.now() - startTimer);
-    setPdfDuration(duration);
-    toast.info(`Generated PDF in ${duration}ms`);
+    setIsGeneratingPdf(true);
+    try {
+      await generatePDF(viewerRef.current);
+      const duration = Math.round(performance.now() - startTimer);
+      setPdfDuration(duration);
+      toast.info(`Generated PDF in ${duration}ms`);
+    } finally {
+      setIsGeneratingPdf(false);
+    }
   };
 
   return (
@@ -111,7 +127,7 @@ export default function Md2Pdf() {
           <div className="flex items-center gap-3">
             <h1 className="text-sm font-semibold text-gray-900">md2pdf (beta)</h1>
             <a
-              href="https://pdfme.com/docs/converter#md2pdf"
+              href={MD2PDF_DOCS_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-1 text-xs font-medium text-green-700 hover:text-green-600"
@@ -128,11 +144,11 @@ export default function Md2Pdf() {
         <div className="shrink-0 pl-4">
           <button
             type="button"
-            disabled={!template || Boolean(error)}
+            disabled={!template || Boolean(error) || isGeneratingPdf}
             onClick={onGeneratePdf}
             className="rounded border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
           >
-            Generate PDF
+            {isGeneratingPdf ? 'Generating...' : 'Generate PDF'}
           </button>
         </div>
       </div>

--- a/playground/src/routes/Md2Pdf.tsx
+++ b/playground/src/routes/Md2Pdf.tsx
@@ -37,10 +37,13 @@ export default function Md2Pdf() {
   const [template, setTemplate] = useState<Template | null>(null);
   const [inputs, setInputs] = useState<Record<string, string>[]>([{}]);
   const [error, setError] = useState<string | null>(null);
+  const [renderDuration, setRenderDuration] = useState<number | null>(null);
+  const [pdfDuration, setPdfDuration] = useState<number | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     const timer = window.setTimeout(async () => {
+      const startTimer = performance.now();
       try {
         const result = await md2pdf(markdown, {
           style: {
@@ -51,10 +54,12 @@ export default function Md2Pdf() {
         if (cancelled) return;
         setTemplate(result.template);
         setInputs(result.inputs);
+        setRenderDuration(Math.round(performance.now() - startTimer));
         setError(null);
       } catch (error) {
         if (cancelled) return;
         setError(error instanceof Error ? error.message : String(error));
+        setRenderDuration(null);
       }
     }, 250);
 
@@ -93,7 +98,9 @@ export default function Md2Pdf() {
   const onGeneratePdf = async () => {
     const startTimer = performance.now();
     await generatePDF(viewerRef.current);
-    toast.info(`Generated PDF in ${Math.round(performance.now() - startTimer)}ms`);
+    const duration = Math.round(performance.now() - startTimer);
+    setPdfDuration(duration);
+    toast.info(`Generated PDF in ${duration}ms`);
   };
 
   return (
@@ -125,7 +132,11 @@ export default function Md2Pdf() {
         <section className="flex min-h-[55vh] flex-col bg-gray-100 lg:min-h-0">
           <div className="flex items-center justify-between border-b border-gray-200 bg-white px-4 py-2 text-xs font-medium uppercase tracking-wide text-gray-500">
             <span>Viewer</span>
-            {error && <span className="normal-case tracking-normal text-red-600">{error}</span>}
+            <div className="flex items-center gap-3 normal-case tracking-normal">
+              {renderDuration !== null && <span>render {renderDuration}ms</span>}
+              {pdfDuration !== null && <span>pdf {pdfDuration}ms</span>}
+              {error && <span className="text-red-600">{error}</span>}
+            </div>
           </div>
           <div ref={viewerRootRef} className="min-h-0 flex-1" />
         </section>

--- a/website/docs/converter.md
+++ b/website/docs/converter.md
@@ -67,7 +67,7 @@ const pdf = await img2pdf([image1, image2], {
 });
 ```
 
-### md2pdf
+### md2pdf (beta)
 Converts GitHub Flavored Markdown into a pdfme `Template` and `inputs` pair.
 
 ```ts

--- a/website/docs/converter.md
+++ b/website/docs/converter.md
@@ -139,6 +139,8 @@ const pdf = await generate({
 });
 ```
 
+If you pass `basePdf`, `md2pdf` uses it directly instead of creating a blank PDF from `page` options. The value is the same `BlankPdf` object used by pdfme templates, so it can include `staticSchema`.
+
 #### Current limitations
 `md2pdf` covers practical GFM blocks, but it is not a complete GitHub Markdown renderer yet.
 
@@ -164,6 +166,8 @@ All functions throw descriptive errors when invalid parameters are provided:
 ## Types
 
 ```ts
+import type { BlankPdf, PageOrientation, PageSize } from '@pdfme/common';
+
 type ImageType = 'jpeg' | 'png';
 
 interface PageRange {
@@ -188,17 +192,16 @@ interface Img2PdfOptions {
   margin?: [number, number, number, number]; // in millimeters [top, right, bottom, left]
 }
 
-type PageSizePreset = 'A3' | 'A4' | 'A5' | 'A6' | 'B4' | 'B5' | 'B6' | 'Letter' | 'Legal' | 'Tabloid';
 type BoxSides = { top?: number, right?: number, bottom?: number, left?: number, x?: number, y?: number };
 type MarkdownMargin = number | [number, number, number, number] | BoxSides;
 
 interface Md2PdfOptions {
   page?: {
-    size?: PageSizePreset | { width: number, height: number };
-    orientation?: 'portrait' | 'landscape';
+    size?: PageSize;
+    orientation?: PageOrientation;
     margin?: MarkdownMargin;
   };
-  basePdf?: { width: number, height: number, padding: [number, number, number, number] };
+  basePdf?: BlankPdf;
   style?: {
     fontName?: string;
     fontSize?: number;

--- a/website/docs/converter.md
+++ b/website/docs/converter.md
@@ -9,9 +9,9 @@ Although it's still under development, you can already use the following feature
 - **Convert PDF to Images**: [pdf2img](https://github.com/pdfme/pdfme/blob/main/packages/converter/src/pdf2img.ts)
 - **Retrieve Each Page's Width and Height**: [pdf2size](https://github.com/pdfme/pdfme/blob/main/packages/converter/src/pdf2size.ts)
 - **Convert Images to PDF**: [img2pdf](https://github.com/pdfme/pdfme/blob/main/packages/converter/src/img2pdf.ts)
+- **Markdown to PDF**: `md2pdf`
 
 Planned conversion features include:
-- **Markdown to PDF**: `md2pdf`
 - **PDF to Markdown**: `pdf2md`
 
 ## Installation
@@ -67,6 +67,90 @@ const pdf = await img2pdf([image1, image2], {
 });
 ```
 
+### md2pdf
+Converts GitHub Flavored Markdown into a pdfme `Template` and `inputs` pair.
+
+```ts
+import { md2pdf } from '@pdfme/converter/md2pdf';
+
+const { template, inputs } = await md2pdf('# Hello\n\nVisit [pdfme](https://pdfme.com).');
+```
+
+You can try it in the [md2pdf playground](https://playground.pdfme.com/md2pdf).
+
+`md2pdf` is exposed as a subpath export so regular `@pdfme/converter` imports do not pull Markdown parser dependencies into browser bundles.
+
+To generate a PDF, pass the returned `template` and `inputs` to `@pdfme/generator` and register the schema plugins used by your Markdown document.
+
+```ts
+import { md2pdf } from '@pdfme/converter/md2pdf';
+import { generate } from '@pdfme/generator';
+import { image, line, list, table, text } from '@pdfme/schemas';
+
+const { template, inputs } = await md2pdf(`
+# Release notes
+
+- Markdown becomes pdfme schemas.
+- Horizontal rules become line schemas.
+
+---
+
+| Feature | Status |
+| --- | --- |
+| Tables | Supported |
+`);
+
+const pdf = await generate({
+  template,
+  inputs,
+  plugins: {
+    Text: text,
+    List: list,
+    Table: table,
+    Image: image,
+    Line: line,
+  },
+});
+```
+
+#### Japanese and CJK text
+The default pdfme font is Roboto, which does not include Japanese/CJK glyphs. For Japanese Markdown, set a CJK-capable `fontName` during conversion and pass the same font to the generator or UI options.
+
+```ts
+import { readFile } from 'node:fs/promises';
+import { md2pdf } from '@pdfme/converter/md2pdf';
+import { generate } from '@pdfme/generator';
+import { image, line, list, table, text } from '@pdfme/schemas';
+
+const fontData = await readFile('./fonts/NotoSansJP-Regular.ttf');
+const { template, inputs } = await md2pdf('# 日本語\n\nこれはPDF生成のテストです。', {
+  style: { fontName: 'NotoSansJP' },
+});
+
+const pdf = await generate({
+  template,
+  inputs,
+  plugins: { Text: text, List: list, Table: table, Image: image, Line: line },
+  options: {
+    font: {
+      NotoSansJP: { data: fontData, fallback: true, subset: false },
+    },
+  },
+});
+```
+
+#### Current limitations
+`md2pdf` covers practical GFM blocks, but it is not a complete GitHub Markdown renderer yet.
+
+- Paragraphs, headings, lists, tables, code blocks, blockquotes, horizontal rules, links, and PNG/JPEG data URI images are supported.
+- Pagination is handled by pdfme dynamic layout after conversion. Text, lists, and tables can split across pages; image keep-together behavior is intentionally basic.
+- Table cells are plain text. Inline Markdown styling inside table cells is stripped.
+- Code block language tags are parsed but not rendered yet.
+- Blockquotes are rendered with a simple background, padding, and left rule, not as nested block layouts.
+- Remote Markdown images are emitted as links for now. Fetching remote images and carrying asset metadata is left for a later step.
+- PNG/JPEG data URI images use a fixed initial height and do not preserve aspect ratio yet.
+- Complex list item children such as nested code blocks or blockquotes are flattened into list item text.
+
 ## Error Handling
 
 All functions throw descriptive errors when invalid parameters are provided:
@@ -102,6 +186,26 @@ interface Img2PdfOptions {
   imageType?: ImageType;
   size?: { height: number, width: number }; // in millimeters
   margin?: [number, number, number, number]; // in millimeters [top, right, bottom, left]
+}
+
+type PageSizePreset = 'A3' | 'A4' | 'A5' | 'A6' | 'B4' | 'B5' | 'B6' | 'Letter' | 'Legal' | 'Tabloid';
+type BoxSides = { top?: number, right?: number, bottom?: number, left?: number, x?: number, y?: number };
+type MarkdownMargin = number | [number, number, number, number] | BoxSides;
+
+interface Md2PdfOptions {
+  page?: {
+    size?: PageSizePreset | { width: number, height: number };
+    orientation?: 'portrait' | 'landscape';
+    margin?: MarkdownMargin;
+  };
+  basePdf?: { width: number, height: number, padding: [number, number, number, number] };
+  style?: {
+    fontName?: string;
+    fontSize?: number;
+    lineHeight?: number;
+    fontColor?: string;
+    headingScale?: Partial<Record<1 | 2 | 3 | 4 | 5 | 6, number>>;
+  };
 }
 ```
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/converter.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/converter.md
@@ -139,6 +139,8 @@ const pdf = await generate({
 });
 ```
 
+`basePdf` を渡した場合、`md2pdf` は `page` options から blank PDF を作らず、その値をそのまま使います。これは pdfme template と同じ `BlankPdf` object なので、`staticSchema` も含められます。
+
 #### 現在の制限
 `md2pdf` は実用的な GFM block を扱えますが、GitHub Markdown renderer の完全互換ではありません。
 
@@ -164,6 +166,8 @@ const pdf = await generate({
 ## 型定義
 
 ```ts
+import type { BlankPdf, PageOrientation, PageSize } from '@pdfme/common';
+
 type ImageType = 'jpeg' | 'png';
 
 interface PageRange {
@@ -188,17 +192,16 @@ interface Img2PdfOptions {
   margin?: [number, number, number, number]; // ミリメートル単位 [上, 右, 下, 左]
 }
 
-type PageSizePreset = 'A3' | 'A4' | 'A5' | 'A6' | 'B4' | 'B5' | 'B6' | 'Letter' | 'Legal' | 'Tabloid';
 type BoxSides = { top?: number, right?: number, bottom?: number, left?: number, x?: number, y?: number };
 type MarkdownMargin = number | [number, number, number, number] | BoxSides;
 
 interface Md2PdfOptions {
   page?: {
-    size?: PageSizePreset | { width: number, height: number };
-    orientation?: 'portrait' | 'landscape';
+    size?: PageSize;
+    orientation?: PageOrientation;
     margin?: MarkdownMargin;
   };
-  basePdf?: { width: number, height: number, padding: [number, number, number, number] };
+  basePdf?: BlankPdf;
   style?: {
     fontName?: string;
     fontSize?: number;

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/converter.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/converter.md
@@ -67,7 +67,7 @@ const pdf = await img2pdf([image1, image2], {
 });
 ```
 
-### md2pdf
+### md2pdf (beta)
 GitHub Flavored Markdown を pdfme の `Template` と `inputs` の組に変換します。
 
 ```ts

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/converter.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/converter.md
@@ -9,9 +9,9 @@
 - **PDFを画像に変換**: [pdf2img](https://github.com/pdfme/pdfme/blob/main/packages/converter/src/pdf2img.ts)
 - **各ページの幅と高さを取得**: [pdf2size](https://github.com/pdfme/pdfme/blob/main/packages/converter/src/pdf2size.ts)
 - **画像をPDFに変換**: [img2pdf](https://github.com/pdfme/pdfme/blob/main/packages/converter/src/img2pdf.ts)
+- **MarkdownからPDF**: `md2pdf`
 
 計画されている変換機能には以下が含まれます：
-- **MarkdownからPDF**: `md2pdf`
 - **PDFからMarkdown**: `pdf2md`
 
 ## インストール
@@ -67,6 +67,90 @@ const pdf = await img2pdf([image1, image2], {
 });
 ```
 
+### md2pdf
+GitHub Flavored Markdown を pdfme の `Template` と `inputs` の組に変換します。
+
+```ts
+import { md2pdf } from '@pdfme/converter/md2pdf';
+
+const { template, inputs } = await md2pdf('# Hello\n\nVisit [pdfme](https://pdfme.com).');
+```
+
+[md2pdf playground](https://playground.pdfme.com/md2pdf) で実際に試せます。
+
+`md2pdf` は subpath export として公開されています。通常の `@pdfme/converter` import では Markdown parser の依存をブラウザ bundle に含めません。
+
+PDFを生成するには、返された `template` と `inputs` を `@pdfme/generator` に渡し、Markdownで使われる schema plugin を登録してください。
+
+```ts
+import { md2pdf } from '@pdfme/converter/md2pdf';
+import { generate } from '@pdfme/generator';
+import { image, line, list, table, text } from '@pdfme/schemas';
+
+const { template, inputs } = await md2pdf(`
+# リリースノート
+
+- Markdown が pdfme schemas に変換されます。
+- 水平線は line schema になります。
+
+---
+
+| Feature | Status |
+| --- | --- |
+| Tables | Supported |
+`);
+
+const pdf = await generate({
+  template,
+  inputs,
+  plugins: {
+    Text: text,
+    List: list,
+    Table: table,
+    Image: image,
+    Line: line,
+  },
+});
+```
+
+#### 日本語とCJKテキスト
+pdfme のデフォルトフォントは Roboto で、日本語/CJK glyph を含みません。日本語 Markdown を扱う場合は、変換時に CJK 対応の `fontName` を指定し、generator または UI options に同じフォントを渡してください。
+
+```ts
+import { readFile } from 'node:fs/promises';
+import { md2pdf } from '@pdfme/converter/md2pdf';
+import { generate } from '@pdfme/generator';
+import { image, line, list, table, text } from '@pdfme/schemas';
+
+const fontData = await readFile('./fonts/NotoSansJP-Regular.ttf');
+const { template, inputs } = await md2pdf('# 日本語\n\nこれはPDF生成のテストです。', {
+  style: { fontName: 'NotoSansJP' },
+});
+
+const pdf = await generate({
+  template,
+  inputs,
+  plugins: { Text: text, List: list, Table: table, Image: image, Line: line },
+  options: {
+    font: {
+      NotoSansJP: { data: fontData, fallback: true, subset: false },
+    },
+  },
+});
+```
+
+#### 現在の制限
+`md2pdf` は実用的な GFM block を扱えますが、GitHub Markdown renderer の完全互換ではありません。
+
+- paragraph、heading、list、table、code block、blockquote、horizontal rule、link、PNG/JPEG data URI image に対応しています。
+- pagination は変換後に pdfme dynamic layout が処理します。text、list、table はページ分割できますが、image の keep-together はまだ基本的な扱いです。
+- table cell は plain text です。table cell 内の inline Markdown 装飾は取り除かれます。
+- code block の language tag は parse されますが、まだ描画されません。
+- blockquote は簡単な background、padding、left rule で表現され、nested block layout としては扱いません。
+- remote Markdown image は現時点では link として出力されます。remote image の fetch と asset metadata は今後の対応です。
+- PNG/JPEG data URI image は固定の初期高さで描画され、まだ aspect ratio を保持しません。
+- list item 内の nested code block や blockquote など複雑な子要素は、list item text に単純化されます。
+
 ## エラー処理
 
 無効なパラメータが提供された場合、すべての関数は説明的なエラーをスローします：
@@ -102,6 +186,26 @@ interface Img2PdfOptions {
   imageType?: ImageType;
   size?: { height: number, width: number }; // ミリメートル単位
   margin?: [number, number, number, number]; // ミリメートル単位 [上, 右, 下, 左]
+}
+
+type PageSizePreset = 'A3' | 'A4' | 'A5' | 'A6' | 'B4' | 'B5' | 'B6' | 'Letter' | 'Legal' | 'Tabloid';
+type BoxSides = { top?: number, right?: number, bottom?: number, left?: number, x?: number, y?: number };
+type MarkdownMargin = number | [number, number, number, number] | BoxSides;
+
+interface Md2PdfOptions {
+  page?: {
+    size?: PageSizePreset | { width: number, height: number };
+    orientation?: 'portrait' | 'landscape';
+    margin?: MarkdownMargin;
+  };
+  basePdf?: { width: number, height: number, padding: [number, number, number, number] };
+  style?: {
+    fontName?: string;
+    fontSize?: number;
+    lineHeight?: number;
+    fontColor?: string;
+    headingScale?: Partial<Record<1 | 2 | 3 | 4 | 5 | 6, number>>;
+  };
 }
 ```
 


### PR DESCRIPTION
## Summary

- Add a `/md2pdf` playground route with a two-column Markdown editor and pdfme Viewer preview.
- Add PDF generation and render/PDF timing display for the md2pdf playground.
- Link the playground to the md2pdf converter docs section and show a small note that GFM support is intentionally partial.
- Document `md2pdf` in the website converter docs in English and Japanese, including usage, CJK font setup, current limitations, and `basePdf?: BlankPdf` behavior.
- Remove the playground template feedback button and keep Designer nav action buttons on one line.

## Validation

- `npm run fmt` in `playground`
- `npm run lint` in `playground`
- `npm run build` in `website`
- Browser checked `/md2pdf`, `/designer`, and `/form-viewer`

## Note

- `npm run typecheck` in `website` currently fails on the existing TypeScript 6 `baseUrl` deprecation setting, unrelated to this PR.