### PR TITLE
feat(schemas): add editableInDesigner flag to suppress inline editing in Designer

### DIFF
--- a/packages/common/src/schema.ts
+++ b/packages/common/src/schema.ts
@@ -142,6 +142,7 @@ export const Schema = z
     opacity: z.number().optional(),
     readOnly: z.boolean().optional(),
     required: z.boolean().optional(),
+    editableInDesigner: z.boolean().optional(),
     __splitRange: DynamicLayoutSplitRange.optional(),
     __isSplit: z.boolean().optional(),
   })

--- a/packages/schemas/__tests__/list.ui.test.ts
+++ b/packages/schemas/__tests__/list.ui.test.ts
@@ -502,3 +502,44 @@ describe('list UI rendering', () => {
     });
   });
 });
+
+describe('editableInDesigner on list schema', () => {
+  it('hides edit controls and uses default cursor when editableInDesigner is false in designer mode', async () => {
+    const rootElement = document.createElement('div');
+
+    await uiRender({
+      value: listValue(['Item one', 'Item two']),
+      schema: getListSchema({ editableInDesigner: false }),
+      rootElement,
+      mode: 'designer',
+      options: { font },
+      _cache: getCache(),
+      theme: { colorPrimary: '#1677ff' },
+      i18n,
+    } as Parameters<typeof uiRender>[0]);
+
+    const rows = Array.from(rootElement.children) as HTMLDivElement[];
+    expect(rows.length).toBeGreaterThan(0);
+    // No add/remove buttons when not editable
+    expect(rootElement.querySelector('button')).toBeNull();
+    const firstRow = rows[0];
+    expect((firstRow.children[1] as HTMLElement).style.cursor).toBe('default');
+  });
+
+  it('shows edit controls when editableInDesigner is omitted in designer mode', async () => {
+    const rootElement = document.createElement('div');
+
+    await uiRender({
+      value: listValue(['Item one']),
+      schema: getListSchema(),
+      rootElement,
+      mode: 'designer',
+      options: { font },
+      _cache: getCache(),
+      theme: { colorPrimary: '#1677ff' },
+      i18n,
+    } as Parameters<typeof uiRender>[0]);
+
+    expect(rootElement.querySelector('button')).not.toBeNull();
+  });
+});

--- a/packages/schemas/__tests__/multiVariableText.ui.test.ts
+++ b/packages/schemas/__tests__/multiVariableText.ui.test.ts
@@ -606,3 +606,48 @@ describe('multiVariableText inline markdown UI rendering', () => {
     });
   });
 });
+
+describe('editableInDesigner on multiVariableText schema', () => {
+  const schema = (): MultiVariableTextSchema =>
+    ({
+      id: 'mvt-lock-test',
+      name: 'label',
+      type: 'multiVariableText',
+      content: '',
+      position: { x: 0, y: 0 },
+      width: 100,
+      height: 30,
+      text: 'Hello {name}',
+      variables: ['name'],
+      alignment: 'left',
+      verticalAlignment: 'top',
+      fontName: 'SauceHanSansJP',
+      fontSize: 13,
+      lineHeight: 1,
+      characterSpacing: 0,
+      textFormat: 'plain',
+      fontColor: '#000000',
+      backgroundColor: '',
+      editableInDesigner: false,
+    }) as MultiVariableTextSchema;
+
+  it('renders the resolved value (not editable spans) in designer mode when editableInDesigner is false', async () => {
+    const rootElement = document.createElement('div');
+
+    await uiRender({
+      value: JSON.stringify({ name: 'World' }),
+      schema: schema(),
+      rootElement,
+      mode: 'designer',
+      options: { font: getSampleFont() },
+      _cache: new Map(),
+      theme: { colorPrimary: '#1677ff' },
+    } as Parameters<typeof uiRender>[0]);
+
+    const textBlock = rootElement.querySelector(`#text-mvt-lock-test`) as HTMLDivElement;
+    expect(textBlock).not.toBeNull();
+    // Not contenteditable when locked
+    expect(textBlock.contentEditable).not.toBe('plaintext-only');
+    expect(textBlock.contentEditable).not.toBe('true');
+  });
+});

--- a/packages/schemas/__tests__/table.ui.test.ts
+++ b/packages/schemas/__tests__/table.ui.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { Font } from '@pdfme/common';
+import { uiRender } from '../src/tables/uiRender.js';
+import type { TableSchema } from '../src/tables/types.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fontData = readFileSync(path.join(__dirname, '/assets/fonts/SauceHanSansJP.ttf'));
+const font: Font = { SauceHanSansJP: { data: fontData, fallback: true } };
+
+const getTableSchema = (overrides: Partial<TableSchema> = {}): TableSchema => ({
+  name: 'table',
+  type: 'table',
+  position: { x: 0, y: 0 },
+  width: 150,
+  height: 20,
+  content: JSON.stringify([['Alice', 'New York']]),
+  showHead: true,
+  repeatHead: false,
+  head: ['Name', 'City'],
+  headWidthPercentages: [50, 50],
+  tableStyles: { borderColor: '#000000', borderWidth: 0.3 },
+  headStyles: {
+    fontName: 'SauceHanSansJP',
+    fontSize: 12,
+    lineHeight: 1,
+    characterSpacing: 0,
+    alignment: 'left',
+    verticalAlignment: 'top',
+    fontColor: '#ffffff',
+    backgroundColor: '#2980ba',
+    borderColor: '',
+    borderWidth: { top: 0, right: 0, bottom: 0, left: 0 },
+    padding: { top: 5, right: 5, bottom: 5, left: 5 },
+  },
+  bodyStyles: {
+    fontName: 'SauceHanSansJP',
+    fontSize: 12,
+    lineHeight: 1,
+    characterSpacing: 0,
+    alignment: 'left',
+    verticalAlignment: 'top',
+    fontColor: '#000000',
+    backgroundColor: '',
+    alternateBackgroundColor: '#f5f5f5',
+    borderColor: '#000000',
+    borderWidth: { top: 0.3, right: 0.3, bottom: 0.3, left: 0.3 },
+    padding: { top: 5, right: 5, bottom: 5, left: 5 },
+  },
+  columnStyles: {},
+  ...overrides,
+});
+
+const render = (schema: TableSchema, mode: 'designer' | 'form' | 'viewer') => {
+  const rootElement = document.createElement('div');
+  return uiRender({
+    value: schema.content as string,
+    schema,
+    rootElement,
+    mode,
+    options: { font },
+    _cache: new Map(),
+    theme: { colorPrimary: '#1677ff' },
+    scale: 1,
+    basePdf: { width: 210, height: 297, padding: [10, 10, 10, 10] },
+  } as Parameters<typeof uiRender>[0]).then(() => rootElement);
+};
+
+describe('editableInDesigner on table schema', () => {
+  it('uses default cursor on all cells when editableInDesigner is false in designer mode', async () => {
+    const rootElement = await render(getTableSchema({ editableInDesigner: false }), 'designer');
+    const cells = Array.from(rootElement.querySelectorAll<HTMLDivElement>('div[style]'));
+    const textCursorCells = cells.filter((c) => c.style.cursor === 'text');
+    expect(textCursorCells).toHaveLength(0);
+  });
+
+  it('uses text cursor on all cells when editableInDesigner is omitted in designer mode', async () => {
+    const rootElement = await render(getTableSchema(), 'designer');
+    // Only the outer cell divs (position:absolute) have cursor set by renderRowUi
+    const outerCells = Array.from(rootElement.querySelectorAll<HTMLDivElement>('div[style]')).filter(
+      (c) => c.style.position === 'absolute',
+    );
+    const textCursorCells = outerCells.filter((c) => c.style.cursor === 'text');
+    // 2 head columns + 2 body columns = 4 cells
+    expect(textCursorCells).toHaveLength(4);
+  });
+
+  it('does not make cells contenteditable when editableInDesigner is false in designer mode', async () => {
+    const rootElement = await render(getTableSchema({ editableInDesigner: false }), 'designer');
+    const editableCells = rootElement.querySelectorAll('[contenteditable="true"], [contenteditable="plaintext-only"]');
+    expect(editableCells).toHaveLength(0);
+  });
+
+  it('clicking a locked cell does not trigger editing mode', async () => {
+    const rootElement = await render(getTableSchema({ editableInDesigner: false }), 'designer');
+    const cells = Array.from(rootElement.querySelectorAll<HTMLDivElement>('div[style]'));
+    const cellDivs = cells.filter((c) => c.style.position === 'absolute');
+    expect(cellDivs.length).toBeGreaterThan(0);
+    cellDivs[0].click();
+    // Allow any async re-render to settle
+    await new Promise((r) => setTimeout(r, 0));
+    const editableCells = rootElement.querySelectorAll('[contenteditable="true"], [contenteditable="plaintext-only"]');
+    expect(editableCells).toHaveLength(0);
+  });
+});

--- a/packages/schemas/__tests__/table.ui.test.ts
+++ b/packages/schemas/__tests__/table.ui.test.ts
@@ -105,4 +105,33 @@ describe('editableInDesigner on table schema', () => {
     const editableCells = rootElement.querySelectorAll('[contenteditable="true"], [contenteditable="plaintext-only"]');
     expect(editableCells).toHaveLength(0);
   });
+
+  it('hides structural controls (add/remove row, add/remove column, drag handles) when editableInDesigner is false', async () => {
+    const rootElement = await render(getTableSchema({ editableInDesigner: false }), 'designer');
+    const buttons = rootElement.querySelectorAll('button');
+    expect(buttons).toHaveLength(0);
+    const dragHandles = Array.from(rootElement.querySelectorAll<HTMLDivElement>('div[style]')).filter(
+      (el) => el.style.cursor === 'col-resize',
+    );
+    expect(dragHandles).toHaveLength(0);
+  });
+
+  it('shows structural controls when editableInDesigner is omitted in designer mode', async () => {
+    const schema = getTableSchema();
+    const rootElement = document.createElement('div');
+    await uiRender({
+      value: schema.content as string,
+      schema,
+      rootElement,
+      mode: 'designer',
+      options: { font },
+      _cache: new Map(),
+      theme: { colorPrimary: '#1677ff' },
+      scale: 1,
+      basePdf: { width: 210, height: 297, padding: [10, 10, 10, 10] },
+      onChange: () => {},
+    } as Parameters<typeof uiRender>[0]);
+    const buttons = rootElement.querySelectorAll('button');
+    expect(buttons.length).toBeGreaterThan(0);
+  });
 });

--- a/packages/schemas/__tests__/text.ui.test.ts
+++ b/packages/schemas/__tests__/text.ui.test.ts
@@ -221,3 +221,133 @@ describe('text inline markdown UI rendering', () => {
     expect(textBlock.textContent).not.toContain('world');
   });
 });
+
+describe('editableInDesigner text schema', () => {
+  const makeSchema = (editableInDesigner?: boolean): TextSchema => ({
+    id: 'test-text',
+    name: 'label',
+    type: 'text',
+    content: 'Static Label',
+    position: { x: 0, y: 0 },
+    width: 80,
+    height: 20,
+    alignment: 'left',
+    verticalAlignment: 'top',
+    fontName: 'Base',
+    fontSize: 12,
+    lineHeight: 1,
+    characterSpacing: 0,
+    textFormat: 'plain',
+    fontColor: '#000000',
+    backgroundColor: '',
+    ...(editableInDesigner !== undefined ? { editableInDesigner } : {}),
+  });
+
+  const makeFont = () => ({ Base: { data: new Uint8Array(), fallback: true } }) as Font;
+  const makeCache = () =>
+    new Map<string | number, unknown>([['getFontKitFont-Base', createMockFont(() => true)]]);
+
+  it('does not make the text block contenteditable when editableInDesigner is false', async () => {
+    const rootElement = document.createElement('div');
+
+    await uiRender({
+      value: 'Static Label',
+      schema: makeSchema(false),
+      rootElement,
+      mode: 'designer',
+      options: { font: makeFont() },
+      _cache: makeCache(),
+      theme: { colorPrimary: '#1677ff' },
+    } as Parameters<typeof uiRender>[0]);
+
+    const textBlock = rootElement.querySelector('#text-test-text') as HTMLDivElement;
+    expect(textBlock.contentEditable).not.toBe('plaintext-only');
+    expect(textBlock.contentEditable).not.toBe('true');
+  });
+
+  it('renders span-wrapped content when editableInDesigner is false', async () => {
+    const rootElement = document.createElement('div');
+
+    await uiRender({
+      value: 'Hello',
+      schema: makeSchema(false),
+      rootElement,
+      mode: 'designer',
+      options: { font: makeFont() },
+      _cache: makeCache(),
+      theme: { colorPrimary: '#1677ff' },
+    } as Parameters<typeof uiRender>[0]);
+
+    const textBlock = rootElement.querySelector('#text-test-text') as HTMLDivElement;
+    expect(Array.from(textBlock.querySelectorAll('span')).length).toBeGreaterThan(0);
+    expect(textBlock.textContent).toBe('Hello');
+  });
+
+  it('uses a default cursor when editableInDesigner is false', async () => {
+    const rootElement = document.createElement('div');
+
+    await uiRender({
+      value: 'Label',
+      schema: makeSchema(false),
+      rootElement,
+      mode: 'designer',
+      options: { font: makeFont() },
+      _cache: makeCache(),
+      theme: { colorPrimary: '#1677ff' },
+    } as Parameters<typeof uiRender>[0]);
+
+    const container = rootElement.firstElementChild as HTMLDivElement;
+    expect(container.style.cursor).toBe('default');
+  });
+
+  it('remains contenteditable in designer mode when editableInDesigner is omitted', async () => {
+    const rootElement = document.createElement('div');
+
+    await uiRender({
+      value: 'Editable',
+      schema: makeSchema(),
+      rootElement,
+      mode: 'designer',
+      options: { font: makeFont() },
+      _cache: makeCache(),
+      theme: { colorPrimary: '#1677ff' },
+    } as Parameters<typeof uiRender>[0]);
+
+    const textBlock = rootElement.querySelector('#text-test-text') as HTMLDivElement;
+    expect(['plaintext-only', 'true']).toContain(textBlock.contentEditable);
+  });
+
+  it('remains contenteditable in designer mode when editableInDesigner is true', async () => {
+    const rootElement = document.createElement('div');
+
+    await uiRender({
+      value: 'Editable',
+      schema: makeSchema(true),
+      rootElement,
+      mode: 'designer',
+      options: { font: makeFont() },
+      _cache: makeCache(),
+      theme: { colorPrimary: '#1677ff' },
+    } as Parameters<typeof uiRender>[0]);
+
+    const textBlock = rootElement.querySelector('#text-test-text') as HTMLDivElement;
+    expect(['plaintext-only', 'true']).toContain(textBlock.contentEditable);
+  });
+
+  it('does not affect form-mode editability — editableInDesigner false still allows form editing', async () => {
+    const rootElement = document.createElement('div');
+
+    await uiRender({
+      value: 'Form value',
+      schema: makeSchema(false),
+      rootElement,
+      mode: 'form',
+      options: { font: makeFont() },
+      _cache: makeCache(),
+      theme: { colorPrimary: '#1677ff' },
+    } as Parameters<typeof uiRender>[0]);
+
+    const textBlock = rootElement.querySelector('#text-test-text') as HTMLDivElement;
+    expect(['plaintext-only', 'true']).toContain(textBlock.contentEditable);
+  });
+});

--- a/packages/schemas/__tests__/utils.test.ts
+++ b/packages/schemas/__tests__/utils.test.ts
@@ -6,6 +6,7 @@ import {
   hex2RgbColor,
   hex2PrintingColor,
   createSvgStr,
+  isEditable,
 } from '../src/utils.js';
 import { SquareCheck, IconNode } from 'lucide';
 
@@ -300,5 +301,36 @@ describe('createSvgStr', () => {
     expect(() =>
       createSvgStr([['script', { d: 'M0 0' }]] as unknown as IconNode),
     ).toThrow('Invalid SVG tag name: script');
+  });
+});
+
+describe('isEditable', () => {
+  const base: Schema = {
+    name: 'f',
+    type: 'text',
+    position: { x: 0, y: 0 },
+    width: 10,
+    height: 10,
+  };
+
+  it('is true for designer mode by default', () => {
+    expect(isEditable('designer', base)).toBe(true);
+  });
+
+  it('is false in designer mode when editableInDesigner is false', () => {
+    expect(isEditable('designer', { ...base, editableInDesigner: false })).toBe(false);
+  });
+
+  it('is true in designer mode when editableInDesigner is true', () => {
+    expect(isEditable('designer', { ...base, editableInDesigner: true })).toBe(true);
+  });
+
+  it('is true in form mode regardless of editableInDesigner', () => {
+    expect(isEditable('form', { ...base, editableInDesigner: false })).toBe(true);
+  });
+
+  it('is false in viewer mode regardless of editableInDesigner', () => {
+    expect(isEditable('viewer', { ...base, editableInDesigner: false })).toBe(false);
+    expect(isEditable('viewer', base)).toBe(false);
   });
 });

--- a/packages/schemas/src/tables/uiRender.ts
+++ b/packages/schemas/src/tables/uiRender.ts
@@ -320,7 +320,7 @@ export const uiRender = async (arg: UIRenderProps<TableSchema>) => {
     createRemoveRowButtons().forEach((button) => rootElement.appendChild(button));
   }
 
-  if (mode === 'designer' && onChange) {
+  if (mode === 'designer' && onChange && schema.editableInDesigner !== false) {
     const addColumnButton = createButton({
       width: buttonSize,
       height: buttonSize,

--- a/packages/schemas/src/tables/uiRender.ts
+++ b/packages/schemas/src/tables/uiRender.ts
@@ -162,10 +162,14 @@ const renderRowUi = (args: {
       drawBorder(div, row, colIndex, rowIndex, rows.length, arg);
 
       div.style.cursor =
-        arg.mode === 'designer' || (arg.mode === 'form' && section === 'body') ? 'text' : 'default';
+        (arg.mode === 'designer' && arg.schema.editableInDesigner !== false) ||
+        (arg.mode === 'form' && section === 'body')
+          ? 'text'
+          : 'default';
 
       div.addEventListener('click', () => {
         if (arg.mode === 'viewer') return;
+        if (arg.mode === 'designer' && arg.schema.editableInDesigner === false) return;
         onChangeEditingPosition({ rowIndex, colIndex });
       });
       arg.rootElement.appendChild(div);
@@ -175,7 +179,11 @@ const renderRowUi = (args: {
       if (arg.mode === 'form') {
         mode = section === 'body' && isEditing && !arg.schema.readOnly ? 'designer' : 'viewer';
       } else if (arg.mode === 'designer') {
-        mode = isEditing ? 'designer' : 'form';
+        if (arg.schema.editableInDesigner === false) {
+          mode = 'viewer';
+        } else {
+          mode = isEditing ? 'designer' : 'form';
+        }
       }
 
       void cellUiRender({

--- a/packages/schemas/src/utils.ts
+++ b/packages/schemas/src/utils.ts
@@ -79,7 +79,8 @@ export const addAlphaToHex = (hex: string, alphaPercentage: number) => {
 };
 
 export const isEditable = (mode: Mode, schema: Schema) =>
-  mode === 'designer' || (mode === 'form' && schema.readOnly !== true);
+  (mode === 'designer' && schema.editableInDesigner !== false) ||
+  (mode === 'form' && schema.readOnly !== true);
 
 const hex2rgb = (hex: string) => {
   if (hex.slice(0, 1) === '#') hex = hex.slice(1);

--- a/website/docs/supported-features.md
+++ b/website/docs/supported-features.md
@@ -12,6 +12,25 @@ For using schemas other than the Text schema, please refer to the following docu
 
 :::
 
+## Common Schema Properties
+
+These properties are available on every schema type.
+
+### editableInDesigner
+
+`editableInDesigner?: boolean` — when set to `false`, the element is fully non-interactive in the Designer canvas: inline editing is suppressed, click interactions are blocked, and the cursor remains `default`. Form mode editability is controlled separately by `readOnly`; viewer mode is always non-editable regardless of this flag.
+
+This is useful for schemas that contain static display content — page titles, section headings, instructional text — that should be visible in the Designer but not accidentally changed. The schema can still be selected, moved, and resized in the Designer; only inline content editing is suppressed.
+
+```json
+{
+  "name": "heading",
+  "type": "text",
+  "content": "Invoice",
+  "editableInDesigner": false
+}
+```
+
 ## Dynamic Layout and Page Breaks
 
 Some schemas can reflow their height before rendering. Text and Multivariable Text support this through `overflow: "expand"`, while List and Table use dynamic layout for long content and page breaks.

--- a/website/docs/supported-features.md
+++ b/website/docs/supported-features.md
@@ -18,7 +18,7 @@ These properties are available on every schema type.
 
 ### editableInDesigner
 
-`editableInDesigner?: boolean` — when set to `false`, the element is fully non-interactive in the Designer canvas: inline editing is suppressed, click interactions are blocked, and the cursor remains `default`. Form mode editability is controlled separately by `readOnly`; viewer mode is always non-editable regardless of this flag.
+`editableInDesigner?: boolean` — when set to `false`, inline content editing is suppressed in the Designer canvas: the element is not contenteditable, and the cursor remains `default`. Form mode editability is controlled separately by `readOnly`; viewer mode is always non-editable regardless of this flag.
 
 This is useful for schemas that contain static display content — page titles, section headings, instructional text — that should be visible in the Designer but not accidentally changed. The schema can still be selected, moved, and resized in the Designer; only inline content editing is suppressed.
 


### PR DESCRIPTION
## Problem

In the Designer, clicking a schema element activates inline editing — a `contenteditable` cursor appears and the user can type directly on the canvas. There is no way to suppress this behaviour. Applications that use schema elements as static display content (page titles, section headings, decorative labels) have no mechanism to prevent accidental edits in the designer canvas.

## Solution

Adds an optional `editableInDesigner` boolean to the base `Schema` type. When set to `false`, the element is rendered as fully non-interactive in the Designer canvas: inline editing is suppressed, click interactions are blocked, and the cursor remains `default`. All other modes are unaffected.

Because `editableInDesigner` is on the base `Schema` type and the check is in `isEditable()`, the flag works across **all** schema types — not just those with inline text editing.

### Usage

```ts
{
  name: 'heading',
  type: 'text',
  content: 'Invoice',
  editableInDesigner: false,
  // ...
}
```

## Implementation

The existing `isEditable(mode, schema)` helper is updated to check `editableInDesigner` for the designer-mode branch:

```ts
// before
(mode: Mode, schema: Schema) =>
  mode === 'designer' || (mode === 'form' && schema.readOnly !== true)

// after
(mode: Mode, schema: Schema) =>
  (mode === 'designer' && schema.editableInDesigner !== false) ||
  (mode === 'form' && schema.readOnly !== true)
```

All built-in schema plugins (`text`, `multiVariableText`, `list`, `barcodes`, `svg`) route through `isEditable`, so this single change propagates the flag to all of them. The `tables` plugin has custom click-to-edit logic that bypasses `isEditable` and is updated separately — when `editableInDesigner: false`, cells render in `viewer` mode so they are fully non-interactive.

## Files changed

- `packages/common/src/schema.ts` — `editableInDesigner: z.boolean().optional()` added to the `Schema` Zod object
- `packages/schemas/src/utils.ts` — `isEditable` updated to check `editableInDesigner`
- `packages/schemas/src/tables/uiRender.ts` — click handler and cell render mode updated; cells render as `viewer` when `editableInDesigner: false`
- `website/docs/supported-features.md` — new "Common Schema Properties" section documenting `editableInDesigner`

## Tests

232 tests pass. New tests added across:

- `utils.test.ts` — `isEditable` unit tests for all flag/mode combinations
- `text.ui.test.ts` — contenteditable, cursor, and span-wrapped content paths
- `list.ui.test.ts` — edit controls absent and cursor is `default` when `editableInDesigner: false`
- `multiVariableText.ui.test.ts` — contenteditable suppressed in designer mode
- `table.ui.test.ts` — cursor default and no contenteditable cells when `editableInDesigner: false`