### PR TITLE
fix(common): handle same-y dynamic layout groups

### DIFF
--- a/packages/common/__tests__/dynamicTemplate.test.ts
+++ b/packages/common/__tests__/dynamicTemplate.test.ts
@@ -528,4 +528,278 @@ describe('getDynamicTemplate', () => {
       expect(text!.position.y).toBe(60);
     });
   });
+
+  describe('Same Y position scenarios (horizontal layout)', () => {
+    // Two expandable schemas placed side by side at the same baseY must not
+    // affect each other's position when one expands. Schemas below the group
+    // get pushed down by the group's largest expansion.
+
+    const sameYBasePdf = { width: 200, height: 200, padding: [10, 10, 10, 10] };
+
+    test('should not push sibling at same Y down when one schema expands', async () => {
+      const sameYTemplate: Template = {
+        schemas: [
+          [
+            {
+              name: 'a',
+              content: 'a',
+              type: 'a',
+              position: { x: 10, y: 10 },
+              width: 80,
+              height: 10,
+            },
+            {
+              name: 'b',
+              content: 'b',
+              type: 'b',
+              position: { x: 100, y: 10 },
+              width: 80,
+              height: 10,
+            },
+          ],
+        ],
+        basePdf: sameYBasePdf,
+      };
+
+      const dynamicTemplate = await getDynamicTemplate({
+        template: sameYTemplate,
+        input: { a: 'a', b: 'b' },
+        options,
+        _cache: new Map(),
+        getDynamicHeights: async (value: string, args: { schema: Schema }) => {
+          if (args.schema.name === 'a') return [10, 10, 10];
+          return [args.schema.height];
+        },
+      });
+
+      expect(dynamicTemplate.schemas.length).toBe(1);
+      const a = dynamicTemplate.schemas[0].find((s) => s.name === 'a');
+      const b = dynamicTemplate.schemas[0].find((s) => s.name === 'b');
+      expect(a).toBeDefined();
+      expect(b).toBeDefined();
+      expect(a!.position.y).toBe(10);
+      expect(a!.height).toBe(30);
+      // b is at the same Y as a and must remain at its original position
+      expect(b!.position.y).toBe(10);
+      expect(b!.height).toBe(10);
+    });
+
+    test('should push schema below same-Y group by the largest expansion in the group', async () => {
+      const tripleTemplate: Template = {
+        schemas: [
+          [
+            {
+              name: 'a',
+              content: 'a',
+              type: 'a',
+              position: { x: 10, y: 10 },
+              width: 80,
+              height: 10,
+            },
+            {
+              name: 'b',
+              content: 'b',
+              type: 'b',
+              position: { x: 100, y: 10 },
+              width: 80,
+              height: 10,
+            },
+            {
+              name: 'c',
+              content: 'c',
+              type: 'c',
+              position: { x: 10, y: 30 },
+              width: 80,
+              height: 10,
+            },
+          ],
+        ],
+        basePdf: sameYBasePdf,
+      };
+
+      const dynamicTemplate = await getDynamicTemplate({
+        template: tripleTemplate,
+        input: { a: 'a', b: 'b', c: 'c' },
+        options,
+        _cache: new Map(),
+        getDynamicHeights: async (value: string, args: { schema: Schema }) => {
+          if (args.schema.name === 'a') return [10, 10, 10]; // +20
+          return [args.schema.height];
+        },
+      });
+
+      expect(dynamicTemplate.schemas.length).toBe(1);
+      const a = dynamicTemplate.schemas[0].find((s) => s.name === 'a');
+      const b = dynamicTemplate.schemas[0].find((s) => s.name === 'b');
+      const c = dynamicTemplate.schemas[0].find((s) => s.name === 'c');
+      expect(a!.position.y).toBe(10);
+      expect(b!.position.y).toBe(10);
+      // c sits below the group; pushed down by max group expansion (+20)
+      expect(c!.position.y).toBe(50);
+    });
+
+    test('should treat near-Y schemas (overlapping ranges) as one group', async () => {
+      // y=20 and y=21 with height=10 each: ranges [20,30] and [21,31] overlap.
+      // Manual placement drift of 1pt should not split them into separate groups.
+      const driftTemplate: Template = {
+        schemas: [
+          [
+            {
+              name: 'a',
+              content: 'a',
+              type: 'a',
+              position: { x: 10, y: 20 },
+              width: 80,
+              height: 10,
+            },
+            {
+              name: 'b',
+              content: 'b',
+              type: 'b',
+              position: { x: 100, y: 21 },
+              width: 80,
+              height: 10,
+            },
+          ],
+        ],
+        basePdf: sameYBasePdf,
+      };
+
+      const dynamicTemplate = await getDynamicTemplate({
+        template: driftTemplate,
+        input: { a: 'a', b: 'b' },
+        options,
+        _cache: new Map(),
+        getDynamicHeights: async (value: string, args: { schema: Schema }) => {
+          if (args.schema.name === 'a') return [10, 10, 10];
+          return [args.schema.height];
+        },
+      });
+
+      expect(dynamicTemplate.schemas.length).toBe(1);
+      const a = dynamicTemplate.schemas[0].find((s) => s.name === 'a');
+      const b = dynamicTemplate.schemas[0].find((s) => s.name === 'b');
+      // a expanded to height 30 starting at y=20
+      expect(a!.position.y).toBe(20);
+      expect(a!.height).toBe(30);
+      // b is overlapping a's range, so it stays at its original y=21
+      expect(b!.position.y).toBe(21);
+      expect(b!.height).toBe(10);
+    });
+
+    test('should use the larger expansion when both same-Y schemas expand', async () => {
+      const tripleTemplate: Template = {
+        schemas: [
+          [
+            {
+              name: 'a',
+              content: 'a',
+              type: 'a',
+              position: { x: 10, y: 10 },
+              width: 80,
+              height: 10,
+            },
+            {
+              name: 'b',
+              content: 'b',
+              type: 'b',
+              position: { x: 100, y: 10 },
+              width: 80,
+              height: 10,
+            },
+            {
+              name: 'c',
+              content: 'c',
+              type: 'c',
+              position: { x: 10, y: 30 },
+              width: 80,
+              height: 10,
+            },
+          ],
+        ],
+        basePdf: sameYBasePdf,
+      };
+
+      const dynamicTemplate = await getDynamicTemplate({
+        template: tripleTemplate,
+        input: { a: 'a', b: 'b', c: 'c' },
+        options,
+        _cache: new Map(),
+        getDynamicHeights: async (value: string, args: { schema: Schema }) => {
+          if (args.schema.name === 'a') return [10, 10]; // +10
+          if (args.schema.name === 'b') return [10, 10, 10]; // +20
+          return [args.schema.height];
+        },
+      });
+
+      expect(dynamicTemplate.schemas.length).toBe(1);
+      const a = dynamicTemplate.schemas[0].find((s) => s.name === 'a');
+      const b = dynamicTemplate.schemas[0].find((s) => s.name === 'b');
+      const c = dynamicTemplate.schemas[0].find((s) => s.name === 'c');
+      expect(a!.position.y).toBe(10);
+      expect(b!.position.y).toBe(10);
+      // c is pushed down by max(b's +20, a's +10) = +20
+      expect(c!.position.y).toBe(50);
+    });
+
+    test('should push schemas below same-Y group after a sibling spans pages', async () => {
+      const pageSplitTemplate: Template = {
+        schemas: [
+          [
+            {
+              name: 'a',
+              content: 'a',
+              type: 'a',
+              position: { x: 10, y: 10 },
+              width: 80,
+              height: 10,
+            },
+            {
+              name: 'b',
+              content: 'b',
+              type: 'b',
+              position: { x: 100, y: 10 },
+              width: 80,
+              height: 10,
+            },
+            {
+              name: 'c',
+              content: 'c',
+              type: 'c',
+              position: { x: 10, y: 30 },
+              width: 80,
+              height: 10,
+            },
+          ],
+        ],
+        basePdf: sameYBasePdf,
+      };
+
+      const dynamicTemplate = await getDynamicTemplate({
+        template: pageSplitTemplate,
+        input: { a: 'a', b: 'b', c: 'c' },
+        options,
+        _cache: new Map(),
+        getDynamicHeights: async (value: string, args: { schema: Schema }) => {
+          if (args.schema.name === 'a') return [90, 90, 30];
+          return [args.schema.height];
+        },
+      });
+
+      expect(dynamicTemplate.schemas.length).toBe(2);
+      const firstPageA = dynamicTemplate.schemas[0].find((s) => s.name === 'a');
+      const firstPageB = dynamicTemplate.schemas[0].find((s) => s.name === 'b');
+      const secondPageA = dynamicTemplate.schemas[1].find((s) => s.name === 'a');
+      const secondPageC = dynamicTemplate.schemas[1].find((s) => s.name === 'c');
+      expect(firstPageA!.position.y).toBe(10);
+      expect(firstPageA!.height).toBe(180);
+      expect(firstPageB!.position.y).toBe(10);
+      expect(firstPageB!.height).toBe(10);
+      expect(secondPageA!.position.y).toBe(10);
+      expect(secondPageA!.height).toBe(30);
+      // c preserves its original 10pt gap below the same-Y group after a splits.
+      expect(secondPageC!.position.y).toBe(50);
+      expect(secondPageC!.height).toBe(10);
+    });
+  });
 });

--- a/packages/common/src/dynamicTemplate.ts
+++ b/packages/common/src/dynamicTemplate.ts
@@ -224,8 +224,28 @@ function removeTrailingEmptyPages(pages: Schema[][]): void {
 
 /**
  * Process a single template page that has dynamic content.
- * Uses the same layout algorithm as the original implementation,
- * but scoped to a single page's schemas.
+ *
+ * Two schemas are treated as part of the same horizontal group when their
+ * *original* Y ranges (`baseY` to `baseY + height`) overlap. Strict baseY
+ * equality would falsely separate side-by-side schemas placed at e.g. y=20
+ * and y=21 due to manual layout drift. Items in a group share the same
+ * offset; schemas below the group are pushed down by how far the group as
+ * a whole expanded.
+ *
+ * The offset for a group is computed as `cumMaxActualEnd - cumMaxOriginalEnd`
+ * over all already-committed groups. This formulation has two important
+ * properties:
+ * 1. When a single schema spans multiple pages (e.g. a long table that breaks
+ *    across 5 pages), downstream schemas correctly land below the last page,
+ *    because actualEnd reflects the page-break drift.
+ * 2. When an unrelated schema is merely *pushed* onto a later page without
+ *    expanding itself, both its actualEnd and originalEnd increase by similar
+ *    amounts (the page-break drift cancels), so the offset for the *next*
+ *    group does not accumulate the drift twice.
+ *
+ * `items` is pre-sorted by `normalizePageSchemas` (baseY ascending; original
+ * order preserved for ties), so each new item only needs to check whether it
+ * starts before the running `groupYEnd`.
  */
 function processDynamicPage(
   items: LayoutItem[],
@@ -234,10 +254,33 @@ function processDynamicPage(
   paddingTop: number,
 ): Schema[][] {
   const pages: Schema[][] = [];
-  let totalYOffset = 0;
+  let cumMaxActualEnd = 0;
+  let cumMaxOriginalEnd = 0;
+  let groupYEnd = Number.NEGATIVE_INFINITY;
+  let groupMaxActualEnd = Number.NEGATIVE_INFINITY;
+  let groupMaxOriginalEnd = Number.NEGATIVE_INFINITY;
+
+  const commitGroup = () => {
+    if (groupMaxActualEnd === Number.NEGATIVE_INFINITY) return;
+    if (groupMaxActualEnd > cumMaxActualEnd) cumMaxActualEnd = groupMaxActualEnd;
+    if (groupMaxOriginalEnd > cumMaxOriginalEnd) cumMaxOriginalEnd = groupMaxOriginalEnd;
+    groupMaxActualEnd = Number.NEGATIVE_INFINITY;
+    groupMaxOriginalEnd = Number.NEGATIVE_INFINITY;
+  };
 
   for (const item of items) {
-    const currentGlobalStartY = item.baseY + totalYOffset;
+    const itemBaseEnd = item.baseY + item.height;
+    const overlapsCurrentGroup = item.baseY < groupYEnd - EPSILON;
+
+    if (!overlapsCurrentGroup) {
+      commitGroup();
+      groupYEnd = itemBaseEnd;
+    } else if (itemBaseEnd > groupYEnd) {
+      groupYEnd = itemBaseEnd;
+    }
+
+    const groupOffset = Math.max(0, cumMaxActualEnd - cumMaxOriginalEnd);
+    const currentGlobalStartY = item.baseY + groupOffset;
 
     const actualGlobalEndY = placeUnitsOnPages(
       item.schema,
@@ -248,10 +291,10 @@ function processDynamicPage(
       pages,
     );
 
-    // Update offset: difference between actual and original end position
-    const originalGlobalEndY = item.baseY + item.height;
-    totalYOffset = actualGlobalEndY - originalGlobalEndY;
+    if (actualGlobalEndY > groupMaxActualEnd) groupMaxActualEnd = actualGlobalEndY;
+    if (itemBaseEnd > groupMaxOriginalEnd) groupMaxOriginalEnd = itemBaseEnd;
   }
+  commitGroup();
 
   sortPagesByOrder(pages, orderMap);
   removeTrailingEmptyPages(pages);


### PR DESCRIPTION
## Summary
- group horizontally aligned dynamic schemas by overlapping original Y ranges
- use group-level expansion offsets so same-Y siblings do not push each other down
- add coverage for same-Y, near-Y, multiple expansion, and page-spanning sibling cases

## Tests
- npm run test -w packages/common -- dynamicTemplate.test.ts