### PR TITLE
[codex] Fix mobile playground preview refresh

### DIFF
--- a/playground/e2e/previewSizing.test.ts
+++ b/playground/e2e/previewSizing.test.ts
@@ -33,6 +33,15 @@ describe('preview sizing helpers', () => {
 
     expect(
       shouldRefreshCollapsedPreviewSnapshot({
+        containerBottom: 200,
+        containerTop: 0,
+        renderedHeight: 0,
+        viewportHeight: 900,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldRefreshCollapsedPreviewSnapshot({
         containerBottom: 800,
         containerTop: 100,
         renderedHeight: 600,

--- a/playground/e2e/previewSizing.test.ts
+++ b/playground/e2e/previewSizing.test.ts
@@ -10,6 +10,15 @@ describe('preview sizing helpers', () => {
         viewportHeight: 900,
       }),
     ).toBe(true);
+
+    expect(
+      shouldRefreshCollapsedPreviewSnapshot({
+        containerBottom: 800,
+        containerTop: 100,
+        renderedHeight: 0,
+        viewportHeight: 900,
+      }),
+    ).toBe(true);
   });
 
   it('does not refresh when the visible area is too small or the preview is not collapsed', () => {

--- a/playground/src/routes/JsxPlayground.tsx
+++ b/playground/src/routes/JsxPlayground.tsx
@@ -84,6 +84,7 @@ declare function PageBreak(props?: Record<string, unknown>): unknown;
 };
 
 export default function JsxPlayground() {
+  const pageRootRef = useRef<HTMLElement | null>(null);
   const previewRootRef = useRef<HTMLDivElement | null>(null);
   const previewRef = useRef<PreviewInstance | null>(null);
   const inputsRef = useRef<Record<string, string>[]>([{}]);
@@ -287,11 +288,14 @@ export default function JsxPlayground() {
       });
     };
 
+    const scrollContainer = pageRootRef.current;
+    scrollContainer?.addEventListener('scroll', refreshPreviewIfVisible, { passive: true });
     window.addEventListener('scroll', refreshPreviewIfVisible, { passive: true });
     window.addEventListener('resize', refreshPreviewIfVisible);
     const timeoutId = window.setTimeout(refreshPreviewIfVisible, 150);
 
     return () => {
+      scrollContainer?.removeEventListener('scroll', refreshPreviewIfVisible);
       window.removeEventListener('scroll', refreshPreviewIfVisible);
       window.removeEventListener('resize', refreshPreviewIfVisible);
       window.clearTimeout(timeoutId);
@@ -340,7 +344,10 @@ export default function JsxPlayground() {
   };
 
   return (
-    <main className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-x-hidden overflow-y-auto bg-gray-100 lg:overflow-hidden">
+    <main
+      ref={pageRootRef}
+      className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-x-hidden overflow-y-auto bg-gray-100 lg:overflow-hidden"
+    >
       <div className="flex flex-col gap-3 border-b border-gray-200 bg-white px-4 py-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
           <div className="flex items-center gap-3">

--- a/playground/src/routes/JsxPlayground.tsx
+++ b/playground/src/routes/JsxPlayground.tsx
@@ -9,7 +9,7 @@ import { downloadJsonFile, generatePDF, getFontsData } from '../helper';
 import { getPlugins } from '../plugins';
 import { initialJsx, jsxPlaygroundPresets } from './jsxPlaygroundExamples';
 import JsxPlaygroundWorker from './jsxPlaygroundWorker?worker';
-import { shouldRefreshCollapsedPreview } from './previewSizing';
+import { useRefreshCollapsedPreview } from './useRefreshCollapsedPreview';
 
 const JSX_DOCS_URL = 'https://pdfme.com/docs/jsx#jsx-playground-beta';
 const JSX_EDITOR_PATH = 'file:///jsx-playground.tsx';
@@ -269,39 +269,21 @@ export default function JsxPlayground() {
     }
   }, [inputs, previewMode]);
 
-  useEffect(() => {
-    if (!template) return;
+  const refreshCollapsedPreview = useCallback(() => {
+    const preview = previewRef.current;
+    if (!preview) return;
 
-    let frameId: number | null = null;
-    const refreshPreviewIfVisible = () => {
-      if (frameId !== null) return;
+    preview.ui.destroy();
+    previewRef.current = null;
+    setPreviewRefreshKey((key) => key + 1);
+  }, []);
 
-      frameId = window.requestAnimationFrame(() => {
-        frameId = null;
-        const container = previewRootRef.current;
-        const preview = previewRef.current;
-        if (!container || !preview || !shouldRefreshCollapsedPreview(container)) return;
-
-        preview.ui.destroy();
-        previewRef.current = null;
-        setPreviewRefreshKey((key) => key + 1);
-      });
-    };
-
-    const scrollContainer = pageRootRef.current;
-    scrollContainer?.addEventListener('scroll', refreshPreviewIfVisible, { passive: true });
-    window.addEventListener('scroll', refreshPreviewIfVisible, { passive: true });
-    window.addEventListener('resize', refreshPreviewIfVisible);
-    const timeoutId = window.setTimeout(refreshPreviewIfVisible, 150);
-
-    return () => {
-      scrollContainer?.removeEventListener('scroll', refreshPreviewIfVisible);
-      window.removeEventListener('scroll', refreshPreviewIfVisible);
-      window.removeEventListener('resize', refreshPreviewIfVisible);
-      window.clearTimeout(timeoutId);
-      if (frameId !== null) window.cancelAnimationFrame(frameId);
-    };
-  }, [template, previewMode]);
+  useRefreshCollapsedPreview({
+    containerRef: previewRootRef,
+    enabled: template != null,
+    onRefresh: refreshCollapsedPreview,
+    scrollRootRef: pageRootRef,
+  });
 
   useEffect(() => {
     return () => {

--- a/playground/src/routes/Md2Pdf.tsx
+++ b/playground/src/routes/Md2Pdf.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ChangeEvent } from 'react';
+import { useCallback, useEffect, useRef, useState, type ChangeEvent } from 'react';
 import type { Template } from '@pdfme/common';
 import { md2pdf } from '@pdfme/converter/md2pdf';
 import { Viewer } from '@pdfme/ui';
@@ -8,7 +8,7 @@ import { generatePDF, getFontsData } from '../helper';
 import { getPlugins } from '../plugins';
 import CodeEditor from '../components/CodeEditor';
 import { initialMarkdown, md2PdfPresets } from './md2PdfPresets';
-import { shouldRefreshCollapsedPreview } from './previewSizing';
+import { useRefreshCollapsedPreview } from './useRefreshCollapsedPreview';
 
 const MD2PDF_DOCS_URL = 'https://pdfme.com/docs/converter#md2pdf-beta';
 
@@ -82,39 +82,21 @@ export default function Md2Pdf() {
     }
   }, [template, inputs, viewerRefreshKey]);
 
-  useEffect(() => {
-    if (!template) return;
+  const refreshCollapsedViewer = useCallback(() => {
+    const viewer = viewerRef.current;
+    if (!viewer) return;
 
-    let frameId: number | null = null;
-    const refreshViewerIfVisible = () => {
-      if (frameId !== null) return;
+    viewer.destroy();
+    viewerRef.current = null;
+    setViewerRefreshKey((key) => key + 1);
+  }, []);
 
-      frameId = window.requestAnimationFrame(() => {
-        frameId = null;
-        const container = viewerRootRef.current;
-        const viewer = viewerRef.current;
-        if (!container || !viewer || !shouldRefreshCollapsedPreview(container)) return;
-
-        viewer.destroy();
-        viewerRef.current = null;
-        setViewerRefreshKey((key) => key + 1);
-      });
-    };
-
-    const scrollContainer = pageRootRef.current;
-    scrollContainer?.addEventListener('scroll', refreshViewerIfVisible, { passive: true });
-    window.addEventListener('scroll', refreshViewerIfVisible, { passive: true });
-    window.addEventListener('resize', refreshViewerIfVisible);
-    const timeoutId = window.setTimeout(refreshViewerIfVisible, 150);
-
-    return () => {
-      scrollContainer?.removeEventListener('scroll', refreshViewerIfVisible);
-      window.removeEventListener('scroll', refreshViewerIfVisible);
-      window.removeEventListener('resize', refreshViewerIfVisible);
-      window.clearTimeout(timeoutId);
-      if (frameId !== null) window.cancelAnimationFrame(frameId);
-    };
-  }, [template]);
+  useRefreshCollapsedPreview({
+    containerRef: viewerRootRef,
+    enabled: template != null,
+    onRefresh: refreshCollapsedViewer,
+    scrollRootRef: pageRootRef,
+  });
 
   useEffect(() => {
     return () => {

--- a/playground/src/routes/Md2Pdf.tsx
+++ b/playground/src/routes/Md2Pdf.tsx
@@ -13,6 +13,7 @@ import { shouldRefreshCollapsedPreview } from './previewSizing';
 const MD2PDF_DOCS_URL = 'https://pdfme.com/docs/converter#md2pdf-beta';
 
 export default function Md2Pdf() {
+  const pageRootRef = useRef<HTMLElement | null>(null);
   const viewerRootRef = useRef<HTMLDivElement | null>(null);
   const viewerRef = useRef<Viewer | null>(null);
   const [selectedPresetId, setSelectedPresetId] = useState(md2PdfPresets[0]?.id ?? '');
@@ -100,11 +101,14 @@ export default function Md2Pdf() {
       });
     };
 
+    const scrollContainer = pageRootRef.current;
+    scrollContainer?.addEventListener('scroll', refreshViewerIfVisible, { passive: true });
     window.addEventListener('scroll', refreshViewerIfVisible, { passive: true });
     window.addEventListener('resize', refreshViewerIfVisible);
     const timeoutId = window.setTimeout(refreshViewerIfVisible, 150);
 
     return () => {
+      scrollContainer?.removeEventListener('scroll', refreshViewerIfVisible);
       window.removeEventListener('scroll', refreshViewerIfVisible);
       window.removeEventListener('resize', refreshViewerIfVisible);
       window.clearTimeout(timeoutId);
@@ -144,7 +148,10 @@ export default function Md2Pdf() {
   };
 
   return (
-    <main className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-x-hidden overflow-y-auto bg-gray-100 lg:overflow-hidden">
+    <main
+      ref={pageRootRef}
+      className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-x-hidden overflow-y-auto bg-gray-100 lg:overflow-hidden"
+    >
       <div className="flex flex-col gap-3 border-b border-gray-200 bg-white px-4 py-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
           <div className="flex items-center gap-3">

--- a/playground/src/routes/previewSizing.ts
+++ b/playground/src/routes/previewSizing.ts
@@ -21,7 +21,6 @@ export const shouldRefreshCollapsedPreviewSnapshot = ({
 
   return (
     visibleHeight >= MIN_VISIBLE_PREVIEW_HEIGHT &&
-    renderedHeight > 0 &&
     renderedHeight < visibleHeight * COLLAPSED_PREVIEW_RATIO
   );
 };
@@ -29,8 +28,9 @@ export const shouldRefreshCollapsedPreviewSnapshot = ({
 export const shouldRefreshCollapsedPreview = (container: HTMLElement) => {
   const rect = container.getBoundingClientRect();
   const renderedRoot = container.firstElementChild;
-  const renderedHeight =
-    renderedRoot instanceof HTMLElement ? renderedRoot.getBoundingClientRect().height : 0;
+  if (!(renderedRoot instanceof HTMLElement)) return false;
+
+  const renderedHeight = renderedRoot.getBoundingClientRect().height;
 
   return shouldRefreshCollapsedPreviewSnapshot({
     containerBottom: rect.bottom,

--- a/playground/src/routes/useRefreshCollapsedPreview.ts
+++ b/playground/src/routes/useRefreshCollapsedPreview.ts
@@ -1,0 +1,61 @@
+import { useEffect, useRef, type RefObject } from 'react';
+import { shouldRefreshCollapsedPreview } from './previewSizing';
+
+const INITIAL_REFRESH_DELAY_MS = 150;
+const REFRESH_COOLDOWN_MS = 750;
+
+type UseRefreshCollapsedPreviewOptions = {
+  containerRef: RefObject<HTMLElement | null>;
+  enabled: boolean;
+  onRefresh: () => void;
+  scrollRootRef: RefObject<HTMLElement | null>;
+};
+
+export const useRefreshCollapsedPreview = ({
+  containerRef,
+  enabled,
+  onRefresh,
+  scrollRootRef,
+}: UseRefreshCollapsedPreviewOptions) => {
+  const onRefreshRef = useRef(onRefresh);
+  const lastRefreshAtRef = useRef(-Infinity);
+
+  useEffect(() => {
+    onRefreshRef.current = onRefresh;
+  }, [onRefresh]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let frameId: number | null = null;
+    const refreshPreviewIfVisible = () => {
+      if (frameId !== null) return;
+
+      frameId = window.requestAnimationFrame(() => {
+        frameId = null;
+        const container = containerRef.current;
+        if (!container || !shouldRefreshCollapsedPreview(container)) return;
+
+        const now = performance.now();
+        if (now - lastRefreshAtRef.current < REFRESH_COOLDOWN_MS) return;
+
+        lastRefreshAtRef.current = now;
+        onRefreshRef.current();
+      });
+    };
+
+    const scrollContainer = scrollRootRef.current;
+    scrollContainer?.addEventListener('scroll', refreshPreviewIfVisible, { passive: true });
+    window.addEventListener('scroll', refreshPreviewIfVisible, { passive: true });
+    window.addEventListener('resize', refreshPreviewIfVisible);
+    const timeoutId = window.setTimeout(refreshPreviewIfVisible, INITIAL_REFRESH_DELAY_MS);
+
+    return () => {
+      scrollContainer?.removeEventListener('scroll', refreshPreviewIfVisible);
+      window.removeEventListener('scroll', refreshPreviewIfVisible);
+      window.removeEventListener('resize', refreshPreviewIfVisible);
+      window.clearTimeout(timeoutId);
+      if (frameId !== null) window.cancelAnimationFrame(frameId);
+    };
+  }, [containerRef, enabled, scrollRootRef]);
+};


### PR DESCRIPTION
## Summary
- refresh JSX/md2pdf previews from the page scroll container as well as window scroll
- treat zero-height rendered preview roots as collapsed so mobile previews can recover
- throttle collapsed-preview refreshes and share the refresh listener hook across JSX/md2pdf
- add preview sizing coverage for zero-height preview roots and the too-small visible-area boundary

## Validation
- npm --prefix playground run lint
- npm --prefix playground run test -- previewSizing jsxPlaygroundRuntime
- npm run typecheck
- mobile viewport smoke: 15 repeated /jsx loads and scrolls, 0 failures
