### PR TITLE
feat(common,ui): add typed custom field to Schema for third-party metadata

### DIFF
--- a/packages/common/src/schema.ts
+++ b/packages/common/src/schema.ts
@@ -144,6 +144,7 @@ export const Schema = z
     required: z.boolean().optional(),
     __splitRange: DynamicLayoutSplitRange.optional(),
     __isSplit: z.boolean().optional(),
+    custom: z.record(z.string(), z.unknown()).optional(),
   })
   .passthrough();
 

--- a/packages/ui/__tests__/helper.test.ts
+++ b/packages/ui/__tests__/helper.test.ts
@@ -586,6 +586,33 @@ describe('changeSchemas test', () => {
       },
     ]);
   });
+
+  test('changeSchemas - type change preserves custom field', () => {
+    const schema: SchemaForUI = {
+      id: uuid(),
+      ...getSchema(),
+      name: 'field1',
+      content: 'hello',
+      custom: { appFieldId: 'app-123', source: 'import' },
+    };
+
+    const objs = [{ key: 'type', value: 'image', schemaId: schema.id }];
+    const mockCallback = vi.fn();
+
+    changeSchemas({
+      schemas: [schema],
+      objs,
+      commitSchemas: mockCallback,
+      basePdf: basePdf1,
+      pluginsRegistry,
+      pageSize,
+    });
+
+    const result = mockCallback.mock.calls[0][0][0] as Record<string, unknown>;
+
+    expect(result.type).toBe('image');
+    expect(result.custom).toStrictEqual({ appFieldId: 'app-123', source: 'import' });
+  });
 });
 
 describe('getDynamicHeightReflowChanges', () => {

--- a/packages/ui/src/helper.ts
+++ b/packages/ui/src/helper.ts
@@ -450,7 +450,7 @@ const handleTypeChange = (
   pluginsRegistry: PluginRegistry,
 ) => {
   if (key !== 'type') return;
-  const keysToKeep = ['id', 'name', 'type', 'position', 'required'];
+  const keysToKeep = ['id', 'name', 'type', 'position', 'required', 'custom'];
   Object.keys(schema).forEach((key) => {
     if (!keysToKeep.includes(key)) {
       delete schema[key as keyof typeof schema];


### PR DESCRIPTION
## Summary

Adds a first-class `custom?: Record<string, unknown>` field to the `Schema` type, giving third-party libraries a typed, namespaced place to attach application metadata to schema elements.

Previously there was no sanctioned way to store app-level annotations (e.g. an external system's field ID, import tags, audit metadata) on a schema element. Libraries working around this by attaching fields at the top level would have them silently dropped whenever a user changed the element's type in the Designer, because `handleTypeChange` only preserves a fixed set of known keys.

## Changes

- **`packages/common/src/schema.ts`** — add `custom: z.record(z.string(), z.unknown()).optional()` to the `Schema` Zod object
- **`packages/ui/src/helper.ts`** — add `'custom'` to `keysToKeep` in `handleTypeChange` so the field survives type changes in the Designer
- **`packages/ui/__tests__/helper.test.ts`** — test that `schema.custom` is preserved across a `text → image` type change

## Usage

```ts
// Attach app metadata when building a template
const schema = {
  name: 'invoice_number',
  type: 'text',
  // ...
  custom: {
    appFieldId: 'field-abc123',
    source: 'import',
  },
};

// schema.custom is preserved even after the user changes the element type
// in the Designer
```

## Test plan

- [x] New test: `changeSchemas - type change preserves custom field`
- [x] All 57 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)