### PR TITLE
feat(ui): add selectSchemas public method to Designer

### DIFF
--- a/packages/ui/__tests__/components/Designer.test.tsx
+++ b/packages/ui/__tests__/components/Designer.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, act, fireEvent, waitFor } from '@testing-library/react';
-import Designer, { type DesignerEditorApi } from '../../src/components/Designer/index.js';
+import Designer from '../../src/components/Designer/index.js';
+import DesignerClass from '../../src/Designer.js';
 import { I18nContext, FontContext, OptionsContext, PluginsRegistry } from '../../src/contexts';
 import { i18n } from '../../src/i18n';
 import { DESIGNER_CLASSNAME, RIGHT_SIDEBAR_WIDTH, SELECTABLE_CLASSNAME } from '../../src/constants';
@@ -104,58 +105,90 @@ test('Designer keeps sidebar toggle interactive when options.sidebarOpen is only
   });
 });
 
-test('selectSchemas selects the matching schema element and deselects with empty array', async () => {
+const withNoopResizeObserver = (fn: () => void) => {
+  const original = globalThis.ResizeObserver;
+  globalThis.ResizeObserver = class {
+    constructor(_cb: ResizeObserverCallback) {}
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+  try {
+    fn();
+  } finally {
+    globalThis.ResizeObserver = original;
+  }
+};
+
+test('Designer.selectSchemas selects and deselects schemas via the public class method', async () => {
   setupUIMock();
-  let editorApi: DesignerEditorApi | null = null;
 
-  const { container } = render(
-    <I18nContext.Provider value={i18n}>
-      <FontContext.Provider value={getDefaultFont()}>
-        <PluginsRegistry.Provider value={pluginRegistry(plugins)}>
-          <Designer
-            template={getSampleTemplate()}
-            onSaveTemplate={console.log}
-            onChangeTemplate={console.log}
-            size={{ width: 1200, height: 1200 }}
-            onPageCursorChange={() => undefined}
-            onMountEditorApi={(api) => {
-              editorApi = api;
-            }}
-          />
-        </PluginsRegistry.Provider>
-      </FontContext.Provider>
-    </I18nContext.Provider>,
-  );
+  let designer: DesignerClass | undefined;
+  const domContainer = document.createElement('div');
+  Object.defineProperty(domContainer, 'clientHeight', { configurable: true, value: 1200 });
+  Object.defineProperty(domContainer, 'clientWidth', { configurable: true, value: 1200 });
+  document.body.appendChild(domContainer);
 
-  // Wait for schema elements to be mounted in the DOM.
-  await waitFor(() => {
-    expect(container.getElementsByClassName(SELECTABLE_CLASSNAME).length).toBeGreaterThan(0);
-  });
+  try {
+    withNoopResizeObserver(() => {
+      designer = new DesignerClass({ domContainer, template: getSampleTemplate(), plugins });
+    });
 
-  expect(editorApi).not.toBeNull();
+    await act(async () => {
+      (designer as any).render();
+      // Flush async template initialisation (template2SchemasList) so subsequent
+      // state updates land inside this act boundary and avoid spurious warnings.
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    });
 
-  // No selection initially – delete button should not be present.
-  expect(container.querySelector(`.${DESIGNER_CLASSNAME}delete-button`)).toBeNull();
+    await waitFor(() => {
+      expect(domContainer.getElementsByClassName(SELECTABLE_CLASSNAME).length).toBeGreaterThan(0);
+    });
 
-  // Select field1 programmatically.
-  await act(async () => {
-    editorApi!.selectSchemas(['field1']);
-    // The internal selectSchemas uses setTimeout; flush it.
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  });
+    // No selection initially.
+    expect(domContainer.querySelector(`.${DESIGNER_CLASSNAME}delete-button`)).toBeNull();
 
-  // The delete button appears whenever one or more elements are active.
-  await waitFor(() => {
-    expect(container.querySelector(`.${DESIGNER_CLASSNAME}delete-button`)).toBeInTheDocument();
-  });
+    // Select field1 via the public class method.
+    await act(async () => {
+      designer!.selectSchemas(['field1']);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
 
-  // Deselect by passing an empty array.
-  await act(async () => {
-    editorApi!.selectSchemas([]);
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  });
+    await waitFor(() => {
+      expect(domContainer.querySelector(`.${DESIGNER_CLASSNAME}delete-button`)).toBeInTheDocument();
+    });
 
-  await waitFor(() => {
-    expect(container.querySelector(`.${DESIGNER_CLASSNAME}delete-button`)).toBeNull();
-  });
+    // Deselect by passing an empty array.
+    await act(async () => {
+      designer!.selectSchemas([]);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    await waitFor(() => {
+      expect(domContainer.querySelector(`.${DESIGNER_CLASSNAME}delete-button`)).toBeNull();
+    });
+  } finally {
+    designer?.destroy();
+    domContainer.remove();
+  }
+});
+
+test('Designer.selectSchemas throws when called before the component mounts', () => {
+  let designer: DesignerClass | undefined;
+  const domContainer = document.createElement('div');
+  Object.defineProperty(domContainer, 'clientHeight', { configurable: true, value: 1200 });
+  Object.defineProperty(domContainer, 'clientWidth', { configurable: true, value: 1200 });
+  document.body.appendChild(domContainer);
+
+  try {
+    withNoopResizeObserver(() => {
+      designer = new DesignerClass({ domContainer, template: getSampleTemplate(), plugins });
+    });
+    expect(() => designer!.selectSchemas(['field1'])).toThrow(
+      '[@pdfme/ui] selectSchemas was called before the Designer finished mounting',
+    );
+  } finally {
+    designer?.destroy();
+    domContainer.remove();
+  }
 });

--- a/packages/ui/__tests__/components/Designer.test.tsx
+++ b/packages/ui/__tests__/components/Designer.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, act, fireEvent, waitFor } from '@testing-library/react';
-import Designer from '../../src/components/Designer/index.js';
+import Designer, { type DesignerEditorApi } from '../../src/components/Designer/index.js';
 import { I18nContext, FontContext, OptionsContext, PluginsRegistry } from '../../src/contexts';
 import { i18n } from '../../src/i18n';
 import { DESIGNER_CLASSNAME, RIGHT_SIDEBAR_WIDTH, SELECTABLE_CLASSNAME } from '../../src/constants';
@@ -101,5 +101,61 @@ test('Designer keeps sidebar toggle interactive when options.sidebarOpen is only
 
   await waitFor(() => {
     expect(sidebar.style.width).toBe('0px');
+  });
+});
+
+test('selectSchemas selects the matching schema element and deselects with empty array', async () => {
+  setupUIMock();
+  let editorApi: DesignerEditorApi | null = null;
+
+  const { container } = render(
+    <I18nContext.Provider value={i18n}>
+      <FontContext.Provider value={getDefaultFont()}>
+        <PluginsRegistry.Provider value={pluginRegistry(plugins)}>
+          <Designer
+            template={getSampleTemplate()}
+            onSaveTemplate={console.log}
+            onChangeTemplate={console.log}
+            size={{ width: 1200, height: 1200 }}
+            onPageCursorChange={() => undefined}
+            onMountEditorApi={(api) => {
+              editorApi = api;
+            }}
+          />
+        </PluginsRegistry.Provider>
+      </FontContext.Provider>
+    </I18nContext.Provider>,
+  );
+
+  // Wait for schema elements to be mounted in the DOM.
+  await waitFor(() => {
+    expect(container.getElementsByClassName(SELECTABLE_CLASSNAME).length).toBeGreaterThan(0);
+  });
+
+  expect(editorApi).not.toBeNull();
+
+  // No selection initially – delete button should not be present.
+  expect(container.querySelector(`.${DESIGNER_CLASSNAME}delete-button`)).toBeNull();
+
+  // Select field1 programmatically.
+  await act(async () => {
+    editorApi!.selectSchemas(['field1']);
+    // The internal selectSchemas uses setTimeout; flush it.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  // The delete button appears whenever one or more elements are active.
+  await waitFor(() => {
+    expect(container.querySelector(`.${DESIGNER_CLASSNAME}delete-button`)).toBeInTheDocument();
+  });
+
+  // Deselect by passing an empty array.
+  await act(async () => {
+    editorApi!.selectSchemas([]);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  await waitFor(() => {
+    expect(container.querySelector(`.${DESIGNER_CLASSNAME}delete-button`)).toBeNull();
   });
 });

--- a/packages/ui/__tests__/components/Designer.test.tsx
+++ b/packages/ui/__tests__/components/Designer.test.tsx
@@ -173,6 +173,53 @@ test('Designer.selectSchemas selects and deselects schemas via the public class 
   }
 });
 
+test('Designer.selectSchemas preserves existing selection when all names are unmatched', async () => {
+  setupUIMock();
+
+  let designer: DesignerClass | undefined;
+  const domContainer = document.createElement('div');
+  Object.defineProperty(domContainer, 'clientHeight', { configurable: true, value: 1200 });
+  Object.defineProperty(domContainer, 'clientWidth', { configurable: true, value: 1200 });
+  document.body.appendChild(domContainer);
+
+  try {
+    withNoopResizeObserver(() => {
+      designer = new DesignerClass({ domContainer, template: getSampleTemplate(), plugins });
+    });
+
+    await act(async () => {
+      (designer as any).render();
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    });
+
+    await waitFor(() => {
+      expect(domContainer.getElementsByClassName(SELECTABLE_CLASSNAME).length).toBeGreaterThan(0);
+    });
+
+    // Select field1 first.
+    await act(async () => {
+      designer!.selectSchemas(['field1']);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    await waitFor(() => {
+      expect(domContainer.querySelector(`.${DESIGNER_CLASSNAME}delete-button`)).toBeInTheDocument();
+    });
+
+    // Calling with an unmatched name should be a no-op — selection must be preserved.
+    await act(async () => {
+      designer!.selectSchemas(['this_name_does_not_exist']);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // Delete button should still be present.
+    expect(domContainer.querySelector(`.${DESIGNER_CLASSNAME}delete-button`)).toBeInTheDocument();
+  } finally {
+    designer?.destroy();
+    domContainer.remove();
+  }
+});
+
 test('Designer.selectSchemas throws when called before the component mounts', () => {
   let designer: DesignerClass | undefined;
   const domContainer = document.createElement('div');

--- a/packages/ui/src/Designer.tsx
+++ b/packages/ui/src/Designer.tsx
@@ -9,7 +9,7 @@ import {
 } from '@pdfme/common';
 import { BaseUIClass } from './class.js';
 import { DESTROYED_ERR_MSG } from './constants.js';
-import DesignerComponent from './components/Designer/index.js';
+import DesignerComponent, { type DesignerEditorApi } from './components/Designer/index.js';
 import AppContextProvider from './components/AppContextProvider.js';
 
 class Designer extends BaseUIClass {
@@ -17,6 +17,7 @@ class Designer extends BaseUIClass {
   private onChangeTemplateCallback?: (template: Template) => void;
   private onPageChangeCallback?: (pageInfo: { currentPage: number; totalPages: number }) => void;
   private pageCursor: number = 0;
+  private editorApi: DesignerEditorApi | null = null;
 
   constructor(props: DesignerProps) {
     super(props);
@@ -61,6 +62,25 @@ class Designer extends BaseUIClass {
     return this.template.schemas.length;
   }
 
+  /**
+   * Programmatically select one or more schema elements by name.
+   *
+   * This is equivalent to clicking the elements on the canvas. Pass an empty
+   * array to deselect everything. Names that do not match any schema on the
+   * current template are silently ignored.
+   *
+   * Note: only schemas on the currently-visible page can be selected because
+   * the canvas only renders DOM nodes for the active page. Call
+   * `onPageChange` / scroll to the target page first if the schema lives on a
+   * different page.
+   */
+  public selectSchemas(names: string[]) {
+    if (!this.domContainer) throw Error(DESTROYED_ERR_MSG);
+    if (this.editorApi) {
+      this.editorApi.selectSchemas(names);
+    }
+  }
+
   protected render() {
     if (!this.domContainer) throw Error(DESTROYED_ERR_MSG);
     this.mount(
@@ -94,6 +114,9 @@ class Designer extends BaseUIClass {
                 totalPages: totalPages,
               });
             }
+          }}
+          onMountEditorApi={(api) => {
+            this.editorApi = api;
           }}
           size={this.size}
         />

--- a/packages/ui/src/Designer.tsx
+++ b/packages/ui/src/Designer.tsx
@@ -76,9 +76,13 @@ class Designer extends BaseUIClass {
    */
   public selectSchemas(names: string[]) {
     if (!this.domContainer) throw Error(DESTROYED_ERR_MSG);
-    if (this.editorApi) {
-      this.editorApi.selectSchemas(names);
+    if (!this.editorApi) {
+      throw Error(
+        '[@pdfme/ui] selectSchemas was called before the Designer finished mounting. ' +
+          'Wait for the component to mount (e.g. inside onChangeTemplate) before calling this method.',
+      );
     }
+    this.editorApi.selectSchemas(names);
   }
 
   protected render() {

--- a/packages/ui/src/components/Designer/index.tsx
+++ b/packages/ui/src/components/Designer/index.tsx
@@ -118,18 +118,16 @@ const TemplateEditor = ({
     if (!onMountEditorApi) return;
     onMountEditorApi({
       selectSchemas: (names: string[]) => {
-        if (names.length === 0) {
-          onEditEnd();
-          return;
-        }
-        // Resolve schema ids from names across all pages.
-        const allSchemas = schemasListRef.current.flat();
-        const matchedIds = names
-          .map((name) => allSchemas.find((s) => s.name === name)?.id)
-          .filter((id): id is string => id !== undefined);
-
-        // Use setTimeout so the DOM is guaranteed to be up-to-date (same pattern as addSchema).
         setTimeout(() => {
+          if (names.length === 0) {
+            onEditEnd();
+            return;
+          }
+          const allSchemas = schemasListRef.current.flat();
+          const matchedIds = names
+            .map((name) => allSchemas.find((s) => s.name === name)?.id)
+            .filter((id): id is string => id !== undefined);
+
           const root = canvasRef.current ?? document;
           const elements = matchedIds
             .map((id) => root.querySelector<HTMLElement>(`[id="${id}"]`))

--- a/packages/ui/src/components/Designer/index.tsx
+++ b/packages/ui/src/components/Designer/index.tsx
@@ -49,12 +49,17 @@ const scaleDragPosAdjustment = (adjustment: number, scale: number): number => {
   return 0;
 };
 
+export type DesignerEditorApi = {
+  selectSchemas: (names: string[]) => void;
+};
+
 const TemplateEditor = ({
   template,
   size,
   onSaveTemplate,
   onChangeTemplate,
   onPageCursorChange,
+  onMountEditorApi,
 }: Omit<DesignerProps, 'domContainer'> & {
   size: Size;
   onSaveTemplate: (t: Template) => void;
@@ -62,6 +67,7 @@ const TemplateEditor = ({
 } & {
   onChangeTemplate: (t: Template) => void;
   onPageCursorChange: (newPageCursor: number, totalPages: number) => void;
+  onMountEditorApi?: (api: DesignerEditorApi) => void;
 }) => {
   const past = useRef<SchemaForUI[][]>([]);
   const future = useRef<SchemaForUI[][]>([]);
@@ -100,6 +106,40 @@ const TemplateEditor = ({
     setActiveElements([]);
     setHoveringSchemaId(null);
   };
+
+  // Keep a ref to current schemasList so the editor API closure never becomes stale.
+  const schemasListRef = useRef(schemasList);
+  useEffect(() => {
+    schemasListRef.current = schemasList;
+  }, [schemasList]);
+
+  // Expose an imperative API to the Designer class once on mount.
+  useEffect(() => {
+    if (!onMountEditorApi) return;
+    onMountEditorApi({
+      selectSchemas: (names: string[]) => {
+        if (names.length === 0) {
+          onEditEnd();
+          return;
+        }
+        // Resolve schema ids from names, searching the current page first.
+        const allSchemas = schemasListRef.current.flat();
+        const matchedIds = names
+          .map((name) => allSchemas.find((s) => s.name === name)?.id)
+          .filter((id): id is string => id !== undefined);
+
+        // Use setTimeout so the DOM is guaranteed to be up-to-date (same pattern as addSchema).
+        setTimeout(() => {
+          const elements = matchedIds
+            .map((id) => document.getElementById(id))
+            .filter((el): el is HTMLElement => el !== null);
+          onEdit(elements);
+        });
+      },
+    });
+    // onMountEditorApi is intentionally excluded – we only want to call it once on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     if (typeof options.zoomLevel === 'number') {

--- a/packages/ui/src/components/Designer/index.tsx
+++ b/packages/ui/src/components/Designer/index.tsx
@@ -132,6 +132,7 @@ const TemplateEditor = ({
           const elements = matchedIds
             .map((id) => root.querySelector<HTMLElement>(`[id="${id}"]`))
             .filter((el): el is HTMLElement => el !== null);
+          if (elements.length === 0) return;
           onEdit(elements);
         });
       },

--- a/packages/ui/src/components/Designer/index.tsx
+++ b/packages/ui/src/components/Designer/index.tsx
@@ -122,7 +122,7 @@ const TemplateEditor = ({
           onEditEnd();
           return;
         }
-        // Resolve schema ids from names, searching the current page first.
+        // Resolve schema ids from names across all pages.
         const allSchemas = schemasListRef.current.flat();
         const matchedIds = names
           .map((name) => allSchemas.find((s) => s.name === name)?.id)

--- a/packages/ui/src/components/Designer/index.tsx
+++ b/packages/ui/src/components/Designer/index.tsx
@@ -130,8 +130,9 @@ const TemplateEditor = ({
 
         // Use setTimeout so the DOM is guaranteed to be up-to-date (same pattern as addSchema).
         setTimeout(() => {
+          const root = canvasRef.current ?? document;
           const elements = matchedIds
-            .map((id) => document.getElementById(id))
+            .map((id) => root.querySelector<HTMLElement>(`[id="${id}"]`))
             .filter((el): el is HTMLElement => el !== null);
           onEdit(elements);
         });

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,3 +3,4 @@ import Form from './Form.js';
 import Viewer from './Viewer.js';
 
 export { Designer, Viewer, Form };
+export type { DesignerEditorApi } from './components/Designer/index.js';


### PR DESCRIPTION
## Problem

The `Designer` class has no public API to programmatically select schema elements. Applications that need to auto-select a newly placed element — for example, after a drag-and-drop from an external palette — currently have no supported path. The only workaround is to find the internal `.selectable` DOM node and synthesise a click/mouse event, which is fragile and breaks across pdfme versions.

## Solution

Add a `selectSchemas(names: string[])` public method to `Designer` that selects one or more elements by their schema `name` property.

### Method signature

```ts
designer.selectSchemas(names: string[])
```

- **`names`** – array of schema names to select. Names that don't match any schema in the template are silently ignored.
- Passing an empty array deselects everything (equivalent to clicking an empty area of the canvas).
- Only schemas on the currently-visible page can be targeted, because the canvas only renders DOM nodes for the active page. If the target schema is on a different page, navigate there first.

### Usage example

```ts
import { Designer } from '@pdfme/ui';

const designer = new Designer({ domContainer, template, plugins });

// After programmatically adding a schema, auto-select it:
designer.onChangeTemplate((t) => {
  const lastSchema = t.schemas[0].at(-1);
  if (lastSchema) {
    designer.selectSchemas([lastSchema.name]);
  }
});

// Select multiple schemas at once:
designer.selectSchemas(['firstName', 'lastName']);

// Deselect everything:
designer.selectSchemas([]);
```

## Implementation

The selection state (`activeElements` / `onEdit`) lives inside the `TemplateEditor` functional component and is not accessible from the `Designer` class directly. The bridge is a callback-registration pattern consistent with the existing `onSaveTemplate` / `onChangeTemplate` style:

1. `TemplateEditor` gains an optional `onMountEditorApi` prop.
2. On mount it calls `onMountEditorApi` with a `DesignerEditorApi` object `{ selectSchemas }`.
3. `Designer` stores the API handle in a private `editorApi` field and proxies `selectSchemas` through it.
4. A `schemasListRef` keeps the closure over `schemasList` fresh so the API handle never becomes stale.
5. A `setTimeout` (matching the existing `addSchema` pattern) ensures DOM nodes exist before calling `onEdit`.

## Test

A new test in `__tests__/components/Designer.test.tsx` renders the component, calls `selectSchemas(['field1'])`, and asserts that the canvas delete button (`pdfme-designer-delete-button`) appears — the same visual cue that appears when a user clicks a schema. It then calls `selectSchemas([])` and asserts the button disappears.

## Files changed

- `packages/ui/src/components/Designer/index.tsx` — `DesignerEditorApi` type + `onMountEditorApi` prop + `useEffect` bridge
- `packages/ui/src/Designer.tsx` — `editorApi` field + `selectSchemas` public method + wires `onMountEditorApi`
- `packages/ui/__tests__/components/Designer.test.tsx` — new test

🤖 Generated with [Claude Code](https://claude.com/claude-code)