### PR TITLE
[codex] simplify pdfme Agent host contract

### DIFF
--- a/playground/src/lib/pdfmeAgentHost.ts
+++ b/playground/src/lib/pdfmeAgentHost.ts
@@ -1,10 +1,8 @@
 export const PDFME_AGENT_HOST_READY_EVENT = 'pdfme-agent-host-ready';
 export const PDFME_AGENT_HOST_DESTROYED_EVENT = 'pdfme-agent-host-destroyed';
 
-export type PdfmeAgentWorkspaceContext = {
+export type PdfmeAgentTemplateContext = {
   templateName?: string | null;
-  templatePath?: string | null;
-  workspaceRootName?: string | null;
 };
 
 export type PdfmeAgentTemplateUpdate = {
@@ -16,9 +14,7 @@ export type PdfmeAgentHost = {
   applyTemplateUpdate?: (input: PdfmeAgentTemplateUpdate) => Promise<void> | void;
   getCurrentTemplate?: () => unknown | null;
   getCurrentTemplateTitle?: () => string | null;
-  getWorkspaceContext?: () => PdfmeAgentWorkspaceContext;
-  navigateToGeneratedTemplate?: (input: { sessionId: string; templateName: string }) => void;
-  refreshTemplate?: () => Promise<void> | void;
+  getTemplateContext?: () => PdfmeAgentTemplateContext;
 };
 
 declare global {

--- a/playground/src/routes/Designer.tsx
+++ b/playground/src/routes/Designer.tsx
@@ -575,17 +575,6 @@ function DesignerApp() {
     }
   };
 
-  const onRefreshAgentTemplate = useCallback(async () => {
-    const currentEntry = fileWorkspaceEntryRef.current;
-    if (!currentEntry) return;
-
-    const readResult = await readTemplateEntry(currentEntry);
-    applyTemplateFromDisk(currentEntry, readResult);
-    toast.info(`Reloaded ${currentEntry.path} from disk`, {
-      toastId: `file-workspace-agent-reload:${currentEntry.path}`,
-    });
-  }, [applyTemplateFromDisk]);
-
   const applyAgentTemplateUpdate: PdfmeAgentHost['applyTemplateUpdate'] = useCallback(
     async ({ baseTemplate, template }) => {
       if (!designer.current) throw new Error('Designer is not ready');
@@ -657,21 +646,12 @@ function DesignerApp() {
       applyTemplateUpdate: applyAgentTemplateUpdate,
       getCurrentTemplate: () => designer.current?.getTemplate() ?? null,
       getCurrentTemplateTitle: () => projectTitleRef.current,
-      getWorkspaceContext: () => {
+      getTemplateContext: () => {
         const currentEntry = fileWorkspaceEntryRef.current;
         return {
           templateName: currentEntry?.name ?? null,
-          templatePath: currentEntry?.path ?? null,
-          workspaceRootName: fileWorkspaceCollectionRef.current?.rootName ?? null,
         };
       },
-      navigateToGeneratedTemplate: ({ sessionId, templateName }) => {
-        const nextUrl = new URL('/designer', window.location.origin);
-        nextUrl.searchParams.set('workspace', templateName);
-        nextUrl.searchParams.set('agentSession', sessionId);
-        window.location.href = `${nextUrl.pathname}${nextUrl.search}`;
-      },
-      refreshTemplate: onRefreshAgentTemplate,
     };
 
     window.pdfmeAgentHost = host;
@@ -684,7 +664,7 @@ function DesignerApp() {
       window.pdfmeAgent?.stop?.();
       delete window.pdfmeAgentHost;
     };
-  }, [applyAgentTemplateUpdate, onRefreshAgentTemplate]);
+  }, [applyAgentTemplateUpdate]);
 
   useEffect(() => {
     if (!fileWorkspaceConflict) return;


### PR DESCRIPTION
## Summary
- Replace the Agent host workspace context with a minimal template context.
- Remove generated-template navigation and refresh callbacks from the Playground host contract.
- Keep Agent edits flowing through getCurrentTemplate and applyTemplateUpdate.

## Impact
- Aligns Playground with the bridge cleanup that removes direct disk workspace mapping.
- Mounted templates and Browser Projects continue to use the same current Designer template update path.

## Review
- Checked for stale direct-disk, workspace root, and /templates/from-pdf references in Playground source.
- No remaining Playground code calls the removed bridge direct-disk APIs.

## Checks
- npx tsc -p tsconfig.json --noEmit
- npm run lint -- src/lib/pdfmeAgentHost.ts src/routes/Designer.tsx
- npm run build
- git diff --check