### PR TITLE
ci(test): split pdfme-test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
-  pdfme-test:
+  pdfme-core:
+    name: pdfme-test / packages
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,9 +27,58 @@ jobs:
       - run: npm run typecheck
       - run: ./node_modules/.bin/vp run --filter '@pdfme/*' lint
       - run: npm run build
-      - run: npm run test
+      - run: npm run test:packages
         env:
           CI: true
+
+  pdfme-cli:
+    name: pdfme-test / cli (${{ matrix.suite }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - suite: validate
+            test_files: __tests__/validate.test.ts
+          - suite: generate
+            test_files: __tests__/generate.test.ts
+          - suite: doctor
+            test_files: __tests__/doctor.test.ts
+          - suite: examples-integration
+            test_files: __tests__/examples.integration.test.ts
+          - suite: rest
+            test_files: __tests__ --exclude __tests__/validate.test.ts --exclude __tests__/generate.test.ts --exclude __tests__/doctor.test.ts --exclude __tests__/examples.integration.test.ts
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            playground/package-lock.json
+      - run: npm ci
+      - run: npm run build:cli
+      - run: npm run test:cli -- ${{ matrix.test_files }}
+        env:
+          CI: true
+
+  pdfme-test:
+    name: pdfme-test
+    runs-on: ubuntu-latest
+    needs:
+      - pdfme-core
+      - pdfme-cli
+    if: always()
+    steps:
+      - name: Check pdfme test suites
+        run: |
+          if [ "${{ needs.pdfme-core.result }}" != "success" ] || [ "${{ needs.pdfme-cli.result }}" != "success" ]; then
+            echo "pdfme-core: ${{ needs.pdfme-core.result }}"
+            echo "pdfme-cli: ${{ needs.pdfme-cli.result }}"
+            exit 1
+          fi
 
   playground-test:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "link-workspaces": "./scripts/link-workspaces.sh",
     "clean": "vp run --filter '@pdfme/*' clean",
     "build": "npm run clean && npm run build -w packages/pdf-lib && npm run build -w packages/common && npm run build -w packages/converter && npm run build -w packages/schemas && npm run build -w packages/jsx && ./scripts/build-workspaces-in-parallel.sh packages/generator packages/ui packages/manipulator && npm run build -w packages/cli",
+    "build:cli": "npm run build -w packages/pdf-lib && npm run build -w packages/common && npm run build -w packages/converter && npm run build -w packages/schemas && npm run build -w packages/generator && npm run build -w packages/cli",
     "check": "npm run fmt:check && npm run lint && npm run typecheck && npm run test && npm --prefix playground run test",
     "fmt": "vp run --filter '@pdfme/*' fmt && npm --prefix playground run fmt && npm run fmt:meta",
     "fmt:check": "vp fmt -c .oxfmtrc.json packages/cli/src packages/common/src packages/converter/src packages/generator/src packages/jsx/src packages/manipulator/src packages/pdf-lib/src packages/schemas/src packages/ui/src playground/src playground/e2e playground/vite.config.ts playground/vitest.setup.ts playground/postcss.config.js playground/tailwind.config.js package.json packages/cli/package.json packages/common/package.json packages/converter/package.json packages/generator/package.json packages/jsx/package.json packages/manipulator/package.json packages/pdf-lib/package.json packages/schemas/package.json packages/ui/package.json playground/package.json .oxlintrc.json .oxfmtrc.json playground/.oxlintrc.json vite.config.mts --check",
@@ -43,6 +44,8 @@
     "ci": "npm run check && npm run build && npm --prefix playground run build",
     "typecheck": "node packages/common/set-version.js && tsc -b",
     "test": "vp run --filter '@pdfme/*' test",
+    "test:packages": "vp run --filter '@pdfme/*' --filter '!@pdfme/cli' test",
+    "test:cli": "npm run test:run -w packages/cli --",
     "lint": "vp run --filter '@pdfme/*' lint && npm --prefix playground run lint",
     "lint:fix": "vp lint -c .oxlintrc.json packages/cli/src packages/common/src packages/converter/src packages/generator/src packages/jsx/src packages/manipulator/src packages/pdf-lib/src packages/schemas/src packages/ui/src --fix && npm --prefix playground run lint -- --fix"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,7 +45,8 @@
     "clean": "rimraf dist",
     "lint": "vp lint -c ../../.oxlintrc.json src",
     "fmt": "vp fmt -c ../../.oxfmtrc.json src --write",
-    "test": "npm run build && vitest run --config ../../vitest.config.ts"
+    "test": "npm run build && npm run test:run",
+    "test:run": "vitest run --config ../../vitest.config.ts"
   },
   "dependencies": {
     "@napi-rs/canvas": "^0.1.100",


### PR DESCRIPTION
## Summary
- split the pdfme-test workflow into package checks and CLI test matrix jobs
- add CLI-specific build/test scripts so CI can avoid rebuilding the CLI inside each test run
- keep a final pdfme-test aggregator job for branch protection compatibility

## Verification
- npm run build
- npm run test:packages
- npm run clean && npm run build:cli
- npm run test:cli -- __tests__/version.test.ts
- npm run test:cli -- __tests__/utils.test.ts __tests__/version.test.ts
- npm run fmt:check -- package.json packages/cli/package.json .github/workflows/test.yml
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/test.yml")'
- git diff --check