### PR TITLE
[codex] Fix MVT empty variable validation

### DIFF
--- a/packages/schemas/__tests__/multiVariableText.test.ts
+++ b/packages/schemas/__tests__/multiVariableText.test.ts
@@ -54,6 +54,13 @@ describe('substituteVariables', () => {
     expect(result).toBe('Hello, !');
   });
 
+  it('should substitute variables with empty string values', () => {
+    const text = 'Hello, {name}!';
+    const variables = { name: '' };
+    const result = substituteVariables(text, variables);
+    expect(result).toBe('Hello, !');
+  });
+
   it('should handle variables as a JSON string', () => {
     const text = 'Hello, {name}!';
     const variables = '{"name": "World"}';
@@ -115,6 +122,11 @@ describe('validateVariables', () => {
     expect(validateVariables(value, schema)).toBe(true);
   });
 
+  it('should return true for empty string values with all required variables present', () => {
+    const value = JSON.stringify({ var1: '', var2: '' });
+    expect(validateVariables(value, schema)).toBe(true);
+  });
+
   it('should throw an error for missing required variables', () => {
     const value = JSON.stringify({ var1: 'value1' });
     expect(() => validateVariables(value, schema)).toThrow(
@@ -131,6 +143,17 @@ describe('validateVariables', () => {
     };
     const value = JSON.stringify({ var1: 'value1' });
     expect(validateVariables(value, nonRequiredSchema)).toBe(false);
+  });
+
+  it('should return true for empty string values with all non-required variables present', () => {
+    // @ts-ignore
+    const nonRequiredSchema: MultiVariableTextSchema = {
+      name: 'test',
+      variables: ['var1', 'var2'],
+      required: false,
+    };
+    const value = JSON.stringify({ var1: '', var2: '' });
+    expect(validateVariables(value, nonRequiredSchema)).toBe(true);
   });
 
   it('should throw an error for invalid JSON input', () => {

--- a/packages/schemas/__tests__/multiVariableText.test.ts
+++ b/packages/schemas/__tests__/multiVariableText.test.ts
@@ -134,6 +134,13 @@ describe('validateVariables', () => {
     );
   });
 
+  it('should throw an error for null required variable values', () => {
+    const value = JSON.stringify({ var1: null, var2: '' });
+    expect(() => validateVariables(value, schema)).toThrow(
+      '[@pdfme/generator] variable var1 is missing for field test'
+    );
+  });
+
   it('should return false for missing non-required variables', () => {
     // @ts-ignore
     const nonRequiredSchema: MultiVariableTextSchema = {
@@ -154,6 +161,17 @@ describe('validateVariables', () => {
     };
     const value = JSON.stringify({ var1: '', var2: '' });
     expect(validateVariables(value, nonRequiredSchema)).toBe(true);
+  });
+
+  it('should return false for null non-required variable values', () => {
+    // @ts-ignore
+    const nonRequiredSchema: MultiVariableTextSchema = {
+      name: 'test',
+      variables: ['var1', 'var2'],
+      required: false,
+    };
+    const value = JSON.stringify({ var1: null, var2: '' });
+    expect(validateVariables(value, nonRequiredSchema)).toBe(false);
   });
 
   it('should throw an error for invalid JSON input', () => {

--- a/packages/schemas/__tests__/text.test.ts
+++ b/packages/schemas/__tests__/text.test.ts
@@ -580,6 +580,27 @@ describe('text dynamic layout', () => {
     expect(result.heights[0]).toBeGreaterThan(5);
   });
 
+  it('expands multiVariableText when optional variables are empty strings', async () => {
+    const schema = {
+      ...getTextSchema(),
+      name: 'message',
+      type: 'multiVariableText',
+      height: 5,
+      width: 20,
+      overflow: 'expand',
+      text: 'Title\n{name}\nFooter\nDone',
+      variables: ['name'],
+      required: false,
+    } as MultiVariableTextSchema;
+
+    const result = await getDynamicLayoutForMultiVariableText(JSON.stringify({ name: '' }), {
+      ...baseArgs,
+      schema,
+    });
+
+    expect(result.heights[0]).toBeGreaterThan(5);
+  });
+
   it('expands read-only multiVariableText as resolved text', async () => {
     const schema = {
       ...getTextSchema(),

--- a/packages/schemas/src/multiVariableText/helper.ts
+++ b/packages/schemas/src/multiVariableText/helper.ts
@@ -60,7 +60,7 @@ export const validateVariables = (value: string, schema: MultiVariableTextSchema
   }
 
   for (const variable of schema.variables) {
-    if (!values[variable]) {
+    if (!Object.prototype.hasOwnProperty.call(values, variable)) {
       if (schema.required) {
         throw new Error(
           `[@pdfme/generator] variable ${variable} is missing for field ${schema.name}`,

--- a/packages/schemas/src/multiVariableText/helper.ts
+++ b/packages/schemas/src/multiVariableText/helper.ts
@@ -60,7 +60,11 @@ export const validateVariables = (value: string, schema: MultiVariableTextSchema
   }
 
   for (const variable of schema.variables) {
-    if (!Object.prototype.hasOwnProperty.call(values, variable)) {
+    if (
+      !Object.prototype.hasOwnProperty.call(values, variable) ||
+      values[variable] === null ||
+      values[variable] === undefined
+    ) {
       if (schema.required) {
         throw new Error(
           `[@pdfme/generator] variable ${variable} is missing for field ${schema.name}`,


### PR DESCRIPTION
## Summary

- Treat present MVT variables with empty string values as valid inputs.
- Keep missing variable keys as missing for both required and non-required schemas.
- Add focused tests for empty-string substitution and validation behavior.

## Root Cause

`validateVariables` used a truthiness check, so `""` was handled the same as an omitted key. That prevented MVT fields from rendering or caused required-field errors even though the placeholder value was intentionally blank.

## Validation

- `npm run test -w packages/schemas -- multiVariableText`
- `npm run lint -w packages/schemas`
- `npm run test -w packages/schemas`
- `npm run build -w packages/schemas`