### PR TITLE
fix(common): support hyphenated field names in template expressions

### DIFF
--- a/packages/common/__tests__/expression.test.ts
+++ b/packages/common/__tests__/expression.test.ts
@@ -297,6 +297,29 @@ describe('replacePlaceholders', () => {
     const result = replacePlaceholders({ content, variables: {}, schemas });
     expect(result).toBe('Content: ');
   });
+
+  it('should not collide when a context key matches a safe identifier name', () => {
+    // Regression for toSafeIdentifier collision: an older encoding produced a safe id
+    // that could be identical to a literal context key (e.g. __k_firstu2dname__ for
+    // both "first-name" and a key literally named "__k_firstu2dname__"). The index-based
+    // scheme produces __pdfme_hk_0__ etc., which cannot appear in user-supplied keys
+    // without quoting and so is collision-free in practice.
+    const variables = { 'first-name': 'John', '__pdfme_hk_0__': 'WRONG' };
+    const content = 'Hello {first-name}';
+    const result = replacePlaceholders({ content, variables, schemas: [] });
+    expect(result).toBe('Hello John');
+  });
+
+  it('should evaluate {1+1} as arithmetic even when "1+1" is a context key', () => {
+    // Regression for over-broad fast-path: previously any context key matching
+    // the placeholder content short-circuited evaluation, so {1+1} with a context
+    // key "1+1" would return the key value instead of 2. Narrowing the fast-path
+    // to non-identifiers only restores correct arithmetic behaviour.
+    const variables = { '1+1': 'WRONG' };
+    const content = 'Result: {1+1}';
+    const result = replacePlaceholders({ content, variables, schemas: [] });
+    expect(result).toBe('Result: 2');
+  });
 });
 
 describe('replacePlaceholders - Security Tests', () => {

--- a/packages/common/__tests__/expression.test.ts
+++ b/packages/common/__tests__/expression.test.ts
@@ -274,6 +274,29 @@ describe('replacePlaceholders', () => {
     const result = replacePlaceholders({ content, variables: {}, schemas: [] });
     expect(result).toBe('Max: 3');
   });
+
+  it('should resolve a three-part hyphenated key {a-b-c}', () => {
+    const content = 'Value: {a-b-c}';
+    const variables = { 'a-b-c': 'three-parts' };
+    const result = replacePlaceholders({ content, variables, schemas: [] });
+    expect(result).toBe('Value: three-parts');
+  });
+
+  it('should use empty string for a non-readOnly schema field with a hyphenated name', () => {
+    const content = 'Content: {my-field}';
+    const schemas = [
+      [
+        {
+          name: 'my-field',
+          type: 'text',
+          content: 'Should not be used',
+          readOnly: false,
+        },
+      ],
+    ] as SchemaPageArray;
+    const result = replacePlaceholders({ content, variables: {}, schemas });
+    expect(result).toBe('Content: ');
+  });
 });
 
 describe('replacePlaceholders - Security Tests', () => {

--- a/packages/common/__tests__/expression.test.ts
+++ b/packages/common/__tests__/expression.test.ts
@@ -165,52 +165,30 @@ describe('replacePlaceholders', () => {
     expect(regex.test(result)).toBe(true);
   });
 
-  it('should replace a placeholder whose name contains a hyphen', () => {
-    // 'field-name' is not a valid JS identifier, so acorn parses it as
-    // subtraction (field - name). The fast-path context lookup must intercept
-    // this before the parser runs.
+  // ── Hyphenated field names ──────────────────────────────────────────────────
+
+  it('should replace a standalone hyphenated field name', () => {
     const content = 'Value: {field-name}';
     const variables = { 'field-name': 'hello' };
     const result = replacePlaceholders({ content, variables, schemas: [] });
     expect(result).toBe('Value: hello');
   });
 
-  it('should replace multiple hyphenated field names in one template', () => {
+  it('should replace multiple standalone hyphenated placeholders', () => {
     const content = '{first-name} {last-name}';
     const variables = { 'first-name': 'John', 'last-name': 'Doe' };
     const result = replacePlaceholders({ content, variables, schemas: [] });
     expect(result).toBe('John Doe');
   });
 
-  it('should handle hyphenated field names with leading/trailing whitespace inside braces', () => {
+  it('should handle whitespace inside braces around a hyphenated name', () => {
     const content = 'Value: { field-name }';
     const variables = { 'field-name': 'world' };
     const result = replacePlaceholders({ content, variables, schemas: [] });
     expect(result).toBe('Value: world');
   });
 
-  it('should still evaluate arithmetic subtraction when the expression is not a context key', () => {
-    // 'a-b' is NOT in context; 'a' and 'b' are separate keys.
-    // The fast-path must not fire, and normal acorn evaluation must still work.
-    const content = 'Result: {a-b}';
-    const variables = { a: 10, b: 3 };
-    const result = replacePlaceholders({ content, variables, schemas: [] });
-    expect(result).toBe('Result: 7');
-  });
-
-  it('should still evaluate math expressions that are not literal context keys', () => {
-    const content = 'Sum: {1 + 2}';
-    const result = replacePlaceholders({ content, variables: {}, schemas: [] });
-    expect(result).toBe('Sum: 3');
-  });
-
-  it('should still resolve allowed globals when not a literal context key', () => {
-    const content = 'Max: {Math.max(1, 2, 3)}';
-    const result = replacePlaceholders({ content, variables: {}, schemas: [] });
-    expect(result).toBe('Max: 3');
-  });
-
-  it('should use schema content for hyphenated field names', () => {
+  it('should use schema content for a hyphenated field name', () => {
     const content = 'Label: {my-field}';
     const schemas = [
       [
@@ -224,6 +202,77 @@ describe('replacePlaceholders', () => {
     ] as SchemaPageArray;
     const result = replacePlaceholders({ content, variables: {}, schemas });
     expect(result).toBe('Label: schema-value');
+  });
+
+  it('should concatenate two hyphenated fields in a compound expression', () => {
+    const content = 'Hello, {first-name + " " + last-name}!';
+    const variables = { 'first-name': 'John', 'last-name': 'Doe' };
+    const result = replacePlaceholders({ content, variables, schemas: [] });
+    expect(result).toBe('Hello, John Doe!');
+  });
+
+  it('should add a number to a hyphenated field value in a compound expression', () => {
+    const content = 'Next: {count-down + 1}';
+    const variables = { 'count-down': 4 };
+    const result = replacePlaceholders({ content, variables, schemas: [] });
+    expect(result).toBe('Next: 5');
+  });
+
+  it('should use || fallback with a hyphenated field in a compound expression', () => {
+    const content = 'Name: {nick-name || first-name}';
+    const variables = { 'nick-name': '', 'first-name': 'Alice' };
+    const result = replacePlaceholders({ content, variables, schemas: [] });
+    expect(result).toBe('Name: Alice');
+  });
+
+  it('should evaluate a ternary with a hyphenated field in a compound expression', () => {
+    const content = 'Status: {is-active ? "yes" : "no"}';
+    const variables = { 'is-active': true };
+    const result = replacePlaceholders({ content, variables, schemas: [] });
+    expect(result).toBe('Status: yes');
+  });
+
+  it('should not corrupt a hyphen inside a string literal', () => {
+    const content = '{first-name + "-" + last-name}';
+    const variables = { 'first-name': 'John', 'last-name': 'Doe' };
+    const result = replacePlaceholders({ content, variables, schemas: [] });
+    expect(result).toBe('John-Doe');
+  });
+
+  it('should treat {a-b} as arithmetic when neither "a-b" nor a longer key exists in context', () => {
+    const content = 'Result: {a-b}';
+    const variables = { a: 10, b: 3 };
+    const result = replacePlaceholders({ content, variables, schemas: [] });
+    expect(result).toBe('Result: 7');
+  });
+
+  it('should prefer the hyphenated key over arithmetic when it exists in context', () => {
+    // Context has both "a-b" as a key AND "a" and "b" as separate keys.
+    // The hyphenated key must win for the adjacent "{a-b}" form.
+    const content = 'Value: {a-b}';
+    const variables = { 'a-b': 'key-wins', a: 10, b: 3 };
+    const result = replacePlaceholders({ content, variables, schemas: [] });
+    expect(result).toBe('Value: key-wins');
+  });
+
+  it('should fall back to arithmetic with spaced "{a - b}" even when "a-b" exists in context', () => {
+    // Spaces break the adjacent-token chain, so the expression is subtraction.
+    const content = 'Result: {a - b}';
+    const variables = { 'a-b': 'should-not-appear', a: 10, b: 3 };
+    const result = replacePlaceholders({ content, variables, schemas: [] });
+    expect(result).toBe('Result: 7');
+  });
+
+  it('should still evaluate math expressions not involving context keys', () => {
+    const content = 'Sum: {1 + 2}';
+    const result = replacePlaceholders({ content, variables: {}, schemas: [] });
+    expect(result).toBe('Sum: 3');
+  });
+
+  it('should still resolve allowed globals when no hyphenated keys are involved', () => {
+    const content = 'Max: {Math.max(1, 2, 3)}';
+    const result = replacePlaceholders({ content, variables: {}, schemas: [] });
+    expect(result).toBe('Max: 3');
   });
 });
 

--- a/packages/common/__tests__/expression.test.ts
+++ b/packages/common/__tests__/expression.test.ts
@@ -164,6 +164,67 @@ describe('replacePlaceholders', () => {
     const regex = /^Chained: \d+\.\d+$/;
     expect(regex.test(result)).toBe(true);
   });
+
+  it('should replace a placeholder whose name contains a hyphen', () => {
+    // 'field-name' is not a valid JS identifier, so acorn parses it as
+    // subtraction (field - name). The fast-path context lookup must intercept
+    // this before the parser runs.
+    const content = 'Value: {field-name}';
+    const variables = { 'field-name': 'hello' };
+    const result = replacePlaceholders({ content, variables, schemas: [] });
+    expect(result).toBe('Value: hello');
+  });
+
+  it('should replace multiple hyphenated field names in one template', () => {
+    const content = '{first-name} {last-name}';
+    const variables = { 'first-name': 'John', 'last-name': 'Doe' };
+    const result = replacePlaceholders({ content, variables, schemas: [] });
+    expect(result).toBe('John Doe');
+  });
+
+  it('should handle hyphenated field names with leading/trailing whitespace inside braces', () => {
+    const content = 'Value: { field-name }';
+    const variables = { 'field-name': 'world' };
+    const result = replacePlaceholders({ content, variables, schemas: [] });
+    expect(result).toBe('Value: world');
+  });
+
+  it('should still evaluate arithmetic subtraction when the expression is not a context key', () => {
+    // 'a-b' is NOT in context; 'a' and 'b' are separate keys.
+    // The fast-path must not fire, and normal acorn evaluation must still work.
+    const content = 'Result: {a-b}';
+    const variables = { a: 10, b: 3 };
+    const result = replacePlaceholders({ content, variables, schemas: [] });
+    expect(result).toBe('Result: 7');
+  });
+
+  it('should still evaluate math expressions that are not literal context keys', () => {
+    const content = 'Sum: {1 + 2}';
+    const result = replacePlaceholders({ content, variables: {}, schemas: [] });
+    expect(result).toBe('Sum: 3');
+  });
+
+  it('should still resolve allowed globals when not a literal context key', () => {
+    const content = 'Max: {Math.max(1, 2, 3)}';
+    const result = replacePlaceholders({ content, variables: {}, schemas: [] });
+    expect(result).toBe('Max: 3');
+  });
+
+  it('should use schema content for hyphenated field names', () => {
+    const content = 'Label: {my-field}';
+    const schemas = [
+      [
+        {
+          name: 'my-field',
+          type: 'text',
+          content: 'schema-value',
+          readOnly: true,
+        },
+      ],
+    ] as SchemaPageArray;
+    const result = replacePlaceholders({ content, variables: {}, schemas });
+    expect(result).toBe('Label: schema-value');
+  });
 });
 
 describe('replacePlaceholders - Security Tests', () => {

--- a/packages/common/src/expression.ts
+++ b/packages/common/src/expression.ts
@@ -370,6 +370,105 @@ const evaluateAST = (node: AcornNode, context: Record<string, unknown>): unknown
   }
 };
 
+const isValidIdentifier = (s: string): boolean => /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(s);
+
+const toSafeIdentifier = (key: string): string =>
+  '__k_' + key.replace(/[^a-zA-Z0-9_$]/g, (c) => `u${c.charCodeAt(0).toString(16)}`) + '__';
+
+// Rewrites an expression so that hyphenated context keys (e.g. "first-name") that
+// would be misread by Acorn as subtraction are substituted with safe JS identifiers
+// (e.g. "__k_first_u2d_name__"). Uses the Acorn tokenizer so string literals and
+// whitespace-separated operators are never touched.
+const preprocessExpression = (
+  code: string,
+  context: Record<string, unknown>,
+): { processedCode: string; augmentedContext: Record<string, unknown> } => {
+  const nonIdentifierKeys = Object.keys(context).filter(
+    (k) => k.includes('-') && !isValidIdentifier(k),
+  );
+  if (nonIdentifierKeys.length === 0) {
+    return { processedCode: code, augmentedContext: context };
+  }
+
+  type TokenInfo = { label: string; value: unknown; start: number; end: number };
+  const tokens: TokenInfo[] = [];
+  try {
+    for (const tok of acorn.tokenizer(code, { ecmaVersion: 'latest' })) {
+      tokens.push({ label: tok.type.label, value: tok.value, start: tok.start, end: tok.end });
+    }
+  } catch {
+    return { processedCode: code, augmentedContext: context };
+  }
+
+  const substitutions: Array<{ start: number; end: number; safeKey: string; origKey: string }> = [];
+  let i = 0;
+
+  while (i < tokens.length) {
+    const tok = tokens[i];
+    if (tok.label === 'name') {
+      // Extend into a hyphen chain: ident(-ident)+ where each '-' is adjacent
+      const parts: string[] = [tok.value as string];
+      let j = i + 1;
+      while (
+        j < tokens.length - 1 &&
+        tokens[j].label === '+/-' &&
+        tokens[j].value === '-' &&
+        tokens[j].start === tokens[j - 1].end &&
+        tokens[j + 1].label === 'name' &&
+        tokens[j + 1].start === tokens[j].end
+      ) {
+        parts.push(tokens[j + 1].value as string);
+        j += 2;
+      }
+
+      if (parts.length > 1) {
+        // Pick the longest prefix of the chain that is a context key
+        let found = false;
+        for (let len = parts.length; len >= 2; len--) {
+          const candidateKey = parts.slice(0, len).join('-');
+          if (Object.prototype.hasOwnProperty.call(context, candidateKey)) {
+            const lastTokenIdx = i + 2 * (len - 1);
+            const safeKey = toSafeIdentifier(candidateKey);
+            substitutions.push({
+              start: tok.start,
+              end: tokens[lastTokenIdx].end,
+              safeKey,
+              origKey: candidateKey,
+            });
+            i = lastTokenIdx + 1;
+            found = true;
+            break;
+          }
+        }
+        if (!found) i++;
+      } else {
+        i++;
+      }
+    } else {
+      i++;
+    }
+  }
+
+  if (substitutions.length === 0) {
+    return { processedCode: code, augmentedContext: context };
+  }
+
+  let processedCode = '';
+  let pos = 0;
+  for (const { start, end, safeKey } of substitutions) {
+    processedCode += code.slice(pos, start) + safeKey;
+    pos = end;
+  }
+  processedCode += code.slice(pos);
+
+  const augmentedContext = { ...context };
+  for (const { safeKey, origKey } of substitutions) {
+    augmentedContext[safeKey] = context[origKey];
+  }
+
+  return { processedCode, augmentedContext };
+};
+
 const evaluatePlaceholders = (arg: {
   content: string;
   context: Record<string, unknown>;
@@ -402,32 +501,36 @@ const evaluatePlaceholders = (arg: {
     if (braceCount === 0) {
       const code = content.slice(startIndex + 1, endIndex - 1).trim();
 
-      // Fast-path: if `code` is a literal key in the context (e.g. "field-name"),
-      // return the value directly without running it through the JavaScript parser.
-      // This handles field names that contain characters that are not valid JS
-      // identifier characters (hyphens, spaces, dots, etc.) and would otherwise be
-      // mis-parsed as expressions (e.g. `field-name` parsed as subtraction).
+      // Fast-path: whole placeholder is a literal context key (handles non-identifier
+      // names like "field-name" without tokenisation).
       if (Object.prototype.hasOwnProperty.call(context, code)) {
         resultContent += String(context[code]);
         index = endIndex;
         continue;
       }
 
-      if (expressionCache.has(code)) {
-        const evalFunc = expressionCache.get(code)!;
+      // Rewrite any hyphenated context keys embedded in a compound expression
+      // (e.g. "{first-name + ' ' + last-name}") into safe JS identifiers before
+      // handing the code to Acorn, which would otherwise mis-parse the hyphens.
+      const { processedCode, augmentedContext } = preprocessExpression(code, context);
+
+      if (expressionCache.has(processedCode)) {
+        const evalFunc = expressionCache.get(processedCode)!;
         try {
-          const value = evalFunc(context);
+          const value = evalFunc(augmentedContext);
           resultContent += String(value);
         } catch {
           resultContent += content.slice(startIndex, endIndex);
         }
       } else {
         try {
-          const ast = acorn.parseExpressionAt(code, 0, { ecmaVersion: 'latest' }) as AcornNode;
+          const ast = acorn.parseExpressionAt(processedCode, 0, {
+            ecmaVersion: 'latest',
+          }) as AcornNode;
           validateAST(ast);
           const evalFunc = (ctx: Record<string, unknown>) => evaluateAST(ast, ctx);
-          expressionCache.set(code, evalFunc);
-          const value = evalFunc(context);
+          expressionCache.set(processedCode, evalFunc);
+          const value = evalFunc(augmentedContext);
           resultContent += String(value);
         } catch {
           resultContent += content.slice(startIndex, endIndex);

--- a/packages/common/src/expression.ts
+++ b/packages/common/src/expression.ts
@@ -372,13 +372,16 @@ const evaluateAST = (node: AcornNode, context: Record<string, unknown>): unknown
 
 const isValidIdentifier = (s: string): boolean => /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(s);
 
-const toSafeIdentifier = (key: string): string =>
-  '__k_' + key.replace(/[^a-zA-Z0-9_$]/g, (c) => `u${c.charCodeAt(0).toString(16)}`) + '__';
+// Matches context key names that look like hyphenated identifiers (e.g. "first-name", "a-b-c").
+// Used to scope the fast-path to the exact case it was designed for: Acorn would otherwise
+// mis-parse these as subtraction.
+const isHyphenatedIdentifier = (s: string): boolean =>
+  /^[a-zA-Z_$][a-zA-Z0-9_$]*(-[a-zA-Z_$][a-zA-Z0-9_$]*)+$/.test(s);
 
 // Rewrites an expression so that hyphenated context keys (e.g. "first-name") that
-// would be misread by Acorn as subtraction are substituted with safe JS identifiers
-// (e.g. "__k_first_u2d_name__"). Uses the Acorn tokenizer so string literals and
-// whitespace-separated operators are never touched.
+// would be misread by Acorn as subtraction are substituted with safe JS identifiers.
+// Uses sequential indices (__pdfme_hk_0__, __pdfme_hk_1__, …) so the mapping is
+// guaranteed collision-free regardless of the original key's content.
 const preprocessExpression = (
   code: string,
   context: Record<string, unknown>,
@@ -391,15 +394,21 @@ const preprocessExpression = (
   }
 
   type TokenInfo = { label: string; value: unknown; start: number; end: number };
+  // acorn's TS declaration omits the runtime `value` field on Token
+  type AcornTokenWithValue = { type: { label: string }; value: unknown; start: number; end: number };
   const tokens: TokenInfo[] = [];
   try {
     for (const tok of acorn.tokenizer(code, { ecmaVersion: 'latest' })) {
-      tokens.push({ label: tok.type.label, value: tok.value, start: tok.start, end: tok.end });
+      const t = tok as unknown as AcornTokenWithValue;
+      tokens.push({ label: t.type.label, value: t.value, start: t.start, end: t.end });
     }
   } catch {
     return { processedCode: code, augmentedContext: context };
   }
 
+  // Assign a stable safe identifier to each unique original key encountered
+  // in this expression, in left-to-right order of first appearance.
+  const keyToSafeId = new Map<string, string>();
   const substitutions: Array<{ start: number; end: number; safeKey: string; origKey: string }> = [];
   let i = 0;
 
@@ -428,7 +437,10 @@ const preprocessExpression = (
           const candidateKey = parts.slice(0, len).join('-');
           if (Object.prototype.hasOwnProperty.call(context, candidateKey)) {
             const lastTokenIdx = i + 2 * (len - 1);
-            const safeKey = toSafeIdentifier(candidateKey);
+            if (!keyToSafeId.has(candidateKey)) {
+              keyToSafeId.set(candidateKey, `__pdfme_hk_${keyToSafeId.size}__`);
+            }
+            const safeKey = keyToSafeId.get(candidateKey)!;
             substitutions.push({
               start: tok.start,
               end: tokens[lastTokenIdx].end,
@@ -462,7 +474,7 @@ const preprocessExpression = (
   processedCode += code.slice(pos);
 
   const augmentedContext = { ...context };
-  for (const { safeKey, origKey } of substitutions) {
+  for (const [origKey, safeKey] of keyToSafeId) {
     augmentedContext[safeKey] = context[origKey];
   }
 
@@ -501,9 +513,10 @@ const evaluatePlaceholders = (arg: {
     if (braceCount === 0) {
       const code = content.slice(startIndex + 1, endIndex - 1).trim();
 
-      // Fast-path: whole placeholder is a literal context key (handles non-identifier
-      // names like "field-name" without tokenisation).
-      if (Object.prototype.hasOwnProperty.call(context, code)) {
+      // Fast-path: whole placeholder is a hyphenated-identifier context key (e.g. "field-name").
+      // Scoped to that exact pattern so expression-like keys (e.g. "1+1") still evaluate as
+      // expressions; valid JS identifiers resolve through the Acorn path as usual.
+      if (isHyphenatedIdentifier(code) && Object.prototype.hasOwnProperty.call(context, code)) {
         resultContent += String(context[code]);
         index = endIndex;
         continue;

--- a/packages/common/src/expression.ts
+++ b/packages/common/src/expression.ts
@@ -402,6 +402,17 @@ const evaluatePlaceholders = (arg: {
     if (braceCount === 0) {
       const code = content.slice(startIndex + 1, endIndex - 1).trim();
 
+      // Fast-path: if `code` is a literal key in the context (e.g. "field-name"),
+      // return the value directly without running it through the JavaScript parser.
+      // This handles field names that contain characters that are not valid JS
+      // identifier characters (hyphens, spaces, dots, etc.) and would otherwise be
+      // mis-parsed as expressions (e.g. `field-name` parsed as subtraction).
+      if (Object.prototype.hasOwnProperty.call(context, code)) {
+        resultContent += String(context[code]);
+        index = endIndex;
+        continue;
+      }
+
       if (expressionCache.has(code)) {
         const evalFunc = expressionCache.get(code)!;
         try {


### PR DESCRIPTION
## Problem

Template expressions that reference field names containing hyphens (e.g. `{my-field}` or `{first-name + " " + last-name}`) were silently broken.

**Root cause:** The expression evaluator in `packages/common/src/expression.ts` passes the inner content of every `{…}` placeholder to Acorn for JavaScript AST parsing. Since a hyphen is not a valid identifier character in JavaScript, Acorn parses `field-name` as a *subtraction expression* (`field − name`) rather than an identifier. When evaluation then tries to resolve `field` and `name` as separate context keys, neither exists (the real key is `field-name`), so the placeholder is left unreplaced in the output.

**Silent-corruption variant:** If the context happens to contain numeric fields named `field` and `name`, the expression evaluates as arithmetic subtraction and produces a number instead of the intended field value.

**Compound expressions** (e.g. `{first-name + " " + last-name}`) were completely unsupported: even with the simple key look-up fix, any expression that *combined* a hyphenated name with an operator still fell through to the Acorn parser, which mis-parsed the hyphen.

## Fix

### Whole-placeholder fast-path

When the entire placeholder is a literal context key (e.g. `{my-field}`), the value is returned directly before Acorn is ever invoked. This handles the common case with zero tokenisation overhead.

### Tokenizer-based preprocessing for compound expressions

For expressions that *use* a hyphenated key alongside operators (e.g. `{first-name + " " + last-name}`), a preprocessing step runs the Acorn tokenizer over the expression and finds adjacent identifier-hyphen-identifier chains whose concatenated form is a known context key. Each matching span is rewritten to a safe JS identifier (`__k_first_u2d_name__`) and a corresponding entry is added to the evaluation context. Acorn then parses the clean expression normally.

Using the tokenizer (rather than naive string replacement) means string literals and whitespace-separated operators are never touched — `{name + "-suffix"}` and `{a - b}` remain correct.

**Disambiguation rule:** `{a-b}` resolves to the field named `a-b` if that key exists in context. To force arithmetic subtraction, use whitespace: `{a - b}`.

## Examples

```
// Template field content: "Hello, {first-name}!"
// Input variables: { "first-name": "Alice" }
// → "Hello, Alice!"

// Template field content: "{first-name + " " + last-name}"
// Input variables: { "first-name": "John", "last-name": "Doe" }
// → "John Doe"

// Template field content: "{nick-name || first-name}"
// Input variables: { "nick-name": "", "first-name": "Alice" }
// → "Alice"

// Template field content: "{is-active ? "yes" : "no"}"
// Input variables: { "is-active": true }
// → "yes"
```

## Test plan

- [x] Standalone hyphenated field: `{field-name}` → field value
- [x] Multiple standalone hyphenated fields in one template
- [x] Whitespace inside braces: `{ field-name }` (trimming still works)
- [x] Schema source for hyphenated names
- [x] Compound: string concatenation `{first-name + " " + last-name}`
- [x] Compound: arithmetic `{count-down + 1}`
- [x] Compound: logical OR fallback `{nick-name || first-name}`
- [x] Compound: ternary `{is-active ? "yes" : "no"}`
- [x] String literal with hyphen not corrupted: `{first-name + "-" + last-name}` → `"John-Doe"`
- [x] Disambiguation: `{a-b}` with key `a-b` resolves to the key, not subtraction
- [x] Disambiguation: `{a - b}` (spaced) evaluates as subtraction even when `a-b` exists in context
- [x] Regression: `{a-b}` with separate `a` and `b` keys (no `a-b` key) still subtracts
- [x] Regression: `{1 + 2}` → `3`
- [x] Regression: `{Math.max(1,2,3)}` → `3`
- [x] All existing expression tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)