### PR TITLE
fix(common): wrap structuredClone to avoid Illegal invocation under farmfe/Vite (#1120)

### DIFF
--- a/packages/common/src/helper.ts
+++ b/packages/common/src/helper.ts
@@ -30,10 +30,6 @@ import {
   DEFAULT_FONT_VALUE,
 } from './constants.js';
 
-// Wrap rather than alias so the call site preserves `this === window`.
-// In some bundler setups (e.g. farmfe/Vite under #1120) assigning the
-// global `structuredClone` to a free variable strips the binding and
-// invoking it raises `TypeError: Illegal invocation`.
 export const cloneDeep = <T>(value: T): T => structuredClone(value);
 
 const uniq = <T>(array: Array<T>) => Array.from(new Set(array));

--- a/packages/common/src/helper.ts
+++ b/packages/common/src/helper.ts
@@ -30,7 +30,11 @@ import {
   DEFAULT_FONT_VALUE,
 } from './constants.js';
 
-export const cloneDeep = structuredClone;
+// Wrap rather than alias so the call site preserves `this === window`.
+// In some bundler setups (e.g. farmfe/Vite under #1120) assigning the
+// global `structuredClone` to a free variable strips the binding and
+// invoking it raises `TypeError: Illegal invocation`.
+export const cloneDeep = <T>(value: T): T => structuredClone(value);
 
 const uniq = <T>(array: Array<T>) => Array.from(new Set(array));
 


### PR DESCRIPTION
Closes #1120.

`packages/common/src/helper.ts` exported `cloneDeep = structuredClone`. Under some bundler setups (the reporter saw it with farmfe; the same shape is documented for some Vite configs, https://stackoverflow.com/a/77772899) the alias loses its `this === window` binding and invoking it raises `TypeError: Illegal invocation`, breaking `createSingleTable` and any other call site that goes through `cloneDeep`.

Wraps `structuredClone` in an arrow so the call site preserves the global binding:

```ts
export const cloneDeep = <T>(value: T): T => structuredClone(value);
```

Type signature is the same (input `T`, output `T`), so no consumer needs to change.