### PR TITLE
[codex] Open generated templates in Designer

### DIFF
--- a/playground/src/components/GeneratedTemplateControls.tsx
+++ b/playground/src/components/GeneratedTemplateControls.tsx
@@ -1,0 +1,39 @@
+import { Download, PencilRuler } from 'lucide-react';
+
+type GeneratedTemplateControlsProps = {
+  disabled?: boolean;
+  onDownloadTemplate: () => void;
+  onOpenDesigner: () => void;
+};
+
+const buttonClassName =
+  'inline-flex min-w-0 items-center justify-center gap-1 whitespace-nowrap rounded border border-gray-300 px-2 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 sm:px-3';
+
+export default function GeneratedTemplateControls({
+  disabled = false,
+  onDownloadTemplate,
+  onOpenDesigner,
+}: GeneratedTemplateControlsProps) {
+  return (
+    <>
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={onDownloadTemplate}
+        className={buttonClassName}
+      >
+        <Download className="size-4" />
+        Template JSON
+      </button>
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={onOpenDesigner}
+        className={buttonClassName}
+      >
+        <PencilRuler className="size-4" />
+        Open Designer
+      </button>
+    </>
+  );
+}

--- a/playground/src/routes/JsxPlayground.tsx
+++ b/playground/src/routes/JsxPlayground.tsx
@@ -2,13 +2,15 @@ import { useCallback, useEffect, useRef, useState, type ChangeEvent } from 'reac
 import type { Template } from '@pdfme/common';
 import type { RenderResult } from '@pdfme/jsx';
 import { Form, Viewer } from '@pdfme/ui';
-import { Download, ExternalLink } from 'lucide-react';
+import { ExternalLink } from 'lucide-react';
 import { toast } from 'react-toastify';
 import CodeEditor from '../components/CodeEditor';
-import { downloadJsonFile, generatePDF, getFontsData } from '../helper';
+import GeneratedTemplateControls from '../components/GeneratedTemplateControls';
+import { generatePDF, getFontsData } from '../helper';
 import { getPlugins } from '../plugins';
 import { initialJsx, jsxPlaygroundPresets } from './jsxPlaygroundExamples';
 import JsxPlaygroundWorker from './jsxPlaygroundWorker?worker';
+import { useGeneratedTemplateActions } from './useGeneratedTemplateActions';
 import { useRefreshCollapsedPreview } from './useRefreshCollapsedPreview';
 
 const JSX_DOCS_URL = 'https://pdfme.com/docs/jsx#jsx-playground-beta';
@@ -106,6 +108,10 @@ export default function JsxPlayground() {
   const selectedPreset =
     jsxPlaygroundPresets.find((preset) => preset.id === selectedPresetId) ??
     jsxPlaygroundPresets[0];
+  const { downloadTemplate, openDesigner } = useGeneratedTemplateActions({
+    template,
+    templateFileName: 'jsx-template',
+  });
 
   const terminateRenderWorker = useCallback(() => {
     renderWorkerRef.current?.terminate();
@@ -313,11 +319,6 @@ export default function JsxPlayground() {
     }
   };
 
-  const onDownloadTemplate = () => {
-    if (!template) return;
-    downloadJsonFile(template, 'jsx-template');
-  };
-
   const onChangePreset = (event: ChangeEvent<HTMLSelectElement>) => {
     const preset = jsxPlaygroundPresets.find((item) => item.id === event.target.value);
     if (!preset) return;
@@ -365,15 +366,11 @@ export default function JsxPlayground() {
               </option>
             ))}
           </select>
-          <button
-            type="button"
+          <GeneratedTemplateControls
             disabled={!template || Boolean(error)}
-            onClick={onDownloadTemplate}
-            className="inline-flex min-w-0 items-center justify-center gap-1 whitespace-nowrap rounded border border-gray-300 px-2 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 sm:px-3"
-          >
-            <Download className="size-4" />
-            Template JSON
-          </button>
+            onDownloadTemplate={downloadTemplate}
+            onOpenDesigner={openDesigner}
+          />
           <button
             type="button"
             disabled={!template || Boolean(error) || isGeneratingPdf}

--- a/playground/src/routes/Md2Pdf.tsx
+++ b/playground/src/routes/Md2Pdf.tsx
@@ -7,7 +7,9 @@ import { toast } from 'react-toastify';
 import { generatePDF, getFontsData } from '../helper';
 import { getPlugins } from '../plugins';
 import CodeEditor from '../components/CodeEditor';
+import GeneratedTemplateControls from '../components/GeneratedTemplateControls';
 import { initialMarkdown, md2PdfPresets } from './md2PdfPresets';
+import { useGeneratedTemplateActions } from './useGeneratedTemplateActions';
 import { useRefreshCollapsedPreview } from './useRefreshCollapsedPreview';
 
 const MD2PDF_DOCS_URL = 'https://pdfme.com/docs/converter#md2pdf-beta';
@@ -27,6 +29,10 @@ export default function Md2Pdf() {
   const [viewerRefreshKey, setViewerRefreshKey] = useState(0);
   const selectedPreset =
     md2PdfPresets.find((preset) => preset.id === selectedPresetId) ?? md2PdfPresets[0];
+  const { downloadTemplate, openDesigner } = useGeneratedTemplateActions({
+    template,
+    templateFileName: 'md2pdf-template',
+  });
 
   useEffect(() => {
     let cancelled = false;
@@ -167,6 +173,11 @@ export default function Md2Pdf() {
               </option>
             ))}
           </select>
+          <GeneratedTemplateControls
+            disabled={!template || Boolean(error)}
+            onDownloadTemplate={downloadTemplate}
+            onOpenDesigner={openDesigner}
+          />
           <button
             type="button"
             disabled={!template || Boolean(error) || isGeneratingPdf}

--- a/playground/src/routes/useGeneratedTemplateActions.ts
+++ b/playground/src/routes/useGeneratedTemplateActions.ts
@@ -1,0 +1,53 @@
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { checkTemplate, type Template } from '@pdfme/common';
+import { toast } from 'react-toastify';
+import { downloadJsonFile } from '../helper';
+
+type UseGeneratedTemplateActionsOptions = {
+  template: Template | null;
+  templateFileName: string;
+};
+
+const getErrorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : String(error);
+
+export const useGeneratedTemplateActions = ({
+  template,
+  templateFileName,
+}: UseGeneratedTemplateActionsOptions) => {
+  const navigate = useNavigate();
+
+  const downloadTemplate = useCallback(() => {
+    if (!template) return;
+    downloadJsonFile(template, templateFileName);
+  }, [template, templateFileName]);
+
+  const openDesigner = useCallback(() => {
+    if (!template) return;
+
+    try {
+      checkTemplate(template);
+      const serializedTemplate = JSON.stringify(template);
+      const savedTemplate = localStorage.getItem('template');
+      if (
+        savedTemplate &&
+        savedTemplate !== serializedTemplate &&
+        !window.confirm(
+          'Opening Designer will replace the template saved in local storage. Continue?',
+        )
+      ) {
+        return;
+      }
+
+      localStorage.setItem('template', serializedTemplate);
+      localStorage.removeItem('inputs');
+      toast.success('Saved generated template — opening Designer');
+      navigate('/designer');
+    } catch (error) {
+      toast.error(getErrorMessage(error));
+    }
+  }, [navigate, template]);
+
+  return { downloadTemplate, openDesigner };
+};


### PR DESCRIPTION
## Summary

- Add shared generated-template actions for playground pages.
- Add `Template JSON` and `Open Designer` actions to the md2pdf playground.
- Keep the JSX playground on the same shared actions.
- Treat JSX / Markdown source as the initial generation seed while the generated template becomes the editable source of truth in Designer.
- Save only the generated template for Designer handoff, clear stale saved inputs, and confirm before replacing an existing saved Designer template.

## Validation

- `npm run typecheck`
- `npm --prefix playground run test`
- `npm --prefix playground run lint`
- Manual Puppeteer smoke test: `/jsx` -> `Open Designer` -> confirm replace -> `/designer`, verifying the generated template is saved, stale inputs are cleared, and Designer renders.
- Manual Puppeteer smoke test: `/md2pdf` -> `Open Designer` -> confirm replace -> `/designer`, verifying the generated template is saved, stale inputs are cleared, and Designer renders.