### PR TITLE
Add Designer selection API

### DIFF
--- a/packages/ui/__tests__/designerSelection.test.ts
+++ b/packages/ui/__tests__/designerSelection.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'vitest';
+import type { SchemaForUI } from '@pdfme/common';
+import {
+  createDesignerSelection,
+  getSelectedSchemaIds,
+} from '../src/designerSelection.js';
+
+const schema = (id: string, name: string, position = { x: 10, y: 20 }): SchemaForUI => ({
+  content: '',
+  height: 6,
+  id,
+  name,
+  position,
+  type: 'text',
+  width: 30,
+});
+
+describe('designer selection helpers', () => {
+  it('creates persisted schema selections with bounds', () => {
+    const selection = createDesignerSelection({
+      activeSchemaIds: ['field-2', 'field-1'],
+      pageIndex: 0,
+      schemasList: [
+        [
+          schema('field-1', 'first', { x: 10, y: 20 }),
+          schema('field-2', 'second', { x: 50, y: 40 }),
+        ],
+      ],
+    });
+
+    assert.deepEqual(
+      selection.schemas.map((item) => ({
+        hasUiId: 'id' in item.schema,
+        name: item.name,
+        schemaIndex: item.schemaIndex,
+      })),
+      [
+        { hasUiId: false, name: 'second', schemaIndex: 1 },
+        { hasUiId: false, name: 'first', schemaIndex: 0 },
+      ],
+    );
+    assert.deepEqual(selection.bounds, { height: 26, width: 70, x: 10, y: 20 });
+  });
+
+  it('selects schemas by id, name, or index on the target page', () => {
+    const schemas = [schema('field-1', 'first'), schema('field-2', 'second')];
+
+    assert.deepEqual(
+      getSelectedSchemaIds({
+        pageIndex: 0,
+        schemas,
+        targets: ['field-1', { name: 'second' }, { pageIndex: 1, schemaIndex: 0 }],
+      }),
+      ['field-1', 'field-2'],
+    );
+  });
+});

--- a/packages/ui/src/Designer.tsx
+++ b/packages/ui/src/Designer.tsx
@@ -11,12 +11,24 @@ import { BaseUIClass } from './class.js';
 import { DESTROYED_ERR_MSG } from './constants.js';
 import DesignerComponent from './components/Designer/index.js';
 import AppContextProvider from './components/AppContextProvider.js';
+import {
+  EMPTY_DESIGNER_SELECTION,
+  type DesignerSelectSchemas,
+  type DesignerSelectSchemasOptions,
+  type DesignerSchemaSelectionTarget,
+  type DesignerSelectedSchema,
+  type DesignerSelection,
+  type DesignerSelectionChangeCallback,
+} from './designerSelection.js';
 
 class Designer extends BaseUIClass {
   private onSaveTemplateCallback?: (template: Template) => void;
   private onChangeTemplateCallback?: (template: Template) => void;
   private onPageChangeCallback?: (pageInfo: { currentPage: number; totalPages: number }) => void;
+  private onChangeSelectionCallback?: DesignerSelectionChangeCallback;
   private pageCursor: number = 0;
+  private selection: DesignerSelection = EMPTY_DESIGNER_SELECTION;
+  private selectSchemasHandler: DesignerSelectSchemas | null = null;
 
   constructor(props: DesignerProps) {
     super(props);
@@ -50,6 +62,27 @@ class Designer extends BaseUIClass {
 
   public onPageChange(cb: (pageInfo: { currentPage: number; totalPages: number }) => void) {
     this.onPageChangeCallback = cb;
+  }
+
+  public onChangeSelection(cb: DesignerSelectionChangeCallback) {
+    this.onChangeSelectionCallback = cb;
+  }
+
+  public getSelection() {
+    if (!this.domContainer) throw Error(DESTROYED_ERR_MSG);
+    return cloneDeep(this.selection);
+  }
+
+  public getSelectedSchemas(): DesignerSelectedSchema[] {
+    return this.getSelection().schemas;
+  }
+
+  public selectSchemas(
+    targets: DesignerSchemaSelectionTarget | DesignerSchemaSelectionTarget[],
+    options?: DesignerSelectSchemasOptions,
+  ) {
+    if (!this.domContainer) throw Error(DESTROYED_ERR_MSG);
+    this.selectSchemasHandler?.(targets, options);
   }
 
   public getPageCursor() {
@@ -94,6 +127,15 @@ class Designer extends BaseUIClass {
                 totalPages: totalPages,
               });
             }
+          }}
+          onChangeSelection={(selection) => {
+            this.selection = cloneDeep(selection);
+            if (this.onChangeSelectionCallback) {
+              this.onChangeSelectionCallback(cloneDeep(selection));
+            }
+          }}
+          onRegisterSchemaSelectionHandler={(handler) => {
+            this.selectSchemasHandler = handler;
           }}
           size={this.size}
         />

--- a/packages/ui/src/components/Designer/index.tsx
+++ b/packages/ui/src/components/Designer/index.tsx
@@ -34,6 +34,14 @@ import {
   useMaxZoom,
 } from '../../helper.js';
 import { useUIPreProcessor, useScrollPageCursor, useInitEvents } from '../../hooks.js';
+import {
+  createDesignerSelection,
+  getDesignerSelectionPageIndex,
+  getSelectedSchemaIds,
+  normalizeDesignerSchemaSelectionTargets,
+  type DesignerSelectSchemas,
+  type DesignerSelection,
+} from '../../designerSelection.js';
 import Root from '../Root.js';
 import ErrorScreen from '../ErrorScreen.js';
 import CtlBar from '../CtlBar.js';
@@ -55,10 +63,14 @@ const TemplateEditor = ({
   onSaveTemplate,
   onChangeTemplate,
   onPageCursorChange,
+  onChangeSelection,
+  onRegisterSchemaSelectionHandler,
 }: Omit<DesignerProps, 'domContainer'> & {
   size: Size;
   onSaveTemplate: (t: Template) => void;
   onChangeTemplate: (t: Template) => void;
+  onChangeSelection?: (selection: DesignerSelection) => void;
+  onRegisterSchemaSelectionHandler?: (handler: DesignerSelectSchemas | null) => void;
 } & {
   onChangeTemplate: (t: Template) => void;
   onPageCursorChange: (newPageCursor: number, totalPages: number) => void;
@@ -89,12 +101,77 @@ const TemplateEditor = ({
     maxZoom,
   });
 
+  const getElementsByIds = (ids: string[]) =>
+    ids
+      .map((id) => document.getElementById(id))
+      .filter((element): element is HTMLElement => element instanceof HTMLElement);
+
   const onEdit = (targets: Array<HTMLElement | null | undefined>) => {
     setActiveElements(
       targets.filter((target): target is HTMLElement => target instanceof HTMLElement),
     );
     setHoveringSchemaId(null);
   };
+
+  const selectSchemas: DesignerSelectSchemas = useCallback(
+    (targets, options = {}) => {
+      const normalizedTargets = normalizeDesignerSchemaSelectionTargets(targets);
+      if (normalizedTargets.length === 0) {
+        onEditEnd();
+        return;
+      }
+
+      const targetPageIndex = getDesignerSelectionPageIndex(
+        normalizedTargets,
+        pageCursor,
+        options,
+      );
+      const targetSchemas = schemasList[targetPageIndex] ?? [];
+      const selectedSchemaIds = getSelectedSchemaIds({
+        pageIndex: targetPageIndex,
+        schemas: targetSchemas,
+        targets: normalizedTargets,
+      });
+
+      const editSelectedSchemas = () => onEdit(getElementsByIds(selectedSchemaIds));
+      if (selectedSchemaIds.length === 0) {
+        onEditEnd();
+        return;
+      }
+
+      if (targetPageIndex !== pageCursor) {
+        setPageCursor(targetPageIndex);
+        onPageCursorChange(targetPageIndex, schemasList.length);
+        if (options.scroll !== false && canvasRef.current) {
+          canvasRef.current.scrollTop = getPagesScrollTopByIndex(
+            pageSizes,
+            targetPageIndex,
+            scale,
+          );
+        }
+        setTimeout(editSelectedSchemas);
+        return;
+      }
+
+      editSelectedSchemas();
+    },
+    [pageCursor, pageSizes, scale, schemasList, onPageCursorChange],
+  );
+
+  useEffect(() => {
+    onRegisterSchemaSelectionHandler?.(selectSchemas);
+    return () => onRegisterSchemaSelectionHandler?.(null);
+  }, [onRegisterSchemaSelectionHandler, selectSchemas]);
+
+  useEffect(() => {
+    onChangeSelection?.(
+      createDesignerSelection({
+        activeSchemaIds: activeElements.map((element) => element.id),
+        pageIndex: pageCursor,
+        schemasList,
+      }),
+    );
+  }, [activeElements, onChangeSelection, pageCursor, schemasList]);
 
   const onEditEnd = () => {
     setActiveElements([]);

--- a/packages/ui/src/designerSelection.ts
+++ b/packages/ui/src/designerSelection.ts
@@ -1,0 +1,182 @@
+import { cloneDeep, type Schema, type SchemaForUI } from '@pdfme/common';
+
+export type DesignerSelectionBounds = {
+  height: number;
+  width: number;
+  x: number;
+  y: number;
+};
+
+export type DesignerSelectedSchema = {
+  name: string;
+  pageIndex: number;
+  schema: Schema;
+  schemaId: string;
+  schemaIndex: number;
+  type: string;
+};
+
+export type DesignerSelection = {
+  bounds: DesignerSelectionBounds | null;
+  pageIndex: number;
+  schemas: DesignerSelectedSchema[];
+};
+
+export type DesignerSelectionChangeCallback = (selection: DesignerSelection) => void;
+
+export type DesignerSchemaSelectionTarget =
+  | string
+  | {
+      name?: string;
+      pageIndex?: number;
+      schemaId?: string;
+      schemaIndex?: number;
+    };
+
+export type DesignerSelectSchemasOptions = {
+  pageIndex?: number;
+  scroll?: boolean;
+};
+
+export type DesignerSelectSchemas = (
+  targets: DesignerSchemaSelectionTarget | DesignerSchemaSelectionTarget[],
+  options?: DesignerSelectSchemasOptions,
+) => void;
+
+export const EMPTY_DESIGNER_SELECTION: DesignerSelection = {
+  bounds: null,
+  pageIndex: 0,
+  schemas: [],
+};
+
+const toPersistedSchema = (schema: SchemaForUI): Schema => {
+  const cloned = cloneDeep(schema) as Schema & { id?: string };
+  delete cloned.id;
+  return cloned;
+};
+
+const getSelectionBounds = (schemas: DesignerSelectedSchema[]): DesignerSelectionBounds | null => {
+  if (schemas.length === 0) return null;
+
+  const left = Math.min(...schemas.map(({ schema }) => schema.position.x));
+  const top = Math.min(...schemas.map(({ schema }) => schema.position.y));
+  const right = Math.max(...schemas.map(({ schema }) => schema.position.x + schema.width));
+  const bottom = Math.max(...schemas.map(({ schema }) => schema.position.y + schema.height));
+
+  return {
+    height: bottom - top,
+    width: right - left,
+    x: left,
+    y: top,
+  };
+};
+
+export const createDesignerSelection = ({
+  activeSchemaIds,
+  pageIndex,
+  schemasList,
+}: {
+  activeSchemaIds: string[];
+  pageIndex: number;
+  schemasList: SchemaForUI[][];
+}): DesignerSelection => {
+  const pageSchemas = schemasList[pageIndex] ?? [];
+  const selectedSchemas = activeSchemaIds.flatMap((schemaId) => {
+    const schemaIndex = pageSchemas.findIndex((schema) => schema.id === schemaId);
+    const schema = pageSchemas[schemaIndex];
+    if (schemaIndex === -1 || !schema) return [];
+
+    return [
+      {
+        name: schema.name,
+        pageIndex,
+        schema: toPersistedSchema(schema),
+        schemaId: schema.id,
+        schemaIndex,
+        type: schema.type,
+      },
+    ];
+  });
+
+  return {
+    bounds: getSelectionBounds(selectedSchemas),
+    pageIndex,
+    schemas: selectedSchemas,
+  };
+};
+
+export const normalizeDesignerSchemaSelectionTargets = (
+  targets: DesignerSchemaSelectionTarget | DesignerSchemaSelectionTarget[],
+): DesignerSchemaSelectionTarget[] => (Array.isArray(targets) ? targets : [targets]);
+
+export const getDesignerSelectionPageIndex = (
+  targets: DesignerSchemaSelectionTarget[],
+  fallbackPageIndex: number,
+  options: DesignerSelectSchemasOptions = {},
+): number => {
+  const optionPageIndex = options.pageIndex;
+  if (Number.isInteger(optionPageIndex) && optionPageIndex !== undefined && optionPageIndex >= 0) {
+    return optionPageIndex;
+  }
+
+  const firstObjectTarget = targets.find(
+    (target): target is Exclude<DesignerSchemaSelectionTarget, string> =>
+      typeof target === 'object' && target !== null,
+  );
+
+  const targetPageIndex = firstObjectTarget?.pageIndex;
+  return Number.isInteger(targetPageIndex) && targetPageIndex !== undefined && targetPageIndex >= 0
+    ? targetPageIndex
+    : fallbackPageIndex;
+};
+
+export const getSelectedSchemaIds = ({
+  pageIndex,
+  schemas,
+  targets,
+}: {
+  pageIndex: number;
+  schemas: SchemaForUI[];
+  targets: DesignerSchemaSelectionTarget[];
+}): string[] => {
+  const selectedIds = new Set<string>();
+
+  targets.forEach((target) => {
+    schemas.forEach((schema, schemaIndex) => {
+      if (typeof target === 'string') {
+        if (schema.id === target || schema.name === target) selectedIds.add(schema.id);
+        return;
+      }
+
+      if (
+        Number.isInteger(target.pageIndex) &&
+        target.pageIndex !== undefined &&
+        target.pageIndex !== pageIndex
+      ) {
+        return;
+      }
+
+      const hasSelector =
+        target.schemaId !== undefined ||
+        target.schemaIndex !== undefined ||
+        target.name !== undefined;
+      if (!hasSelector) return;
+
+      if (target.schemaId !== undefined && target.schemaId === schema.id) {
+        selectedIds.add(schema.id);
+        return;
+      }
+
+      if (target.schemaIndex !== undefined && target.schemaIndex === schemaIndex) {
+        selectedIds.add(schema.id);
+        return;
+      }
+
+      if (target.name !== undefined && target.name === schema.name) {
+        selectedIds.add(schema.id);
+      }
+    });
+  });
+
+  return [...selectedIds];
+};

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,3 +3,12 @@ import Form from './Form.js';
 import Viewer from './Viewer.js';
 
 export { Designer, Viewer, Form };
+export type {
+  DesignerSchemaSelectionTarget,
+  DesignerSelectSchemas,
+  DesignerSelectSchemasOptions,
+  DesignerSelectedSchema,
+  DesignerSelection,
+  DesignerSelectionBounds,
+  DesignerSelectionChangeCallback,
+} from './designerSelection.js';

--- a/playground/src/lib/pdfmeAgentHost.ts
+++ b/playground/src/lib/pdfmeAgentHost.ts
@@ -2,7 +2,28 @@ export const PDFME_AGENT_HOST_READY_EVENT = 'pdfme-agent-host-ready';
 export const PDFME_AGENT_HOST_DESTROYED_EVENT = 'pdfme-agent-host-destroyed';
 
 export type PdfmeAgentTemplateContext = {
+  editingStaticSchemas?: boolean;
   templateName?: string | null;
+};
+
+export type PdfmeAgentSelectedSchema = {
+  name: string;
+  pageIndex: number;
+  schema: unknown;
+  schemaId?: string;
+  schemaIndex: number;
+  type: string;
+};
+
+export type PdfmeAgentSelection = {
+  bounds?: {
+    height: number;
+    width: number;
+    x: number;
+    y: number;
+  } | null;
+  pageIndex?: number;
+  schemas: PdfmeAgentSelectedSchema[];
 };
 
 export type PdfmeAgentTemplateUpdate = {
@@ -14,7 +35,12 @@ export type PdfmeAgentHost = {
   applyTemplateUpdate?: (input: PdfmeAgentTemplateUpdate) => Promise<void> | void;
   getCurrentTemplate?: () => unknown | null;
   getCurrentTemplateTitle?: () => string | null;
+  getSelectedSchemas?: () => PdfmeAgentSelectedSchema[];
+  getSelection?: () => PdfmeAgentSelection | null;
   getTemplateContext?: () => PdfmeAgentTemplateContext;
+  onChangeSelection?: (
+    cb: (selection: PdfmeAgentSelection | null) => void,
+  ) => (() => void) | void;
 };
 
 declare global {

--- a/playground/src/routes/Designer.tsx
+++ b/playground/src/routes/Designer.tsx
@@ -3,7 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { Code2, Copy, Download, Save } from 'lucide-react';
 import { cloneDeep, Template, checkTemplate, Lang, isBlankPdf } from '@pdfme/common';
-import { Designer } from '@pdfme/ui';
+import { Designer, type DesignerSelection } from '@pdfme/ui';
 import {
   getFontsData,
   getTemplateById,
@@ -147,6 +147,11 @@ function DesignerApp() {
   const isFileWorkspaceDirtyRef = useRef(false);
   const fileWorkspaceStatusRef = useRef<FileWorkspaceStatus>(null);
   const projectTitleRef = useRef('Untitled Template');
+  const agentSelectionRef = useRef<DesignerSelection | null>(null);
+  const agentSelectionListenersRef = useRef(
+    new Set<(selection: DesignerSelection | null) => void>(),
+  );
+  const editingStaticSchemasRef = useRef(false);
   const loadRequestRef = useRef<DesignerLoadRequest | null>(null);
   const didCleanLoadQueryRef = useRef(false);
 
@@ -166,6 +171,10 @@ function DesignerApp() {
   useEffect(() => {
     searchParamsRef.current = searchParams;
   }, [searchParams]);
+
+  useEffect(() => {
+    editingStaticSchemasRef.current = editingStaticSchemas;
+  }, [editingStaticSchemas]);
 
   const setCurrentProjectTitle = useCallback((title: string) => {
     projectTitleRef.current = title;
@@ -460,6 +469,11 @@ function DesignerApp() {
           plugins: getPlugins(),
         });
         designer.current = nextDesigner;
+        agentSelectionRef.current = nextDesigner.getSelection();
+        nextDesigner.onChangeSelection((selection) => {
+          agentSelectionRef.current = selection;
+          agentSelectionListenersRef.current.forEach((listener) => listener(selection));
+        });
         nextDesigner.onSaveTemplate(onSaveTemplate);
         nextDesigner.onChangeTemplate((nextTemplate) => {
           if (!fileWorkspaceEntryRef.current || isApplyingTemplateRef.current) return;
@@ -646,10 +660,22 @@ function DesignerApp() {
       applyTemplateUpdate: applyAgentTemplateUpdate,
       getCurrentTemplate: () => designer.current?.getTemplate() ?? null,
       getCurrentTemplateTitle: () => projectTitleRef.current,
+      getSelection: () => agentSelectionRef.current ?? designer.current?.getSelection() ?? null,
+      getSelectedSchemas: () =>
+        agentSelectionRef.current?.schemas ?? designer.current?.getSelectedSchemas() ?? [],
       getTemplateContext: () => {
         const currentEntry = fileWorkspaceEntryRef.current;
         return {
+          editingStaticSchemas: editingStaticSchemasRef.current,
           templateName: currentEntry?.name ?? null,
+        };
+      },
+      onChangeSelection: (cb) => {
+        const listeners = agentSelectionListenersRef.current;
+        listeners.add(cb);
+        cb(agentSelectionRef.current ?? designer.current?.getSelection() ?? null);
+        return () => {
+          listeners.delete(cb);
         };
       },
     };
@@ -732,12 +758,15 @@ function DesignerApp() {
   useEffect(() => {
     let cancelled = false;
     let mountedDesigner: Designer | null = null;
+    const selectionListeners = agentSelectionListenersRef.current;
 
     void buildDesigner(() => cancelled).then((nextDesigner) => {
       if (!nextDesigner) return;
 
       if (cancelled) {
         if (designer.current === nextDesigner) designer.current = null;
+        agentSelectionRef.current = null;
+        agentSelectionListenersRef.current.forEach((listener) => listener(null));
         destroyDesignerInstance(nextDesigner);
         return;
       }
@@ -750,6 +779,8 @@ function DesignerApp() {
       if (!mountedDesigner) return;
 
       if (designer.current === mountedDesigner) designer.current = null;
+      agentSelectionRef.current = null;
+      selectionListeners.forEach((listener) => listener(null));
       destroyDesignerInstance(mountedDesigner);
     };
   }, [buildDesigner]);


### PR DESCRIPTION
## Summary
- add public Designer selection APIs: `getSelection`, `getSelectedSchemas`, `onChangeSelection`, and `selectSchemas`
- expose typed selection metadata and helpers that strip UI-only schema ids
- wire the Playground agent host to publish selected schemas and static-schema edit state

## Validation
- `npm run build -w packages/ui`
- `npm run test -w packages/ui -- designerSelection.test.ts`
- `npm run lint -w packages/ui`
- `npm --prefix playground run lint`
- `npm --prefix playground run build`
- `npm --prefix playground run test:exports`
- `git diff --check`
- local smoke: selected schema updates the pdfme Agent widget from `Edit all` to `Edit 1 selected`
