### PR TITLE
fix(ui): ensure updateOptions creates new options reference

### DIFF
--- a/packages/ui/__tests__/class.test.tsx
+++ b/packages/ui/__tests__/class.test.tsx
@@ -13,6 +13,13 @@ class TestUI extends BaseUIClass {
   }
 }
 
+class ResizeObserverMock {
+  constructor(_callback: ResizeObserverCallback) {}
+  public observe() {}
+  public unobserve() {}
+  public disconnect() {}
+}
+
 const template: Template = {
   basePdf: BLANK_PDF,
   schemas: [[]],
@@ -20,14 +27,6 @@ const template: Template = {
 
 test('BaseUIClass mount renders without forcing a synchronous flush', async () => {
   const originalResizeObserver = globalThis.ResizeObserver;
-
-  class ResizeObserverMock {
-    constructor(_callback: ResizeObserverCallback) {}
-
-    public observe() {}
-    public unobserve() {}
-    public disconnect() {}
-  }
 
   globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
 
@@ -46,6 +45,37 @@ test('BaseUIClass mount renders without forcing a synchronous flush', async () =
     await waitFor(() => {
       expect(domContainer.querySelector('[data-testid="base-ui-mounted"]')).toBeInTheDocument();
     });
+
+    ui.destroy();
+  } finally {
+    domContainer.remove();
+    globalThis.ResizeObserver = originalResizeObserver;
+  }
+});
+
+test('updateOptions creates a new options object reference', () => {
+  const originalResizeObserver = globalThis.ResizeObserver;
+  globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+
+  const domContainer = document.createElement('div');
+  Object.defineProperty(domContainer, 'clientHeight', { configurable: true, value: 240 });
+  Object.defineProperty(domContainer, 'clientWidth', { configurable: true, value: 320 });
+  document.body.appendChild(domContainer);
+
+  try {
+    const initialOptions = { lang: 'en' as const };
+    const ui = new TestUI({ domContainer, template, options: initialOptions } as UIProps);
+
+    const optionsBefore = ui.getOptions();
+
+    act(() => {
+      ui.updateOptions({ lang: 'ja' as const });
+    });
+
+    const optionsAfter = ui.getOptions();
+
+    expect(optionsAfter).not.toBe(optionsBefore);
+    expect(optionsAfter.lang).toBe('ja');
 
     ui.destroy();
   } finally {

--- a/packages/ui/__tests__/class.test.tsx
+++ b/packages/ui/__tests__/class.test.tsx
@@ -53,6 +53,29 @@ test('BaseUIClass mount renders without forcing a synchronous flush', async () =
   }
 });
 
+test('constructor stores a copy of the options object, not the original reference', () => {
+  const originalResizeObserver = globalThis.ResizeObserver;
+  globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+
+  const domContainer = document.createElement('div');
+  Object.defineProperty(domContainer, 'clientHeight', { configurable: true, value: 240 });
+  Object.defineProperty(domContainer, 'clientWidth', { configurable: true, value: 320 });
+  document.body.appendChild(domContainer);
+
+  try {
+    const initialOptions = { lang: 'en' as const };
+    const ui = new TestUI({ domContainer, template, options: initialOptions } as UIProps);
+
+    expect(ui.getOptions()).not.toBe(initialOptions);
+    expect(ui.getOptions().lang).toBe('en');
+
+    ui.destroy();
+  } finally {
+    domContainer.remove();
+    globalThis.ResizeObserver = originalResizeObserver;
+  }
+});
+
 test('updateOptions creates a new options object reference', () => {
   const originalResizeObserver = globalThis.ResizeObserver;
   globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;

--- a/packages/ui/src/class.ts
+++ b/packages/ui/src/class.ts
@@ -67,7 +67,7 @@ export abstract class BaseUIClass {
     const { domContainer, template, options = {}, plugins = {} } = props;
     this.domContainer = domContainer;
     this.template = cloneDeep(template);
-    this.options = options;
+    this.options = Object.assign({}, options);
     const container = this.domContainer;
     this.size = {
       height: container.clientHeight || window.innerHeight,

--- a/packages/ui/src/class.ts
+++ b/packages/ui/src/class.ts
@@ -128,7 +128,7 @@ export abstract class BaseUIClass {
     if (font) {
       this.font = font;
     }
-    this.options = Object.assign(this.options, options);
+    this.options = Object.assign({}, this.options, options);
     this.render();
   }
 


### PR DESCRIPTION
## Summary

- `BaseUIClass.updateOptions()` was calling `Object.assign(this.options, newOptions)`, which mutates the existing options object in place.
- This means callers that hold a reference to the options object, or that compare options by reference (e.g. React Context value checks, reactive state systems), cannot detect that the options changed — the reference before and after the call is the same object.
- Fixed by changing to `Object.assign({}, this.options, options)` so each `updateOptions()` call assigns a fresh object to `this.options`, giving the new options a distinct reference.

## Test plan

- [ ] Existing test suite passes: `cd packages/ui && npm run test`
- [ ] New test `updateOptions creates a new options object reference` in `packages/ui/__tests__/class.test.tsx` verifies that `getOptions()` returns a different object reference after `updateOptions()` is called, and that the updated value is correctly reflected.
- [ ] `npm run lint` — no warnings or errors
- [ ] `npm run fmt` — no formatting changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)