### PR TITLE
[codex] Preserve blank pages in dynamic templates

### DIFF
--- a/packages/common/__tests__/dynamicTemplate.test.ts
+++ b/packages/common/__tests__/dynamicTemplate.test.ts
@@ -222,6 +222,24 @@ describe('getDynamicTemplate', () => {
   });
 
   describe('Edge cases', () => {
+    test('should preserve explicit blank pages', async () => {
+      const blankTemplate: Template = {
+        schemas: [[]],
+        basePdf: { width: 100, height: 100, padding: [padding, padding, padding, padding] },
+      };
+      const getDynamicHeights = vi.fn();
+
+      const dynamicTemplate = await getDynamicTemplate({
+        ...getDynamicTemplateArg,
+        template: blankTemplate,
+        getDynamicHeights,
+      });
+
+      expect(dynamicTemplate).toBe(blankTemplate);
+      expect(dynamicTemplate.schemas).toEqual([[]]);
+      expect(getDynamicHeights).not.toHaveBeenCalled();
+    });
+
     test('should handle empty increase heights', async () => {
       const increaseHeights: number[] = [];
       const dynamicTemplate = await getDynamicTemplate(

--- a/packages/common/src/dynamicTemplate.ts
+++ b/packages/common/src/dynamicTemplate.ts
@@ -298,6 +298,11 @@ export const getDynamicTemplate = async (
   for (let pageIndex = 0; pageIndex < template.schemas.length; pageIndex++) {
     const pageSchemas = template.schemas[pageIndex];
 
+    if (pageSchemas.length === 0) {
+      resultPages.push([]);
+      continue;
+    }
+
     // Normalize this page's schemas
     const { items, orderMap } = normalizePageSchemas(pageSchemas, paddingTop);
 
@@ -325,8 +330,6 @@ export const getDynamicTemplate = async (
     const processedPages = processDynamicPage(items, orderMap, contentHeight, paddingTop);
     resultPages.push(...processedPages);
   }
-
-  removeTrailingEmptyPages(resultPages);
 
   // Check if anything changed - return original template if not
   if (resultPages.length === template.schemas.length) {


### PR DESCRIPTION
## Summary

- Preserve explicit blank pages when `getDynamicTemplate` processes blank PDFs.
- Avoid running dynamic height callbacks for pages that have no schemas.
- Add a regression test for `schemas: [[]]`, matching templates such as A4 Blank.

## Why

`Form` and `Viewer` always pass templates through dynamic layout. For templates whose only page has no schemas, the dynamic layout pass returned `schemas: []`, so the preview preprocessor also produced zero backgrounds and no paper was rendered.

## Validation

- `npm run test -w packages/common -- dynamicTemplate.test.ts`
- `npm run typecheck`
- Manual Puppeteer smoke test: load A4 Blank into `/form-viewer` and verify a blank paper is rendered.