### PR TITLE
Apply agent edits to browser project templates

### DIFF
--- a/playground/src/lib/pdfmeAgentHost.ts
+++ b/playground/src/lib/pdfmeAgentHost.ts
@@ -7,7 +7,14 @@ export type PdfmeAgentWorkspaceContext = {
   workspaceRootName?: string | null;
 };
 
+export type PdfmeAgentTemplateUpdate = {
+  baseTemplate?: unknown | null;
+  template: unknown;
+  title?: string | null;
+};
+
 export type PdfmeAgentHost = {
+  applyTemplateUpdate?: (input: PdfmeAgentTemplateUpdate) => Promise<void> | void;
   getCurrentTemplate?: () => unknown | null;
   getCurrentTemplateTitle?: () => string | null;
   getWorkspaceContext?: () => PdfmeAgentWorkspaceContext;

--- a/playground/src/routes/Designer.tsx
+++ b/playground/src/routes/Designer.tsx
@@ -584,8 +584,58 @@ function DesignerApp() {
     });
   }, [applyTemplateFromDisk]);
 
+  const applyAgentTemplateUpdate: PdfmeAgentHost['applyTemplateUpdate'] = useCallback(
+    async ({ baseTemplate, template }) => {
+      if (!designer.current) throw new Error('Designer is not ready');
+
+      const currentProject = projectRef.current;
+      if (currentProject && currentProject.kind !== 'template') {
+        throw new Error('AI edits are currently supported for template browser projects only');
+      }
+
+      checkTemplate(template as Template);
+      const nextTemplate = cloneDeep(template as Template);
+
+      if (
+        baseTemplate &&
+        serializeTemplateForFileWorkspace(designer.current.getTemplate()) !==
+          serializeTemplateForFileWorkspace(baseTemplate as Template)
+      ) {
+        throw new Error(
+          'Template changed while the agent was editing. The AI update was not applied.',
+        );
+      }
+
+      designer.current.updateTemplate(nextTemplate);
+
+      if (!currentProject) {
+        toast.success('AI update applied');
+        return;
+      }
+
+      const thumbnail = await createTemplateThumbnailDataUrl(
+        nextTemplate,
+        currentProject.inputs,
+      ).catch(() => currentProject.thumbnail);
+      const savedProject = savePlaygroundProject({
+        id: currentProject.id,
+        inputs: currentProject.inputs,
+        kind: 'template',
+        source: currentProject.source,
+        template: nextTemplate,
+        thumbnail,
+        title: currentProject.title,
+      });
+      projectRef.current = savedProject;
+      setCurrentProjectTitle(savedProject.title);
+      toast.success('AI update saved to Browser Project');
+    },
+    [setCurrentProjectTitle],
+  );
+
   useEffect(() => {
     const host: PdfmeAgentHost = {
+      applyTemplateUpdate: applyAgentTemplateUpdate,
       getCurrentTemplate: () => designer.current?.getTemplate() ?? null,
       getCurrentTemplateTitle: () => projectTitleRef.current,
       getWorkspaceContext: () => {
@@ -615,7 +665,7 @@ function DesignerApp() {
       window.pdfmeAgent?.stop?.();
       delete window.pdfmeAgentHost;
     };
-  }, [onRefreshAgentTemplate]);
+  }, [applyAgentTemplateUpdate, onRefreshAgentTemplate]);
 
   useEffect(() => {
     if (!fileWorkspaceConflict) return;


### PR DESCRIPTION
## Summary
- add an applyTemplateUpdate hook to the pdfme Agent host contract
- apply updated templates from the SDK to Designer and save them back to existing Browser Projects
- guard against applying an AI result if the Designer template changed during the agent run
- keep JSX/md2pdf projects out of this edit path for now

Depends on pdfme/pdfme-agent-bridge#2.

## Verification
- npm exec -- tsc -p tsconfig.json --noEmit
- npm run lint