### PR TITLE
[codex] Add playground presets and JSX Form preview

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,6 +1,6 @@
 # JSX / md2pdf ロードマップ
 
-最終更新: 2026-05-07
+最終更新: 2026-05-08
 
 ## 目的
 
@@ -58,6 +58,10 @@ layout 品質と rich content の応用範囲を広げる。
 - CSS/Flexbox 互換を目指さず、flexbox の使いやすさだけを `Stack` / `Row` に取り込む。
 - `flexWrap`, `flexShrink`, media query, full `style` prop, CSS parser は当面対象外。
 - `%` width は将来検討でよい。まずは `flex` / `flexGrow` で比率指定を表現する。
+- Form 入力や dynamic layout reflow で `Text` / MVT が runtime に `overflow: "expand"` した場合、
+  JSX の親 `Box` / container は自動では広がらない。生成後の `Box` は rectangle schema であり、
+  子 schema の実描画高さと親 container を結び直す contract がまだないため。親子 container dynamic
+  layout は将来の設計課題として扱う。
 - `Absolute` は `Page`, top `Static`, `Box` 内の小さな escape hatch として扱う。`Stack` / `Row`
   直下対応、anchor / top-right / bottom-right shorthand、z-index 的な描画順制御は必要性が出てから検討する。
 

--- a/packages/jsx/README.md
+++ b/packages/jsx/README.md
@@ -102,5 +102,5 @@ it provides its own `jsx-runtime` and `jsx-dev-runtime`.
   `Row`, leaf schemas, `List`, and `Table`.
 - All `Page` nodes in one `renderToTemplate` call must use the same page size, orientation, and
   margin because a pdfme blank `basePdf` has one shared size and padding.
-- `Table widths` are percentages passed to pdfme `headWidthPercentages`, for example
-  `widths={[70, 30]}`.
+- `Table columnWeights` are relative column width weights that are normalized to pdfme
+  `headWidthPercentages`, for example `columnWeights={[70, 30]}`.

--- a/packages/jsx/README.md
+++ b/packages/jsx/README.md
@@ -104,3 +104,5 @@ it provides its own `jsx-runtime` and `jsx-dev-runtime`.
   margin because a pdfme blank `basePdf` has one shared size and padding.
 - `Table columnWeights` are relative column width weights, not millimeter widths. They are
   normalized to pdfme `headWidthPercentages`, for example `columnWeights={[70, 30]}`.
+  Missing or invalid weights default to `1`, so pass one weight per column when you need exact
+  ratios. Earlier beta builds used `widths`; use `columnWeights` going forward.

--- a/packages/jsx/README.md
+++ b/packages/jsx/README.md
@@ -102,5 +102,5 @@ it provides its own `jsx-runtime` and `jsx-dev-runtime`.
   `Row`, leaf schemas, `List`, and `Table`.
 - All `Page` nodes in one `renderToTemplate` call must use the same page size, orientation, and
   margin because a pdfme blank `basePdf` has one shared size and padding.
-- `Table columnWeights` are relative column width weights that are normalized to pdfme
-  `headWidthPercentages`, for example `columnWeights={[70, 30]}`.
+- `Table columnWeights` are relative column width weights, not millimeter widths. They are
+  normalized to pdfme `headWidthPercentages`, for example `columnWeights={[70, 30]}`.

--- a/packages/jsx/src/__tests__/render.test.tsx
+++ b/packages/jsx/src/__tests__/render.test.tsx
@@ -620,6 +620,26 @@ describe('@pdfme/jsx renderToTemplate', () => {
     expect(table?.headWidthPercentages).toEqual([29.230769230769234, 70.76923076923077]);
   });
 
+  it('defaults missing or invalid Table columnWeights to 1', async () => {
+    const result = await renderToTemplate(
+      <Page>
+        <Table
+          head={['A', 'B', 'C', 'D']}
+          rows={[['1', '2', '3', '4']]}
+          columnWeights={[50, 0, Number.NaN]}
+        />
+      </Page>,
+    );
+
+    const [table] = result.template.schemas[0] ?? [];
+    const widths = table?.headWidthPercentages ?? [];
+    expect(widths).toHaveLength(4);
+    expect(widths[0]).toBeCloseTo((50 / 53) * 100);
+    expect(widths[1]).toBeCloseTo((1 / 53) * 100);
+    expect(widths[2]).toBeCloseTo((1 / 53) * 100);
+    expect(widths[3]).toBeCloseTo((1 / 53) * 100);
+  });
+
   it('renders Image and Svg schemas', async () => {
     const result = await renderToTemplate(
       <Page margin={0}>

--- a/packages/jsx/src/__tests__/render.test.tsx
+++ b/packages/jsx/src/__tests__/render.test.tsx
@@ -632,7 +632,7 @@ describe('@pdfme/jsx renderToTemplate', () => {
     );
 
     const [table] = result.template.schemas[0] ?? [];
-    const widths = table?.headWidthPercentages ?? [];
+    const widths = Array.isArray(table?.headWidthPercentages) ? table.headWidthPercentages : [];
     expect(widths).toHaveLength(4);
     expect(widths[0]).toBeCloseTo((50 / 53) * 100);
     expect(widths[1]).toBeCloseTo((1 / 53) * 100);

--- a/packages/jsx/src/__tests__/render.test.tsx
+++ b/packages/jsx/src/__tests__/render.test.tsx
@@ -84,11 +84,7 @@ describe('@pdfme/jsx renderToTemplate', () => {
   it('renders Text padding and border box props', async () => {
     const result = await renderToTemplate(
       <Page>
-        <Text
-          borderColor="#d0d7de"
-          borderWidth={{ left: 0.8 }}
-          padding={{ x: 3, y: 2 }}
-        >
+        <Text borderColor="#d0d7de" borderWidth={{ left: 0.8 }} padding={{ x: 3, y: 2 }}>
           Boxed text
         </Text>
       </Page>,
@@ -585,7 +581,7 @@ describe('@pdfme/jsx renderToTemplate', () => {
             ['Alice', 10],
             ['Bob', 12],
           ]}
-          widths={[70, 30]}
+          columnWeights={[70, 30]}
         />
       </Page>,
     );
@@ -609,10 +605,14 @@ describe('@pdfme/jsx renderToTemplate', () => {
     ]);
   });
 
-  it('normalizes Table widths as relative column weights', async () => {
+  it('normalizes Table columnWeights as relative column weights', async () => {
     const result = await renderToTemplate(
       <Page>
-        <Table head={['Label', 'Description']} rows={[['Font', 'NotoSansJP']]} widths={[38, 92]} />
+        <Table
+          head={['Label', 'Description']}
+          rows={[['Font', 'NotoSansJP']]}
+          columnWeights={[38, 92]}
+        />
       </Page>,
     );
 

--- a/packages/jsx/src/__tests__/render.test.tsx
+++ b/packages/jsx/src/__tests__/render.test.tsx
@@ -609,6 +609,17 @@ describe('@pdfme/jsx renderToTemplate', () => {
     ]);
   });
 
+  it('normalizes Table widths as relative column weights', async () => {
+    const result = await renderToTemplate(
+      <Page>
+        <Table head={['Label', 'Description']} rows={[['Font', 'NotoSansJP']]} widths={[38, 92]} />
+      </Page>,
+    );
+
+    const [table] = result.template.schemas[0] ?? [];
+    expect(table?.headWidthPercentages).toEqual([29.230769230769234, 70.76923076923077]);
+  });
+
   it('renders Image and Svg schemas', async () => {
     const result = await renderToTemplate(
       <Page margin={0}>

--- a/packages/jsx/src/render.ts
+++ b/packages/jsx/src/render.ts
@@ -1123,7 +1123,7 @@ const normalizeColumnWeights = (
   if (columnWeights && columnWeights.length > 0) {
     const normalizedWidths = Array.from({ length: columnCount }, (_, index) => {
       const width = columnWeights[index];
-      return Number.isFinite(width) && Number(width) > 0 ? Number(width) : 1;
+      return typeof width === 'number' && Number.isFinite(width) && width > 0 ? width : 1;
     });
 
     const totalWidth = normalizedWidths.reduce((sum, width) => sum + width, 0);

--- a/packages/jsx/src/render.ts
+++ b/packages/jsx/src/render.ts
@@ -1023,7 +1023,7 @@ const renderTable = (
     showHead,
     repeatHead: props.repeatHead ?? false,
     head: props.head,
-    headWidthPercentages: normalizeColumnWidths(props.widths, props.head.length),
+    headWidthPercentages: normalizeColumnWeights(props.columnWeights, props.head.length),
     tableStyles: {
       borderColor: props.tableStyles?.borderColor ?? '#000000',
       borderWidth: props.tableStyles?.borderWidth ?? 0.3,
@@ -1116,10 +1116,13 @@ const substituteMultiVariableText = (
   return result + templateText.slice(lastIndex);
 };
 
-const normalizeColumnWidths = (widths: number[] | undefined, columnCount: number): number[] => {
-  if (widths && widths.length > 0) {
+const normalizeColumnWeights = (
+  columnWeights: number[] | undefined,
+  columnCount: number,
+): number[] => {
+  if (columnWeights && columnWeights.length > 0) {
     const normalizedWidths = Array.from({ length: columnCount }, (_, index) => {
-      const width = widths[index];
+      const width = columnWeights[index];
       return Number.isFinite(width) && Number(width) > 0 ? Number(width) : 1;
     });
 

--- a/packages/jsx/src/render.ts
+++ b/packages/jsx/src/render.ts
@@ -1117,7 +1117,16 @@ const substituteMultiVariableText = (
 };
 
 const normalizeColumnWidths = (widths: number[] | undefined, columnCount: number): number[] => {
-  if (widths && widths.length > 0) return widths;
+  if (widths && widths.length > 0) {
+    const normalizedWidths = Array.from({ length: columnCount }, (_, index) => {
+      const width = widths[index];
+      return Number.isFinite(width) && Number(width) > 0 ? Number(width) : 1;
+    });
+
+    const totalWidth = normalizedWidths.reduce((sum, width) => sum + width, 0);
+    if (totalWidth > 0) return normalizedWidths.map((width) => (width / totalWidth) * 100);
+  }
+
   if (columnCount <= 0) return [];
   return Array.from({ length: columnCount }, () => 100 / columnCount);
 };

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -288,7 +288,7 @@ export type TableProps = CommonProps & {
   head: string[];
   rows?: (string | number)[][];
   data?: (string | number)[][];
-  /** Relative column width weights. Values are normalized to pdfme headWidthPercentages. */
+  /** Relative column width weights, not millimeter widths. Values are normalized to pdfme headWidthPercentages. */
   columnWeights?: number[];
   width?: number;
   height?: number;

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -288,8 +288,8 @@ export type TableProps = CommonProps & {
   head: string[];
   rows?: (string | number)[][];
   data?: (string | number)[][];
-  /** Relative column widths. Values are normalized to pdfme headWidthPercentages. */
-  widths?: number[];
+  /** Relative column width weights. Values are normalized to pdfme headWidthPercentages. */
+  columnWeights?: number[];
   width?: number;
   height?: number;
   font?: string;

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -288,7 +288,7 @@ export type TableProps = CommonProps & {
   head: string[];
   rows?: (string | number)[][];
   data?: (string | number)[][];
-  /** Column width percentages passed to pdfme headWidthPercentages. */
+  /** Relative column widths. Values are normalized to pdfme headWidthPercentages. */
   widths?: number[];
   width?: number;
   height?: number;

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -288,7 +288,10 @@ export type TableProps = CommonProps & {
   head: string[];
   rows?: (string | number)[][];
   data?: (string | number)[][];
-  /** Relative column width weights, not millimeter widths. Values are normalized to pdfme headWidthPercentages. */
+  /**
+   * Relative column width weights, not millimeter widths. Values are normalized to pdfme
+   * headWidthPercentages. Missing or invalid weights default to 1.
+   */
   columnWeights?: number[];
   width?: number;
   height?: number;

--- a/playground/e2e/jsxPlaygroundRuntime.test.ts
+++ b/playground/e2e/jsxPlaygroundRuntime.test.ts
@@ -64,6 +64,15 @@ describe('JSX playground runtime', () => {
     });
   });
 
+  it('rejects JSX that renders an invalid pdfme template', async () => {
+    await expect(
+      renderJsxSource(
+        'return (<Page><Text name={123} height={10}>Bad name</Text></Page>);',
+        testFont,
+      ),
+    ).rejects.toThrow('Invalid argument');
+  });
+
   it.each(jsxPlaygroundPresets)('renders the $label preset', async ({ source }) => {
     const result = await renderJsxSource(source, testFont);
 

--- a/playground/e2e/jsxPlaygroundRuntime.test.ts
+++ b/playground/e2e/jsxPlaygroundRuntime.test.ts
@@ -1,5 +1,15 @@
-import { getDefaultFont } from '@pdfme/common';
+import { DEFAULT_FONT_NAME, getDefaultFont } from '@pdfme/common';
 import { compileJsxFunctionBody, renderJsxSource } from '../src/routes/jsxPlaygroundRuntime';
+import { jsxPlaygroundPresets } from '../src/routes/jsxPlaygroundExamples';
+
+const defaultFont = getDefaultFont();
+const testFont = {
+  ...defaultFont,
+  NotoSansJP: {
+    ...defaultFont[DEFAULT_FONT_NAME],
+    fallback: false,
+  },
+};
 
 describe('JSX playground runtime', () => {
   it('compiles JSX function bodies with pdfme component calls', () => {
@@ -40,7 +50,7 @@ describe('JSX playground runtime', () => {
   it('renders JSX into a normal pdfme template result', async () => {
     const result = await renderJsxSource(
       'return (<Page size="A4"><Text height={10}>Hello JSX</Text></Page>);',
-      getDefaultFont(),
+      testFont,
     );
 
     expect(result.inputs).toEqual([{}]);
@@ -52,5 +62,13 @@ describe('JSX playground runtime', () => {
       readOnly: true,
       type: 'text',
     });
+  });
+
+  it.each(jsxPlaygroundPresets)('renders the $label preset', async ({ source }) => {
+    const result = await renderJsxSource(source, testFont);
+
+    expect(result.inputs).toHaveLength(1);
+    expect(result.template.schemas.length).toBeGreaterThan(0);
+    expect(result.template.schemas[0]?.length).toBeGreaterThan(0);
   });
 });

--- a/playground/e2e/md2PdfPresets.test.ts
+++ b/playground/e2e/md2PdfPresets.test.ts
@@ -1,0 +1,17 @@
+import { md2pdf } from '@pdfme/converter/md2pdf';
+import { md2PdfPresets } from '../src/routes/md2PdfPresets';
+
+describe('md2pdf playground presets', () => {
+  it.each(md2PdfPresets)('converts the $label preset', async ({ markdown }) => {
+    const result = await md2pdf(markdown, {
+      style: {
+        fontName: 'NotoSansJP',
+        lineHeight: 1.3,
+      },
+    });
+
+    expect(result.inputs).toEqual([{}]);
+    expect(result.template.schemas.length).toBeGreaterThan(0);
+    expect(result.template.schemas[0]?.length).toBeGreaterThan(0);
+  });
+});

--- a/playground/e2e/previewSizing.test.ts
+++ b/playground/e2e/previewSizing.test.ts
@@ -1,0 +1,34 @@
+import { shouldRefreshCollapsedPreviewSnapshot } from '../src/routes/previewSizing';
+
+describe('preview sizing helpers', () => {
+  it('refreshes when a visible preview rendered much smaller than its container', () => {
+    expect(
+      shouldRefreshCollapsedPreviewSnapshot({
+        containerBottom: 800,
+        containerTop: 100,
+        renderedHeight: 300,
+        viewportHeight: 900,
+      }),
+    ).toBe(true);
+  });
+
+  it('does not refresh when the visible area is too small or the preview is not collapsed', () => {
+    expect(
+      shouldRefreshCollapsedPreviewSnapshot({
+        containerBottom: 220,
+        containerTop: 0,
+        renderedHeight: 80,
+        viewportHeight: 900,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldRefreshCollapsedPreviewSnapshot({
+        containerBottom: 800,
+        containerTop: 100,
+        renderedHeight: 600,
+        viewportHeight: 900,
+      }),
+    ).toBe(false);
+  });
+});

--- a/playground/src/routes/JsxPlayground.tsx
+++ b/playground/src/routes/JsxPlayground.tsx
@@ -229,10 +229,20 @@ export default function JsxPlayground() {
 
         if (previewMode === 'form') {
           (ui as Form).onChangeInput(({ index, name, value }) => {
+            const nextValue = value as string | undefined;
             setInputs((previousInputs) => {
-              if (previousInputs[index]?.[name] === value) return previousInputs;
+              const previousInput = previousInputs[index] ?? {};
+              if (nextValue === undefined && !(name in previousInput)) return previousInputs;
+              if (previousInput[name] === nextValue) return previousInputs;
+
               const nextInputs = [...previousInputs];
-              nextInputs[index] = { ...nextInputs[index], [name]: value };
+              const nextInput = { ...previousInput };
+              if (nextValue === undefined) {
+                delete nextInput[name];
+              } else {
+                nextInput[name] = nextValue;
+              }
+              nextInputs[index] = nextInput;
               inputsRef.current = nextInputs;
               return nextInputs;
             });

--- a/playground/src/routes/JsxPlayground.tsx
+++ b/playground/src/routes/JsxPlayground.tsx
@@ -40,6 +40,9 @@ type PreviewInstance = {
   ui: Form | Viewer;
 };
 
+const getErrorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : String(error);
+
 const configureJsxEditor: Parameters<typeof CodeEditor>[0]['beforeMount'] = (monaco) => {
   const typeScriptLanguage = monaco.languages.typescript;
   if (!typeScriptLanguage) return;
@@ -174,7 +177,7 @@ export default function JsxPlayground() {
         setError(null);
       } catch (err) {
         if (cancelled) return;
-        setError(err instanceof Error ? err.message : String(err));
+        setError(getErrorMessage(err));
         setRenderDuration(null);
       }
     }, 250);
@@ -188,43 +191,47 @@ export default function JsxPlayground() {
   useEffect(() => {
     if (!previewRootRef.current || !template) return;
 
-    if (previewRef.current && previewRef.current.mode !== previewMode) {
-      previewRef.current.ui.destroy();
-      previewRef.current = null;
-    }
-
-    if (previewRef.current) {
-      previewRef.current.ui.updateTemplate(template);
-      previewRef.current.ui.setInputs(inputs);
-    } else {
-      const Ui = previewMode === 'form' ? Form : Viewer;
-      const ui = new Ui({
-        domContainer: previewRootRef.current,
-        template,
-        inputs,
-        options: {
-          font: getFontsData(),
-          lang: 'en',
-          theme: {
-            token: {
-              colorPrimary: '#25c2a0',
-            },
-          },
-        },
-        plugins: getPlugins(),
-      });
-
-      if (previewMode === 'form') {
-        (ui as Form).onChangeInput(({ index, name, value }) => {
-          setInputs((previousInputs) => {
-            const nextInputs = [...previousInputs];
-            nextInputs[index] = { ...nextInputs[index], [name]: value };
-            return nextInputs;
-          });
-        });
+    try {
+      if (previewRef.current && previewRef.current.mode !== previewMode) {
+        previewRef.current.ui.destroy();
+        previewRef.current = null;
       }
 
-      previewRef.current = { mode: previewMode, ui };
+      if (previewRef.current) {
+        previewRef.current.ui.updateTemplate(template);
+        previewRef.current.ui.setInputs(inputs);
+      } else {
+        const Ui = previewMode === 'form' ? Form : Viewer;
+        const ui = new Ui({
+          domContainer: previewRootRef.current,
+          template,
+          inputs,
+          options: {
+            font: getFontsData(),
+            lang: 'en',
+            theme: {
+              token: {
+                colorPrimary: '#25c2a0',
+              },
+            },
+          },
+          plugins: getPlugins(),
+        });
+
+        if (previewMode === 'form') {
+          (ui as Form).onChangeInput(({ index, name, value }) => {
+            setInputs((previousInputs) => {
+              const nextInputs = [...previousInputs];
+              nextInputs[index] = { ...nextInputs[index], [name]: value };
+              return nextInputs;
+            });
+          });
+        }
+
+        previewRef.current = { mode: previewMode, ui };
+      }
+    } catch (err) {
+      setError(getErrorMessage(err));
     }
   }, [template, inputs, previewMode]);
 
@@ -248,7 +255,7 @@ export default function JsxPlayground() {
       setPdfDuration(duration);
       toast.info(`Generated PDF in ${duration}ms`);
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : String(error));
+      toast.error(getErrorMessage(error));
     } finally {
       setIsGeneratingPdf(false);
     }

--- a/playground/src/routes/JsxPlayground.tsx
+++ b/playground/src/routes/JsxPlayground.tsx
@@ -86,6 +86,7 @@ declare function PageBreak(props?: Record<string, unknown>): unknown;
 export default function JsxPlayground() {
   const previewRootRef = useRef<HTMLDivElement | null>(null);
   const previewRef = useRef<PreviewInstance | null>(null);
+  const inputsRef = useRef<Record<string, string>[]>([{}]);
   const renderWorkerRef = useRef<Worker | null>(null);
   const pendingRenderRef = useRef<PendingRender | null>(null);
   const nextRenderRequestIdRef = useRef(0);
@@ -167,6 +168,10 @@ export default function JsxPlayground() {
   );
 
   useEffect(() => {
+    inputsRef.current = inputs;
+  }, [inputs]);
+
+  useEffect(() => {
     let cancelled = false;
     const timer = window.setTimeout(async () => {
       const startTimer = performance.now();
@@ -175,6 +180,7 @@ export default function JsxPlayground() {
         if (cancelled) return;
         setTemplate(result.template);
         setInputs(result.inputs);
+        inputsRef.current = result.inputs;
         setRenderDuration(Math.round(performance.now() - startTimer));
         setError(null);
       } catch (err) {
@@ -192,6 +198,7 @@ export default function JsxPlayground() {
 
   useEffect(() => {
     if (!previewRootRef.current || !template) return;
+    const currentInputs = inputsRef.current;
 
     try {
       if (previewRef.current && previewRef.current.mode !== previewMode) {
@@ -201,13 +208,13 @@ export default function JsxPlayground() {
 
       if (previewRef.current) {
         previewRef.current.ui.updateTemplate(template);
-        previewRef.current.ui.setInputs(inputs);
+        previewRef.current.ui.setInputs(currentInputs);
       } else {
         const Ui = previewMode === 'form' ? Form : Viewer;
         const ui = new Ui({
           domContainer: previewRootRef.current,
           template,
-          inputs,
+          inputs: currentInputs,
           options: {
             font: getFontsData(),
             lang: 'en',
@@ -223,8 +230,10 @@ export default function JsxPlayground() {
         if (previewMode === 'form') {
           (ui as Form).onChangeInput(({ index, name, value }) => {
             setInputs((previousInputs) => {
+              if (previousInputs[index]?.[name] === value) return previousInputs;
               const nextInputs = [...previousInputs];
               nextInputs[index] = { ...nextInputs[index], [name]: value };
+              inputsRef.current = nextInputs;
               return nextInputs;
             });
           });
@@ -235,7 +244,19 @@ export default function JsxPlayground() {
     } catch (err) {
       setError(getErrorMessage(err));
     }
-  }, [template, inputs, previewMode, previewRefreshKey]);
+  }, [template, previewMode, previewRefreshKey]);
+
+  useEffect(() => {
+    if (previewMode !== 'viewer' || !previewRef.current || previewRef.current.mode !== 'viewer') {
+      return;
+    }
+
+    try {
+      previewRef.current.ui.setInputs(inputs);
+    } catch (err) {
+      setError(getErrorMessage(err));
+    }
+  }, [inputs, previewMode]);
 
   useEffect(() => {
     if (!template) return;

--- a/playground/src/routes/JsxPlayground.tsx
+++ b/playground/src/routes/JsxPlayground.tsx
@@ -9,6 +9,7 @@ import { downloadJsonFile, generatePDF, getFontsData } from '../helper';
 import { getPlugins } from '../plugins';
 import { initialJsx, jsxPlaygroundPresets } from './jsxPlaygroundExamples';
 import JsxPlaygroundWorker from './jsxPlaygroundWorker?worker';
+import { shouldRefreshCollapsedPreview } from './previewSizing';
 
 const JSX_DOCS_URL = 'https://pdfme.com/docs/jsx#jsx-playground-beta';
 const JSX_EDITOR_PATH = 'file:///jsx-playground.tsx';
@@ -97,6 +98,7 @@ export default function JsxPlayground() {
   const [renderDuration, setRenderDuration] = useState<number | null>(null);
   const [pdfDuration, setPdfDuration] = useState<number | null>(null);
   const [isGeneratingPdf, setIsGeneratingPdf] = useState(false);
+  const [previewRefreshKey, setPreviewRefreshKey] = useState(0);
   const selectedPreset =
     jsxPlaygroundPresets.find((preset) => preset.id === selectedPresetId) ??
     jsxPlaygroundPresets[0];
@@ -233,7 +235,38 @@ export default function JsxPlayground() {
     } catch (err) {
       setError(getErrorMessage(err));
     }
-  }, [template, inputs, previewMode]);
+  }, [template, inputs, previewMode, previewRefreshKey]);
+
+  useEffect(() => {
+    if (!template) return;
+
+    let frameId: number | null = null;
+    const refreshPreviewIfVisible = () => {
+      if (frameId !== null) return;
+
+      frameId = window.requestAnimationFrame(() => {
+        frameId = null;
+        const container = previewRootRef.current;
+        const preview = previewRef.current;
+        if (!container || !preview || !shouldRefreshCollapsedPreview(container)) return;
+
+        preview.ui.destroy();
+        previewRef.current = null;
+        setPreviewRefreshKey((key) => key + 1);
+      });
+    };
+
+    window.addEventListener('scroll', refreshPreviewIfVisible, { passive: true });
+    window.addEventListener('resize', refreshPreviewIfVisible);
+    const timeoutId = window.setTimeout(refreshPreviewIfVisible, 150);
+
+    return () => {
+      window.removeEventListener('scroll', refreshPreviewIfVisible);
+      window.removeEventListener('resize', refreshPreviewIfVisible);
+      window.clearTimeout(timeoutId);
+      if (frameId !== null) window.cancelAnimationFrame(frameId);
+    };
+  }, [template, previewMode]);
 
   useEffect(() => {
     return () => {
@@ -276,8 +309,8 @@ export default function JsxPlayground() {
   };
 
   return (
-    <main className="flex min-h-0 flex-1 flex-col bg-gray-100">
-      <div className="flex items-center justify-between border-b border-gray-200 bg-white px-4 py-3">
+    <main className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-x-hidden overflow-y-auto bg-gray-100 lg:overflow-hidden">
+      <div className="flex flex-col gap-3 border-b border-gray-200 bg-white px-4 py-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
           <div className="flex items-center gap-3">
             <h1 className="text-sm font-semibold text-gray-900">@pdfme/jsx (beta)</h1>
@@ -291,18 +324,18 @@ export default function JsxPlayground() {
               <ExternalLink className="size-3" />
             </a>
           </div>
-          <p className="mt-1 text-xs text-gray-500">{selectedPreset?.description}</p>
-          <p className="mt-1 text-xs text-gray-500">
+          <p className="mt-1 break-words text-xs text-gray-500">{selectedPreset?.description}</p>
+          <p className="mt-1 break-words text-xs text-gray-500">
             Write a JSX function body that returns pdfme pages. Imports are intentionally disabled
             in this beta playground.
           </p>
         </div>
-        <div className="flex shrink-0 items-center gap-2 pl-4">
+        <div className="grid w-full min-w-0 grid-cols-2 gap-2 sm:flex sm:w-auto sm:shrink-0 sm:items-center sm:pl-4">
           <select
             aria-label="JSX preset"
             value={selectedPresetId}
             onChange={onChangePreset}
-            className="rounded border border-gray-300 bg-white px-2 py-1.5 text-sm text-gray-700"
+            className="col-span-2 max-w-full rounded border border-gray-300 bg-white px-2 py-1.5 text-sm text-gray-700 sm:col-span-1 sm:min-w-40"
           >
             {jsxPlaygroundPresets.map((preset) => (
               <option key={preset.id} value={preset.id}>
@@ -314,7 +347,7 @@ export default function JsxPlayground() {
             type="button"
             disabled={!template || Boolean(error)}
             onClick={onDownloadTemplate}
-            className="inline-flex items-center gap-1 rounded border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex min-w-0 items-center justify-center gap-1 whitespace-nowrap rounded border border-gray-300 px-2 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 sm:px-3"
           >
             <Download className="size-4" />
             Template JSON
@@ -323,7 +356,7 @@ export default function JsxPlayground() {
             type="button"
             disabled={!template || Boolean(error) || isGeneratingPdf}
             onClick={onGeneratePdf}
-            className="rounded border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+            className="min-w-0 whitespace-nowrap rounded border border-gray-300 px-2 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 sm:px-3"
           >
             {isGeneratingPdf ? 'Generating...' : 'Generate PDF'}
           </button>
@@ -333,8 +366,8 @@ export default function JsxPlayground() {
         This beta runs JSX in an isolated worker and blocks common browser globals, but it is still
         for trusted examples. Do not paste code you do not trust.
       </div>
-      <div className="grid min-h-0 flex-1 grid-cols-1 gap-0 lg:grid-cols-2">
-        <section className="flex min-h-[45vh] flex-col border-b border-gray-200 bg-white lg:min-h-0 lg:border-b-0 lg:border-r">
+      <div className="grid min-w-0 flex-none grid-cols-1 gap-0 lg:min-h-0 lg:flex-1 lg:grid-cols-2">
+        <section className="flex min-h-[28rem] min-w-0 flex-col border-b border-gray-200 bg-white lg:min-h-0 lg:border-b-0 lg:border-r">
           <div className="border-b border-gray-200 px-4 py-2 text-xs font-medium uppercase tracking-wide text-gray-500">
             JSX
           </div>
@@ -348,8 +381,8 @@ export default function JsxPlayground() {
             value={source}
           />
         </section>
-        <section className="flex min-h-[55vh] flex-col bg-gray-100 lg:min-h-0">
-          <div className="flex items-center justify-between border-b border-gray-200 bg-white px-4 py-2 text-xs font-medium uppercase tracking-wide text-gray-500">
+        <section className="flex min-h-[44rem] min-w-0 flex-col bg-gray-100 lg:min-h-0">
+          <div className="flex flex-col gap-2 border-b border-gray-200 bg-white px-4 py-2 text-xs font-medium uppercase tracking-wide text-gray-500 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-center gap-2">
               <span>{previewMode === 'form' ? 'Form' : 'Viewer'}</span>
               <div className="inline-flex overflow-hidden rounded border border-gray-300 normal-case tracking-normal">
@@ -375,7 +408,10 @@ export default function JsxPlayground() {
               {error && <span className="max-w-[32rem] truncate text-red-600">{error}</span>}
             </div>
           </div>
-          <div ref={previewRootRef} className="min-h-0 flex-1" />
+          <div
+            ref={previewRootRef}
+            className="h-[38rem] flex-none lg:h-auto lg:min-h-0 lg:flex-1"
+          />
         </section>
       </div>
     </main>

--- a/playground/src/routes/JsxPlayground.tsx
+++ b/playground/src/routes/JsxPlayground.tsx
@@ -1,13 +1,13 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type ChangeEvent } from 'react';
 import type { Template } from '@pdfme/common';
 import type { RenderResult } from '@pdfme/jsx';
-import { Viewer } from '@pdfme/ui';
+import { Form, Viewer } from '@pdfme/ui';
 import { Download, ExternalLink } from 'lucide-react';
 import { toast } from 'react-toastify';
 import CodeEditor from '../components/CodeEditor';
 import { downloadJsonFile, generatePDF, getFontsData } from '../helper';
 import { getPlugins } from '../plugins';
-import { initialJsx } from './jsxPlaygroundExamples';
+import { initialJsx, jsxPlaygroundPresets } from './jsxPlaygroundExamples';
 import JsxPlaygroundWorker from './jsxPlaygroundWorker?worker';
 
 const JSX_DOCS_URL = 'https://pdfme.com/docs/jsx#jsx-playground-beta';
@@ -31,6 +31,13 @@ type PendingRender = {
   reject: (error: Error) => void;
   resolve: (result: RenderResult) => void;
   timeoutId: number;
+};
+
+type PreviewMode = 'viewer' | 'form';
+
+type PreviewInstance = {
+  mode: PreviewMode;
+  ui: Form | Viewer;
 };
 
 const configureJsxEditor: Parameters<typeof CodeEditor>[0]['beforeMount'] = (monaco) => {
@@ -73,11 +80,13 @@ declare function PageBreak(props?: Record<string, unknown>): unknown;
 };
 
 export default function JsxPlayground() {
-  const viewerRootRef = useRef<HTMLDivElement | null>(null);
-  const viewerRef = useRef<Viewer | null>(null);
+  const previewRootRef = useRef<HTMLDivElement | null>(null);
+  const previewRef = useRef<PreviewInstance | null>(null);
   const renderWorkerRef = useRef<Worker | null>(null);
   const pendingRenderRef = useRef<PendingRender | null>(null);
   const nextRenderRequestIdRef = useRef(0);
+  const [selectedPresetId, setSelectedPresetId] = useState(jsxPlaygroundPresets[0]?.id ?? '');
+  const [previewMode, setPreviewMode] = useState<PreviewMode>('viewer');
   const [source, setSource] = useState(initialJsx);
   const [template, setTemplate] = useState<Template | null>(null);
   const [inputs, setInputs] = useState<Record<string, string>[]>([{}]);
@@ -85,6 +94,9 @@ export default function JsxPlayground() {
   const [renderDuration, setRenderDuration] = useState<number | null>(null);
   const [pdfDuration, setPdfDuration] = useState<number | null>(null);
   const [isGeneratingPdf, setIsGeneratingPdf] = useState(false);
+  const selectedPreset =
+    jsxPlaygroundPresets.find((preset) => preset.id === selectedPresetId) ??
+    jsxPlaygroundPresets[0];
 
   const terminateRenderWorker = useCallback(() => {
     renderWorkerRef.current?.terminate();
@@ -174,14 +186,20 @@ export default function JsxPlayground() {
   }, [renderJsxSourceInWorker, source]);
 
   useEffect(() => {
-    if (!viewerRootRef.current || !template) return;
+    if (!previewRootRef.current || !template) return;
 
-    if (viewerRef.current) {
-      viewerRef.current.updateTemplate(template);
-      viewerRef.current.setInputs(inputs);
+    if (previewRef.current && previewRef.current.mode !== previewMode) {
+      previewRef.current.ui.destroy();
+      previewRef.current = null;
+    }
+
+    if (previewRef.current) {
+      previewRef.current.ui.updateTemplate(template);
+      previewRef.current.ui.setInputs(inputs);
     } else {
-      viewerRef.current = new Viewer({
-        domContainer: viewerRootRef.current,
+      const Ui = previewMode === 'form' ? Form : Viewer;
+      const ui = new Ui({
+        domContainer: previewRootRef.current,
         template,
         inputs,
         options: {
@@ -195,15 +213,27 @@ export default function JsxPlayground() {
         },
         plugins: getPlugins(),
       });
+
+      if (previewMode === 'form') {
+        (ui as Form).onChangeInput(({ index, name, value }) => {
+          setInputs((previousInputs) => {
+            const nextInputs = [...previousInputs];
+            nextInputs[index] = { ...nextInputs[index], [name]: value };
+            return nextInputs;
+          });
+        });
+      }
+
+      previewRef.current = { mode: previewMode, ui };
     }
-  }, [template, inputs]);
+  }, [template, inputs, previewMode]);
 
   useEffect(() => {
     return () => {
       clearPendingRender(new Error('JSX render cancelled.'));
       terminateRenderWorker();
-      viewerRef.current?.destroy();
-      viewerRef.current = null;
+      previewRef.current?.ui.destroy();
+      previewRef.current = null;
     };
   }, [clearPendingRender, terminateRenderWorker]);
 
@@ -213,7 +243,7 @@ export default function JsxPlayground() {
     const startTimer = performance.now();
     setIsGeneratingPdf(true);
     try {
-      await generatePDF(viewerRef.current);
+      await generatePDF(previewRef.current?.ui ?? null);
       const duration = Math.round(performance.now() - startTimer);
       setPdfDuration(duration);
       toast.info(`Generated PDF in ${duration}ms`);
@@ -227,6 +257,15 @@ export default function JsxPlayground() {
   const onDownloadTemplate = () => {
     if (!template) return;
     downloadJsonFile(template, 'jsx-template');
+  };
+
+  const onChangePreset = (event: ChangeEvent<HTMLSelectElement>) => {
+    const preset = jsxPlaygroundPresets.find((item) => item.id === event.target.value);
+    if (!preset) return;
+    setSelectedPresetId(preset.id);
+    setSource(preset.source);
+    setError(null);
+    setPdfDuration(null);
   };
 
   return (
@@ -245,12 +284,25 @@ export default function JsxPlayground() {
               <ExternalLink className="size-3" />
             </a>
           </div>
+          <p className="mt-1 text-xs text-gray-500">{selectedPreset?.description}</p>
           <p className="mt-1 text-xs text-gray-500">
             Write a JSX function body that returns pdfme pages. Imports are intentionally disabled
             in this beta playground.
           </p>
         </div>
         <div className="flex shrink-0 items-center gap-2 pl-4">
+          <select
+            aria-label="JSX preset"
+            value={selectedPresetId}
+            onChange={onChangePreset}
+            className="rounded border border-gray-300 bg-white px-2 py-1.5 text-sm text-gray-700"
+          >
+            {jsxPlaygroundPresets.map((preset) => (
+              <option key={preset.id} value={preset.id}>
+                {preset.label}
+              </option>
+            ))}
+          </select>
           <button
             type="button"
             disabled={!template || Boolean(error)}
@@ -291,14 +343,32 @@ export default function JsxPlayground() {
         </section>
         <section className="flex min-h-[55vh] flex-col bg-gray-100 lg:min-h-0">
           <div className="flex items-center justify-between border-b border-gray-200 bg-white px-4 py-2 text-xs font-medium uppercase tracking-wide text-gray-500">
-            <span>Viewer</span>
+            <div className="flex items-center gap-2">
+              <span>{previewMode === 'form' ? 'Form' : 'Viewer'}</span>
+              <div className="inline-flex overflow-hidden rounded border border-gray-300 normal-case tracking-normal">
+                {(['viewer', 'form'] as const).map((mode) => (
+                  <button
+                    key={mode}
+                    type="button"
+                    onClick={() => setPreviewMode(mode)}
+                    className={`px-2 py-1 text-xs ${
+                      previewMode === mode
+                        ? 'bg-green-50 text-green-700'
+                        : 'bg-white text-gray-600 hover:bg-gray-50'
+                    }`}
+                  >
+                    {mode === 'form' ? 'Form' : 'Viewer'}
+                  </button>
+                ))}
+              </div>
+            </div>
             <div className="flex items-center gap-3 normal-case tracking-normal">
               {renderDuration !== null && <span>render {renderDuration}ms</span>}
               {pdfDuration !== null && <span>pdf {pdfDuration}ms</span>}
               {error && <span className="max-w-[32rem] truncate text-red-600">{error}</span>}
             </div>
           </div>
-          <div ref={viewerRootRef} className="min-h-0 flex-1" />
+          <div ref={previewRootRef} className="min-h-0 flex-1" />
         </section>
       </div>
     </main>

--- a/playground/src/routes/Md2Pdf.tsx
+++ b/playground/src/routes/Md2Pdf.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type ChangeEvent } from 'react';
 import type { Template } from '@pdfme/common';
 import { md2pdf } from '@pdfme/converter/md2pdf';
 import { Viewer } from '@pdfme/ui';
@@ -7,36 +7,14 @@ import { toast } from 'react-toastify';
 import { generatePDF, getFontsData } from '../helper';
 import { getPlugins } from '../plugins';
 import CodeEditor from '../components/CodeEditor';
+import { initialMarkdown, md2PdfPresets } from './md2PdfPresets';
 
 const MD2PDF_DOCS_URL = 'https://pdfme.com/docs/converter#md2pdf-beta';
-
-const initialMarkdown = `# md2pdf playground
-
-Markdownからpdfme Templateを作ります。日本語もフォントを指定すれば表示できます。
-
-## Blocks
-
-- Paragraph
-- **Bold**, *italic*, ~~strike~~, \`inline code\`
-- [pdfme](https://pdfme.com)
-
----
-
-> Blockquote uses a left rule and padding.
-
-\`\`\`ts
-const template = await md2pdf(markdown);
-\`\`\`
-
-| Feature | Status |
-| --- | --- |
-| Table grid | Supported |
-| Remote image | Link fallback |
-`;
 
 export default function Md2Pdf() {
   const viewerRootRef = useRef<HTMLDivElement | null>(null);
   const viewerRef = useRef<Viewer | null>(null);
+  const [selectedPresetId, setSelectedPresetId] = useState(md2PdfPresets[0]?.id ?? '');
   const [markdown, setMarkdown] = useState(initialMarkdown);
   const [template, setTemplate] = useState<Template | null>(null);
   const [inputs, setInputs] = useState<Record<string, string>[]>([{}]);
@@ -44,6 +22,8 @@ export default function Md2Pdf() {
   const [renderDuration, setRenderDuration] = useState<number | null>(null);
   const [pdfDuration, setPdfDuration] = useState<number | null>(null);
   const [isGeneratingPdf, setIsGeneratingPdf] = useState(false);
+  const selectedPreset =
+    md2PdfPresets.find((preset) => preset.id === selectedPresetId) ?? md2PdfPresets[0];
 
   useEffect(() => {
     let cancelled = false;
@@ -121,6 +101,15 @@ export default function Md2Pdf() {
     }
   };
 
+  const onChangePreset = (event: ChangeEvent<HTMLSelectElement>) => {
+    const preset = md2PdfPresets.find((item) => item.id === event.target.value);
+    if (!preset) return;
+    setSelectedPresetId(preset.id);
+    setMarkdown(preset.markdown);
+    setError(null);
+    setPdfDuration(null);
+  };
+
   return (
     <main className="flex min-h-0 flex-1 flex-col bg-gray-100">
       <div className="flex items-center justify-between border-b border-gray-200 bg-white px-4 py-3">
@@ -137,12 +126,25 @@ export default function Md2Pdf() {
               <ExternalLink className="size-3" />
             </a>
           </div>
+          <p className="mt-1 text-xs text-gray-500">{selectedPreset?.description}</p>
           <p className="mt-1 text-xs text-gray-500">
             GFM support is intentionally partial: complex table/list content and remote images are
             simplified.
           </p>
         </div>
-        <div className="shrink-0 pl-4">
+        <div className="flex shrink-0 items-center gap-2 pl-4">
+          <select
+            aria-label="Markdown preset"
+            value={selectedPresetId}
+            onChange={onChangePreset}
+            className="rounded border border-gray-300 bg-white px-2 py-1.5 text-sm text-gray-700"
+          >
+            {md2PdfPresets.map((preset) => (
+              <option key={preset.id} value={preset.id}>
+                {preset.label}
+              </option>
+            ))}
+          </select>
           <button
             type="button"
             disabled={!template || Boolean(error) || isGeneratingPdf}

--- a/playground/src/routes/Md2Pdf.tsx
+++ b/playground/src/routes/Md2Pdf.tsx
@@ -8,6 +8,7 @@ import { generatePDF, getFontsData } from '../helper';
 import { getPlugins } from '../plugins';
 import CodeEditor from '../components/CodeEditor';
 import { initialMarkdown, md2PdfPresets } from './md2PdfPresets';
+import { shouldRefreshCollapsedPreview } from './previewSizing';
 
 const MD2PDF_DOCS_URL = 'https://pdfme.com/docs/converter#md2pdf-beta';
 
@@ -22,6 +23,7 @@ export default function Md2Pdf() {
   const [renderDuration, setRenderDuration] = useState<number | null>(null);
   const [pdfDuration, setPdfDuration] = useState<number | null>(null);
   const [isGeneratingPdf, setIsGeneratingPdf] = useState(false);
+  const [viewerRefreshKey, setViewerRefreshKey] = useState(0);
   const selectedPreset =
     md2PdfPresets.find((preset) => preset.id === selectedPresetId) ?? md2PdfPresets[0];
 
@@ -77,7 +79,38 @@ export default function Md2Pdf() {
         plugins: getPlugins(),
       });
     }
-  }, [template, inputs]);
+  }, [template, inputs, viewerRefreshKey]);
+
+  useEffect(() => {
+    if (!template) return;
+
+    let frameId: number | null = null;
+    const refreshViewerIfVisible = () => {
+      if (frameId !== null) return;
+
+      frameId = window.requestAnimationFrame(() => {
+        frameId = null;
+        const container = viewerRootRef.current;
+        const viewer = viewerRef.current;
+        if (!container || !viewer || !shouldRefreshCollapsedPreview(container)) return;
+
+        viewer.destroy();
+        viewerRef.current = null;
+        setViewerRefreshKey((key) => key + 1);
+      });
+    };
+
+    window.addEventListener('scroll', refreshViewerIfVisible, { passive: true });
+    window.addEventListener('resize', refreshViewerIfVisible);
+    const timeoutId = window.setTimeout(refreshViewerIfVisible, 150);
+
+    return () => {
+      window.removeEventListener('scroll', refreshViewerIfVisible);
+      window.removeEventListener('resize', refreshViewerIfVisible);
+      window.clearTimeout(timeoutId);
+      if (frameId !== null) window.cancelAnimationFrame(frameId);
+    };
+  }, [template]);
 
   useEffect(() => {
     return () => {
@@ -111,8 +144,8 @@ export default function Md2Pdf() {
   };
 
   return (
-    <main className="flex min-h-0 flex-1 flex-col bg-gray-100">
-      <div className="flex items-center justify-between border-b border-gray-200 bg-white px-4 py-3">
+    <main className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-x-hidden overflow-y-auto bg-gray-100 lg:overflow-hidden">
+      <div className="flex flex-col gap-3 border-b border-gray-200 bg-white px-4 py-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
           <div className="flex items-center gap-3">
             <h1 className="text-sm font-semibold text-gray-900">md2pdf (beta)</h1>
@@ -126,18 +159,18 @@ export default function Md2Pdf() {
               <ExternalLink className="size-3" />
             </a>
           </div>
-          <p className="mt-1 text-xs text-gray-500">{selectedPreset?.description}</p>
-          <p className="mt-1 text-xs text-gray-500">
+          <p className="mt-1 break-words text-xs text-gray-500">{selectedPreset?.description}</p>
+          <p className="mt-1 break-words text-xs text-gray-500">
             GFM support is intentionally partial: complex table/list content and remote images are
             simplified.
           </p>
         </div>
-        <div className="flex shrink-0 items-center gap-2 pl-4">
+        <div className="grid w-full min-w-0 grid-cols-2 gap-2 sm:flex sm:w-auto sm:shrink-0 sm:items-center sm:pl-4">
           <select
             aria-label="Markdown preset"
             value={selectedPresetId}
             onChange={onChangePreset}
-            className="rounded border border-gray-300 bg-white px-2 py-1.5 text-sm text-gray-700"
+            className="col-span-2 max-w-full rounded border border-gray-300 bg-white px-2 py-1.5 text-sm text-gray-700 sm:col-span-1 sm:min-w-40"
           >
             {md2PdfPresets.map((preset) => (
               <option key={preset.id} value={preset.id}>
@@ -149,14 +182,14 @@ export default function Md2Pdf() {
             type="button"
             disabled={!template || Boolean(error) || isGeneratingPdf}
             onClick={onGeneratePdf}
-            className="rounded border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+            className="col-span-2 min-w-0 whitespace-nowrap rounded border border-gray-300 px-2 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 sm:col-span-1 sm:px-3"
           >
             {isGeneratingPdf ? 'Generating...' : 'Generate PDF'}
           </button>
         </div>
       </div>
-      <div className="grid min-h-0 flex-1 grid-cols-1 gap-0 lg:grid-cols-2">
-        <section className="flex min-h-[45vh] flex-col border-b border-gray-200 bg-white lg:min-h-0 lg:border-b-0 lg:border-r">
+      <div className="grid min-w-0 flex-none grid-cols-1 gap-0 lg:min-h-0 lg:flex-1 lg:grid-cols-2">
+        <section className="flex min-h-[28rem] min-w-0 flex-col border-b border-gray-200 bg-white lg:min-h-0 lg:border-b-0 lg:border-r">
           <div className="border-b border-gray-200 px-4 py-2 text-xs font-medium uppercase tracking-wide text-gray-500">
             Markdown
           </div>
@@ -168,8 +201,8 @@ export default function Md2Pdf() {
             value={markdown}
           />
         </section>
-        <section className="flex min-h-[55vh] flex-col bg-gray-100 lg:min-h-0">
-          <div className="flex items-center justify-between border-b border-gray-200 bg-white px-4 py-2 text-xs font-medium uppercase tracking-wide text-gray-500">
+        <section className="flex min-h-[44rem] min-w-0 flex-col bg-gray-100 lg:min-h-0">
+          <div className="flex flex-col gap-2 border-b border-gray-200 bg-white px-4 py-2 text-xs font-medium uppercase tracking-wide text-gray-500 sm:flex-row sm:items-center sm:justify-between">
             <span>Viewer</span>
             <div className="flex items-center gap-3 normal-case tracking-normal">
               {renderDuration !== null && <span>render {renderDuration}ms</span>}
@@ -177,7 +210,7 @@ export default function Md2Pdf() {
               {error && <span className="text-red-600">{error}</span>}
             </div>
           </div>
-          <div ref={viewerRootRef} className="min-h-0 flex-1" />
+          <div ref={viewerRootRef} className="h-[38rem] flex-none lg:h-auto lg:min-h-0 lg:flex-1" />
         </section>
       </div>
     </main>

--- a/playground/src/routes/jsxPlaygroundExamples.ts
+++ b/playground/src/routes/jsxPlaygroundExamples.ts
@@ -102,7 +102,7 @@ export const jsxPlaygroundPresets: JsxPlaygroundPreset[] = [
             ['PDF template automation', 2, '$1,200'],
             ['QA and playground review', 1, '$350'],
           ]}
-          widths={[55, 15, 30]}
+          columnWeights={[55, 15, 30]}
           rowHeight={9}
           headerHeight={9}
           font="NotoSansJP"
@@ -336,7 +336,7 @@ export const jsxPlaygroundPresets: JsxPlaygroundPreset[] = [
           ['出力', 'Template + inputs'],
           ['プレビュー', 'Viewer / Form'],
         ]}
-        widths={[38, 92]}
+        columnWeights={[38, 92]}
         rowHeight={9}
         headerHeight={9}
         font="NotoSansJP"

--- a/playground/src/routes/jsxPlaygroundExamples.ts
+++ b/playground/src/routes/jsxPlaygroundExamples.ts
@@ -336,7 +336,7 @@ export const jsxPlaygroundPresets: JsxPlaygroundPreset[] = [
           ['出力', 'Template + inputs'],
           ['プレビュー', 'Viewer / Form'],
         ]}
-        columnWeights={[38, 92]}
+        columnWeights={[30, 70]}
         rowHeight={9}
         headerHeight={9}
         font="NotoSansJP"

--- a/playground/src/routes/jsxPlaygroundExamples.ts
+++ b/playground/src/routes/jsxPlaygroundExamples.ts
@@ -201,13 +201,13 @@ export const jsxPlaygroundPresets: JsxPlaygroundPreset[] = [
           </Text>
           <MultiVariableText
             name="message"
-            height={28}
             size={10}
             lineHeight={1.3}
             padding={2}
             borderColor="#cbd5e1"
             borderWidth={0.3}
             text={'Hello {firstName},\\nYour plan is {plan}.\\nStatus: {status}'}
+            overflow="expand"
             values={{ firstName: 'Mina', plan: 'Growth', status: 'Ready for review' }}
           />
         </Stack>

--- a/playground/src/routes/jsxPlaygroundExamples.ts
+++ b/playground/src/routes/jsxPlaygroundExamples.ts
@@ -1,4 +1,16 @@
-export const initialJsx = `return (
+export type JsxPlaygroundPreset = {
+  id: string;
+  label: string;
+  description: string;
+  source: string;
+};
+
+export const jsxPlaygroundPresets: JsxPlaygroundPreset[] = [
+  {
+    id: 'invoice',
+    label: 'Invoice layout',
+    description: 'A two-page invoice with Header, Footer, Absolute, Table, and visual schemas.',
+    source: `return (
   <>
     <Page size="A4" margin={{ x: 16, y: 18 }} font="NotoSansJP">
       <Header>
@@ -18,8 +30,8 @@ export const initialJsx = `return (
           <Text width={80} height={5} size={7} color="#64748b">
             Generated from JSX
           </Text>
-          <Text width={40} height={5} size={7} align="right" color="#64748b">
-            Page 1
+          <Text width={54} height={5} size={7} align="right" color="#64748b">
+            {'Page {currentPage} of {totalPages}'}
           </Text>
         </Row>
       </Footer>
@@ -131,4 +143,211 @@ export const initialJsx = `return (
       </Stack>
     </Page>
   </>
-);`;
+);`,
+  },
+  {
+    id: 'form-fields',
+    label: 'Form fields',
+    description: 'Input-backed Text, MultiVariableText, and Image fields for testing Form preview.',
+    source: `return (
+  <Page size="A4" margin={{ x: 18, y: 18 }} font="NotoSansJP">
+    <Header>
+      <Text height={7} size={8} color="#64748b">
+        Editable fields example
+      </Text>
+    </Header>
+
+    <Footer>
+      <Text height={6} size={7} align="right" color="#64748b">
+        {'Page {currentPage} of {totalPages}'}
+      </Text>
+    </Footer>
+
+    <Stack gap={7}>
+      <Text height={12} size={22} color="#111827">
+        Customer Intake Form
+      </Text>
+      <Text height={8} size={9} color="#6b7280">
+        Switch the preview to Form and edit the fields directly.
+      </Text>
+
+      <Row gap={6}>
+        <Box flex={1} padding={4} borderColor="#d1d5db" borderWidth={0.4}>
+          <Stack gap={2}>
+            <Text height={5} size={7} color="#6b7280">
+              Customer name
+            </Text>
+            <Text name="customerName" height={9} size={11} padding={1.5} borderColor="#cbd5e1" borderWidth={0.3}>
+              Mina Carter
+            </Text>
+          </Stack>
+        </Box>
+        <Box flex={1} padding={4} borderColor="#d1d5db" borderWidth={0.4}>
+          <Stack gap={2}>
+            <Text height={5} size={7} color="#6b7280">
+              Email
+            </Text>
+            <Text name="email" height={9} size={11} padding={1.5} borderColor="#cbd5e1" borderWidth={0.3}>
+              mina@example.com
+            </Text>
+          </Stack>
+        </Box>
+      </Row>
+
+      <Box padding={4} background="#f8fafc" borderColor="#cbd5e1" borderWidth={0.4}>
+        <Stack gap={2}>
+          <Text height={5} size={7} color="#64748b">
+            Message
+          </Text>
+          <MultiVariableText
+            name="message"
+            height={28}
+            size={10}
+            lineHeight={1.3}
+            padding={2}
+            borderColor="#cbd5e1"
+            borderWidth={0.3}
+            text={'Hello {firstName},\\nYour plan is {plan}.\\nStatus: {status}'}
+            values={{ firstName: 'Mina', plan: 'Growth', status: 'Ready for review' }}
+          />
+        </Stack>
+      </Box>
+
+      <Row gap={6}>
+        <Box width={56} padding={4} borderColor="#d1d5db" borderWidth={0.4}>
+          <Stack gap={2}>
+            <Text height={5} size={7} color="#6b7280">
+              Logo upload
+            </Text>
+            <Image name="logo" width={48} height={28} />
+          </Stack>
+        </Box>
+        <Box flex={1} padding={4} background="#ecfeff" borderColor="#06b6d4" borderWidth={0.4}>
+          <Text height={30} size={9} lineHeight={1.35}>
+            This preset keeps the generated template editable. The Form preview writes changed input values back into the playground state, so Generate PDF uses the latest edits.
+          </Text>
+        </Box>
+      </Row>
+    </Stack>
+  </Page>
+);`,
+  },
+  {
+    id: 'report',
+    label: 'Report page',
+    description:
+      'A dashboard-style report with cards, progress bars, list content, and page footer.',
+    source: `return (
+  <Page size="A4" margin={{ x: 16, y: 18 }} font="NotoSansJP">
+    <Footer>
+      <Row height={8} justifyContent="space-between" alignItems="center">
+        <Text width={80} height={5} size={7} color="#64748b">
+          Quarterly product report
+        </Text>
+        <Text width={50} height={5} size={7} align="right" color="#64748b">
+          {'Page {currentPage} of {totalPages}'}
+        </Text>
+      </Row>
+    </Footer>
+
+    <Stack gap={7}>
+      <Row justifyContent="space-between" alignItems="end">
+        <Stack width={110} gap={2}>
+          <Text height={10} size={20} color="#0f172a">
+            Product Health Report
+          </Text>
+          <Text height={7} size={9} color="#64748b">
+            A layout-focused preset for reports and internal briefs.
+          </Text>
+        </Stack>
+        <Text width={42} height={8} size={8} align="right" color="#16a34a">
+          Healthy
+        </Text>
+      </Row>
+
+      <Row gap={5}>
+        {[
+          ['Activation', '74%', '#dcfce7'],
+          ['Retention', '61%', '#e0f2fe'],
+          ['Expansion', '28%', '#fef3c7'],
+        ].map(([label, value, background]) => (
+          <Box flex={1} padding={4} background={background} borderColor="#d1d5db" borderWidth={0.3}>
+            <Stack gap={2}>
+              <Text height={5} size={7} color="#64748b">{label}</Text>
+              <Text height={9} size={18} color="#0f172a">{value}</Text>
+            </Stack>
+          </Box>
+        ))}
+      </Row>
+
+      <Box padding={5} borderColor="#cbd5e1" borderWidth={0.4}>
+        <Stack gap={4}>
+          <Text height={7} size={12} color="#0f172a">
+            Notes
+          </Text>
+          <Text height={28} size={9} lineHeight={1.35} overflow="expand">
+            The JSX authoring layer is useful when a document has repeated visual patterns but still needs to become a normal pdfme template. This example uses boxes, rows, static footer content, and simple visual bars.
+          </Text>
+          <List
+            height={24}
+            size={8}
+            items={[
+              'Use Row and Stack for predictable layout.',
+              'Use Box for padding, borders, and backgrounds.',
+              'Use Static or Footer for repeated page content.',
+            ]}
+          />
+        </Stack>
+      </Box>
+    </Stack>
+  </Page>
+);`,
+  },
+  {
+    id: 'japanese-notice',
+    label: 'Japanese notice',
+    description: 'A Japanese preset that uses NotoSansJP and static footer page numbers.',
+    source: `return (
+  <Page size="A4" margin={{ x: 18, y: 20 }} font="NotoSansJP">
+    <Footer>
+      <Text height={6} size={7} align="right" color="#64748b">
+        {'{currentPage} / {totalPages} ページ'}
+      </Text>
+    </Footer>
+
+    <Stack gap={7}>
+      <Text height={12} size={22} color="#0f172a">
+        お知らせ
+      </Text>
+      <Text height={8} size={9} color="#64748b">
+        JSX から日本語を含むテンプレートを作成する例です。
+      </Text>
+
+      <Box padding={5} background="#f8fafc" borderColor="#cbd5e1" borderWidth={0.4}>
+        <Text height={36} size={10} lineHeight={1.45} overflow="expand">
+          pdfme の JSX authoring は、通常の pdfme Template と inputs を生成するための薄いレイヤーです。日本語を扱う場合は、Viewer や generator の options.font に NotoSansJP などのフォントを登録してください。
+        </Text>
+      </Box>
+
+      <Table
+        head={['項目', '内容']}
+        rows={[
+          ['フォント', 'NotoSansJP'],
+          ['出力', 'Template + inputs'],
+          ['プレビュー', 'Viewer / Form'],
+        ]}
+        widths={[38, 92]}
+        rowHeight={9}
+        headerHeight={9}
+        font="NotoSansJP"
+        fontSize={8}
+        headStyles={{ backgroundColor: '#0f766e', borderColor: '#0f766e', padding: 2 }}
+        bodyStyles={{ borderColor: '#cbd5e1', borderWidth: 0.25, padding: 2 }}
+      />
+    </Stack>
+  </Page>
+);`,
+  },
+];
+
+export const initialJsx = jsxPlaygroundPresets[0]?.source ?? '';

--- a/playground/src/routes/jsxPlaygroundRuntime.ts
+++ b/playground/src/routes/jsxPlaygroundRuntime.ts
@@ -1,4 +1,4 @@
-import type { Font } from '@pdfme/common';
+import { checkTemplate, type Font } from '@pdfme/common';
 import {
   Absolute,
   Box,
@@ -136,5 +136,8 @@ export const evaluateJsxFunctionBody = (source: string): PdfJsxChild => {
   return evaluate(...scopeValues) as PdfJsxChild;
 };
 
-export const renderJsxSource = async (source: string, font?: Font): Promise<RenderResult> =>
-  renderToTemplate(evaluateJsxFunctionBody(source), { font });
+export const renderJsxSource = async (source: string, font?: Font): Promise<RenderResult> => {
+  const result = await renderToTemplate(evaluateJsxFunctionBody(source), { font });
+  checkTemplate(result.template);
+  return result;
+};

--- a/playground/src/routes/md2PdfPresets.ts
+++ b/playground/src/routes/md2PdfPresets.ts
@@ -1,0 +1,132 @@
+export type Md2PdfPreset = {
+  id: string;
+  label: string;
+  description: string;
+  markdown: string;
+};
+
+export const md2PdfPresets: Md2PdfPreset[] = [
+  {
+    id: 'overview',
+    label: 'Overview',
+    description:
+      'Basic GFM blocks, inline formatting, horizontal rule, blockquote, code, and table.',
+    markdown: `# md2pdf playground
+
+Markdown becomes a pdfme Template. Japanese text also works when you choose a CJK-capable font.
+
+## Blocks
+
+- Paragraph
+- **Bold**, *italic*, ~~strike~~, \`inline code\`
+- [pdfme](https://pdfme.com)
+
+---
+
+> Blockquotes use a left rule, background, and padding.
+
+\`\`\`ts
+const result = await md2pdf(markdown);
+const pdf = await generate(result);
+\`\`\`
+
+| Feature | Status |
+| --- | --- |
+| Table grid | Supported |
+| Remote image | Link fallback |
+`,
+  },
+  {
+    id: 'release-notes',
+    label: 'Release notes',
+    description: 'A product-note style document with task list syntax and tables.',
+    markdown: `# Release Notes
+
+This preset is useful for checking how md2pdf handles headings, task lists, tables, and longer paragraphs.
+
+## Highlights
+
+- [x] JSX playground with Monaco editor
+- [x] md2pdf live preview
+- [ ] Remote image fetching
+- [ ] Rich inline content inside table cells
+
+## Changes
+
+| Area | Change | Notes |
+| --- | --- | --- |
+| Playground | Added presets | Selector is intentionally simple |
+| JSX | Viewer and Form preview | Input-backed fields can be edited |
+| Markdown | Partial GFM support | Complex nested blocks are simplified |
+
+## Notes
+
+Longer documents are converted into regular pdfme schemas. Paragraphs use expandable text schemas, while tables and images still need keep-together improvements.
+`,
+  },
+  {
+    id: 'article',
+    label: 'Article',
+    description: 'A longer article-like sample for pagination and text wrapping checks.',
+    markdown: `# Designing PDF templates with structure
+
+When a document grows, absolute coordinates become hard to maintain. A structured authoring layer lets you describe intent first and turn it into pdfme schemas later.
+
+## Why structure helps
+
+1. Repeated patterns can be expressed once.
+2. Rows and stacks make spacing easier to review.
+3. The output still stays compatible with normal pdfme tooling.
+
+> The goal is not to turn pdfme into a browser layout engine. The goal is to make common document authoring tasks less fragile.
+
+## Example checklist
+
+- Start with semantic sections.
+- Use tables for grid data.
+- Use static headers and footers for repeated page content.
+- Keep custom positioning as an escape hatch.
+
+\`\`\`tsx
+return (
+  <Page>
+    <Stack gap={6}>
+      <Text>Structured authoring</Text>
+    </Stack>
+  </Page>
+);
+\`\`\`
+`,
+  },
+  {
+    id: 'japanese-report',
+    label: 'Japanese report',
+    description: 'A Japanese Markdown sample for CJK font and table rendering checks.',
+    markdown: `# 日本語レポート
+
+これは md2pdf で日本語を含む Markdown を PDF に変換するサンプルです。フォントには NotoSansJP を指定しています。
+
+## 概要
+
+- Markdown から pdfme Template を生成します。
+- Viewer でプレビューし、PDF も生成できます。
+- GFM の完全互換ではなく、PDF として扱いやすい表現を優先します。
+
+> 引用ブロックは左線と余白を持つテキストボックスとして表現されます。
+
+| 項目 | 状態 |
+| --- | --- |
+| 日本語テキスト | 対応 |
+| テーブル | 基本対応 |
+| リモート画像 | 現在はリンク fallback |
+
+\`\`\`ts
+const { template, inputs } = await md2pdf(markdown, {
+  style: { fontName: 'NotoSansJP' },
+});
+\`\`\`
+`,
+  },
+];
+
+export const initialMarkdown = md2PdfPresets[0]?.markdown ?? '';

--- a/playground/src/routes/previewSizing.ts
+++ b/playground/src/routes/previewSizing.ts
@@ -1,19 +1,41 @@
 const MIN_VISIBLE_PREVIEW_HEIGHT = 240;
 const COLLAPSED_PREVIEW_RATIO = 0.7;
 
-export const shouldRefreshCollapsedPreview = (container: HTMLElement) => {
-  const rect = container.getBoundingClientRect();
+type PreviewSizingSnapshot = {
+  containerBottom: number;
+  containerTop: number;
+  renderedHeight: number;
+  viewportHeight: number;
+};
+
+export const shouldRefreshCollapsedPreviewSnapshot = ({
+  containerBottom,
+  containerTop,
+  renderedHeight,
+  viewportHeight,
+}: PreviewSizingSnapshot) => {
   const visibleHeight = Math.max(
     0,
-    Math.min(rect.bottom, window.innerHeight) - Math.max(rect.top, 0),
+    Math.min(containerBottom, viewportHeight) - Math.max(containerTop, 0),
   );
-  const renderedHeight =
-    container.querySelector<HTMLElement>('.pdfme-designer-root')?.getBoundingClientRect().height ??
-    0;
 
   return (
     visibleHeight >= MIN_VISIBLE_PREVIEW_HEIGHT &&
     renderedHeight > 0 &&
     renderedHeight < visibleHeight * COLLAPSED_PREVIEW_RATIO
   );
+};
+
+export const shouldRefreshCollapsedPreview = (container: HTMLElement) => {
+  const rect = container.getBoundingClientRect();
+  const renderedRoot = container.firstElementChild;
+  const renderedHeight =
+    renderedRoot instanceof HTMLElement ? renderedRoot.getBoundingClientRect().height : 0;
+
+  return shouldRefreshCollapsedPreviewSnapshot({
+    containerBottom: rect.bottom,
+    containerTop: rect.top,
+    renderedHeight,
+    viewportHeight: window.innerHeight,
+  });
 };

--- a/playground/src/routes/previewSizing.ts
+++ b/playground/src/routes/previewSizing.ts
@@ -1,0 +1,19 @@
+const MIN_VISIBLE_PREVIEW_HEIGHT = 240;
+const COLLAPSED_PREVIEW_RATIO = 0.7;
+
+export const shouldRefreshCollapsedPreview = (container: HTMLElement) => {
+  const rect = container.getBoundingClientRect();
+  const visibleHeight = Math.max(
+    0,
+    Math.min(rect.bottom, window.innerHeight) - Math.max(rect.top, 0),
+  );
+  const renderedHeight =
+    container.querySelector<HTMLElement>('.pdfme-designer-root')?.getBoundingClientRect().height ??
+    0;
+
+  return (
+    visibleHeight >= MIN_VISIBLE_PREVIEW_HEIGHT &&
+    renderedHeight > 0 &&
+    renderedHeight < visibleHeight * COLLAPSED_PREVIEW_RATIO
+  );
+};

--- a/website/docs/converter.md
+++ b/website/docs/converter.md
@@ -76,7 +76,8 @@ import { md2pdf } from '@pdfme/converter/md2pdf';
 const { template, inputs } = await md2pdf('# Hello\n\nVisit [pdfme](https://pdfme.com).');
 ```
 
-You can try it in the [md2pdf playground](https://playground.pdfme.com/md2pdf).
+You can try it in the [md2pdf playground](https://playground.pdfme.com/md2pdf), which includes a few
+sample Markdown presets for quick checks.
 
 `md2pdf` is exposed as a subpath export so regular `@pdfme/converter` imports do not pull Markdown parser dependencies into browser bundles.
 

--- a/website/docs/jsx.md
+++ b/website/docs/jsx.md
@@ -6,7 +6,8 @@
 It is an authoring layer only. The output is a normal pdfme `Template` plus `inputs`, so you can pass
 the result to `generate`, `Designer`, `Form`, or `Viewer` with the usual plugins and fonts.
 
-You can try the browser version in the [JSX playground](https://playground.pdfme.com/jsx).
+You can try the browser version in the [JSX playground](https://playground.pdfme.com/jsx). The
+playground includes sample presets and can switch the preview between `Viewer` and `Form`.
 
 ## Installation
 

--- a/website/docs/jsx.md
+++ b/website/docs/jsx.md
@@ -90,6 +90,11 @@ Use `gap`, `margin`, `alignItems`, `justifyContent`, and `flex` / `flexGrow` for
 If a component has a `name`, it becomes input-backed by default. If it has no `name`, it is rendered as
 read-only content. This mirrors the pdfme template data model.
 
+`Table` uses `columnWeights` for relative column sizing. The values are normalized to pdfme
+`headWidthPercentages`, so `columnWeights={[30, 70]}` means a 30/70 split, not `30mm` / `70mm`.
+Missing or invalid weights default to `1`, so pass one weight per column when the exact ratio
+matters. Earlier beta builds used `widths`; use `columnWeights` going forward.
+
 ## JSX Playground Beta
 
 The playground accepts a function body, not a full module:

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/converter.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/converter.md
@@ -76,7 +76,8 @@ import { md2pdf } from '@pdfme/converter/md2pdf';
 const { template, inputs } = await md2pdf('# Hello\n\nVisit [pdfme](https://pdfme.com).');
 ```
 
-[md2pdf playground](https://playground.pdfme.com/md2pdf) で実際に試せます。
+[md2pdf playground](https://playground.pdfme.com/md2pdf) で実際に試せます。いくつかの Markdown sample
+preset も切り替えられます。
 
 `md2pdf` は subpath export として公開されています。通常の `@pdfme/converter` import では Markdown parser の依存をブラウザ bundle に含めません。
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/converter.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/converter.md
@@ -76,8 +76,8 @@ import { md2pdf } from '@pdfme/converter/md2pdf';
 const { template, inputs } = await md2pdf('# Hello\n\nVisit [pdfme](https://pdfme.com).');
 ```
 
-[md2pdf playground](https://playground.pdfme.com/md2pdf) で実際に試せます。いくつかの Markdown sample
-preset も切り替えられます。
+[md2pdf playground](https://playground.pdfme.com/md2pdf) で実際に試せます。いくつかの Markdown サンプル
+プリセットも切り替えられます。
 
 `md2pdf` は subpath export として公開されています。通常の `@pdfme/converter` import では Markdown parser の依存をブラウザ bundle に含めません。
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/jsx.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/jsx.md
@@ -6,7 +6,8 @@
 出力は通常の pdfme `Template` と `inputs` です。そのため、結果はいつもの `generate`, `Designer`,
 `Form`, `Viewer` に、通常の plugins / fonts と一緒に渡せます。
 
-[JSX playground](https://playground.pdfme.com/jsx) でブラウザ上から試せます。
+[JSX playground](https://playground.pdfme.com/jsx) でブラウザ上から試せます。playground には sample
+preset があり、preview は `Viewer` / `Form` を切り替えられます。
 
 ## インストール
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/jsx.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/jsx.md
@@ -6,8 +6,8 @@
 出力は通常の pdfme `Template` と `inputs` です。そのため、結果はいつもの `generate`, `Designer`,
 `Form`, `Viewer` に、通常の plugins / fonts と一緒に渡せます。
 
-[JSX playground](https://playground.pdfme.com/jsx) でブラウザ上から試せます。playground には sample
-preset があり、preview は `Viewer` / `Form` を切り替えられます。
+[JSX playground](https://playground.pdfme.com/jsx) でブラウザ上から試せます。playground にはサンプル
+プリセットがあり、preview は `Viewer` / `Form` を切り替えられます。
 
 ## インストール
 
@@ -88,6 +88,11 @@ layout API は CSS/Flexbox 互換を目指していません。`gap`, `margin`, 
 
 component に `name` がある場合は input-backed schema になり、`name` がない場合は read-only content として
 描画されます。これは pdfme template のデータモデルに合わせた挙動です。
+
+`Table` の `columnWeights` は相対的な列幅の重みです。値は pdfme の `headWidthPercentages` に正規化されるため、
+`columnWeights={[30, 70]}` は `30mm` / `70mm` ではなく 30/70 の比率を意味します。不足している weight や不正な
+weight は `1` として扱われるため、正確な比率が必要な場合は列数分の weight を指定してください。以前の beta build
+では `widths` を使っていましたが、今後は `columnWeights` を使います。
 
 ## JSX playground beta
 


### PR DESCRIPTION
## Summary
- add sample preset selectors for the JSX and md2pdf playgrounds
- add Viewer/Form preview switching to the JSX playground and keep Form edits in inputs state
- cover playground presets with conversion/render smoke tests
- update English/Japanese docs to mention presets and Form preview

## Validation
- npm --prefix playground run fmt
- npm --prefix playground run lint
- npx tsc -p playground/tsconfig.json --noEmit
- npm --prefix playground run test -- jsxPlaygroundRuntime md2PdfPresets
- npm --prefix playground run build
- browser smoke check for /jsx and /md2pdf preset selectors