### PR TITLE
fix(generator): render each page's schemas in their own array order

### DIFF
--- a/packages/generator/__tests__/render-order.test.ts
+++ b/packages/generator/__tests__/render-order.test.ts
@@ -1,0 +1,114 @@
+import generate from '../src/generate.js';
+import { Template, BLANK_A4_PDF, Schema } from '@pdfme/common';
+import { PDFDocument, PDFName } from '@pdfme/pdf-lib';
+import { image } from '@pdfme/schemas';
+
+const plugins = { image };
+
+// PNGs at distinct widths so the embedded XObject's IHDR-reported
+// width × height fingerprints which schema rendered it. Widths chosen to
+// be far apart so the data URLs differ in length and in their last-16
+// bytes — the image plugin caches PDFImage by
+// `${type}:${value.length}:${value.slice(0,16)}:${value.slice(-16)}`,
+// which would collide on near-identical small PNGs.
+const PNG_10x1 =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAABCAIAAABol6gpAAAAKElEQVR4nGPgEpHTMLJxC4hKyato6pm2YNWWfScu3Xn24RcLn4SSDgCy3w0rOw2EswAAAABJRU5ErkJggg==';
+const PNG_50x1 =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAABCAIAAAATs2rlAAAAkklEQVR4nGMwSpl24pdO3IRDX9Qiuva8Uwhq2fZCyqduwyMRt4pVd/gcipZc47DKmXeBySRtxqk/egmTjnzTiOrZ90EppG3HKxm/hk1PxDyq1twTcCpZdoPLJm/BJRazjFln/hkkTTn2Qyum78AnlbCOXW/kApq2PJPwqln3QMilbMUtHruCRVfYLLLmnGPAbj8ANjFK63cxzToAAAAASUVORK5CYII=';
+const PNG_100x1 =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAAABCAIAAACnuZzqAAAAT0lEQVR4nGNIOaEz4UvEHoWWFz4bRCruOCzhyLlgMuNPwhGNng8hO2QannisESi5YbOAJeOMwZQfMQdUOt4EbJGoeeCygqfgisUchpGkHwBM9pO5H56lWgAAAABJRU5ErkJggg==';
+const PNG_500x1 =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAfQAAAABCAIAAACnnMvDAAAAWklEQVR4nGP48uLOhSM71iyY0lFTkBLh42CiISPA8uPNgysn9mxYMqOnoSQjJsDFQkdBhOPPhyc3zhzYsmLOhJaKnIQQDxsDFQkehlH9o/pH9Y/qH9U/+PQDAPjv5JcUZMYGAAAAAElFTkSuQmCC';
+
+const img = (name: string, content: string, x: number, y: number): Schema => ({
+  name,
+  type: 'image',
+  content,
+  position: { x, y },
+  width: 20,
+  height: 20,
+  readOnly: true, // use schema.content directly, not input[name]
+});
+
+const xObjectImageDimsPerPage = async (pdfBytes: Uint8Array): Promise<string[][]> => {
+  const pdfDoc = await PDFDocument.load(pdfBytes);
+  const pages = pdfDoc.getPages();
+  return pages.map((page) => {
+    const resources = page.node.Resources();
+    const xobj = resources?.lookup(PDFName.of('XObject')) as
+      | { entries?: () => Iterable<[{ encodedName: string }, unknown]> }
+      | undefined;
+    const dims: string[] = [];
+    for (const [, ref] of xobj?.entries?.() ?? []) {
+      const obj = pdfDoc.context.lookup(ref) as
+        | { dict?: { get: (n: ReturnType<typeof PDFName.of>) => unknown } }
+        | undefined;
+      const subtype = obj?.dict?.get?.(PDFName.of('Subtype'));
+      if (subtype && String(subtype) === '/Image') {
+        const w = obj!.dict!.get(PDFName.of('Width'));
+        const h = obj!.dict!.get(PDFName.of('Height'));
+        dims.push(`${String(w)}x${String(h)}`);
+      }
+    }
+    return dims;
+  });
+};
+
+// These tests cover the per-page schema render-order contract in
+// `packages/generator/src/generate.ts`: each page renders its schemas
+// in that page's own array order, regardless of name overlap with
+// other pages. Pre-fix behavior is documented in the sibling
+// "test/per-page-render-order" demo branch as a `describe.skip`.
+//
+// Two regressions guarded by these tests:
+//
+//   1. Z-order on a page must follow that page's own schema array
+//      order — not the order in which names first appear across all
+//      pages. A background rectangle declared *after* an image on
+//      page 2 must draw *after* (i.e. on top of) the image, even when
+//      the same names also appear on page 1 in the opposite order.
+//
+//   2. Multiple schemas with the same name on the SAME page must each
+//      be rendered, not deduplicated to the first match.
+describe('per-page schema render order', () => {
+  test("renders schemas on each page in that page's own array order, not the global name order", async () => {
+    // Names "alpha" and "beta" appear on both pages, in opposite per-page
+    // order. Page 1: alpha then beta. Page 2: beta then alpha.
+    // Each schema carries a uniquely-sized image so render order can be
+    // read off the resulting XObject embedding order.
+    const template: Template = {
+      basePdf: BLANK_A4_PDF,
+      schemas: [
+        [img('alpha', PNG_10x1, 0, 0), img('beta', PNG_50x1, 30, 0)],
+        [img('beta', PNG_100x1, 0, 0), img('alpha', PNG_500x1, 30, 0)],
+      ],
+    };
+
+    const pdf = await generate({ template, inputs: [{}], plugins });
+    const dimsPerPage = await xObjectImageDimsPerPage(pdf);
+
+    expect(dimsPerPage.length).toBe(2);
+    // Page 1 array order is [alpha=10x1, beta=50x1].
+    expect(dimsPerPage[0]).toEqual(['10x1', '50x1']);
+    // Page 2 array order is [beta=100x1, alpha=500x1]. Bug: schemaNames
+    // Set = ["alpha", "beta"] from page-1, so page-2 renders alpha
+    // (500x1) FIRST and beta (100x1) SECOND — flipped from intent.
+    expect(dimsPerPage[1]).toEqual(['100x1', '500x1']);
+  });
+
+  test('renders multiple same-named schemas on the same page', async () => {
+    // Two image schemas on one page sharing a name. Bug: `.find()` returns
+    // the first match in the global name iteration → second image silently
+    // dropped at render.
+    const template: Template = {
+      basePdf: BLANK_A4_PDF,
+      schemas: [[img('twin', PNG_10x1, 0, 0), img('twin', PNG_50x1, 30, 0)]],
+    };
+
+    const pdf = await generate({ template, inputs: [{}], plugins });
+    const dimsPerPage = await xObjectImageDimsPerPage(pdf);
+
+    expect(dimsPerPage.length).toBe(1);
+    expect(dimsPerPage[0]).toEqual(['10x1', '50x1']);
+  });
+});

--- a/packages/generator/src/generate.ts
+++ b/packages/generator/src/generate.ts
@@ -60,16 +60,6 @@ const generate = async (props: GenerateProps): Promise<Uint8Array<ArrayBuffer>> 
     });
 
     const schemas = dynamicTemplate.schemas;
-    // Create a type-safe array of schema names without using Set spread which requires downlevelIteration
-    const schemaNameSet = new Set<string>();
-    schemas.forEach((page: Schema[]) => {
-      page.forEach((schema: Schema) => {
-        if (schema.name) {
-          schemaNameSet.add(schema.name);
-        }
-      });
-    });
-    const schemaNames = Array.from(schemaNameSet);
 
     for (let j = 0; j < basePages.length; j += 1) {
       const basePage = basePages[j];
@@ -117,11 +107,19 @@ const generate = async (props: GenerateProps): Promise<Uint8Array<ArrayBuffer>> 
         }
       }
 
-      for (let l = 0; l < schemaNames.length; l += 1) {
-        const name = schemaNames[l];
-        const schemaPage = schemas[j] || [];
-        const schema = schemaPage.find((s: Schema) => s.name == name);
-        if (!schema) {
+      // Iterate this page's schemas in their own array order. The previous
+      // implementation looped over a globally-deduplicated `schemaNames` Set
+      // and used `schemaPage.find(s => s.name == name)`, which (a) imposed
+      // page-1's name order on every later page (corrupting z-order when the
+      // same name appeared on multiple pages) and (b) silently dropped all
+      // but the first within-page same-named schema. pdfme.generate's input
+      // model already collapses by name (Set), so sharing a name across or
+      // within pages is the documented way to bind one input row to many
+      // visible fields — render order must follow each page's own schemas.
+      const schemaPage = schemas[j] || [];
+      for (let l = 0; l < schemaPage.length; l += 1) {
+        const schema = schemaPage[l];
+        if (!schema.name) {
           continue;
         }
 
@@ -135,7 +133,7 @@ const generate = async (props: GenerateProps): Promise<Uint8Array<ArrayBuffer>> 
               variables: { ...input, totalPages: basePages.length, currentPage: j + 1 },
               schemas: schemas, // Use the properly typed schemas variable
             })
-          : ((input[name] || '') as string);
+          : ((input[schema.name] || '') as string);
 
         schema.position = {
           x: schema.position.x + boundingBoxLeft,


### PR DESCRIPTION
## Summary

`generate` iterates each page through a globally-deduplicated schema-name array (`Set` across all pages) then resolves each name on the current page with `schemaPage.find(s => s.name == name)`. Two consequences:

1. **Z-order on a page no longer matches that page's own schema array order** if the same name appears on another page first. A background rectangle declared *after* an image on page 2 still draws *before* the image because the `Set` put the image at page-1's earlier index — flipping the intended z-order. Real-world incidence: an image field repeated on both faces of a postcard with the same field name vanishes on the back face beneath that face's solid-fill background rectangle.

2. **Multiple schemas with the same name on the same page silently drop all but the first** because `.find()` returns one match.

The fix iterates each page's schemas array directly. Render order = the page's own ordering. Names continue to flow through `input[name]` for non-readOnly schemas (`pdfme.generate` already collapses by name on the input side via `Set` — that contract is unchanged, only the per-page render loop is corrected).

The companion reproduction PR is #1509. This PR contains the same test code with the suite enabled (only explanatory comments, the suite title, and `describe.skip` differ). Fix review and regression coverage are tracked here; the standalone skipped-test PR can be closed without losing coverage. This PR remains open for conflict resolution and validation against current main.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run fmt` passes
- [x] `npx vitest run __tests__/render-order.test.ts` — 2/2 pass post-fix
- [x] Same tests fail on `main` without the fix (verified by running them on the companion demo branch with `describe.skip` removed)
- [x] No regressions in the rest of the generator suite (pre-existing snapshot failures unaffected — they reproduce on `main` independently)
- [x] Tests use synthetic 4-color tiny PNGs at distinct widths (10×1, 50×1, 100×1, 500×1); no real-world templates or proprietary data