### PR TITLE
fix(schemas): prevent form text wrapping with character spacing

### DIFF
--- a/packages/schemas/__tests__/text.ui.test.ts
+++ b/packages/schemas/__tests__/text.ui.test.ts
@@ -186,6 +186,38 @@ describe('text inline markdown UI rendering', () => {
     expect(textBlock.style.height).toBe('');
   });
 
+  it('compensates editable text wrapping for final character spacing', async () => {
+    const rootElement = document.createElement('div');
+    const schema: TextSchema = {
+      ...getTextSchema(),
+      readOnly: false,
+      textFormat: 'plain',
+      characterSpacing: 12,
+    };
+    const font = {
+      Base: { data: new Uint8Array(), fallback: true },
+    } as Font;
+    const cache = new Map<string | number, unknown>([
+      ['getFontKitFont-Base', createMockFont(() => true)],
+    ]);
+
+    await uiRender({
+      value: '12345',
+      schema,
+      rootElement,
+      mode: 'form',
+      options: { font },
+      _cache: cache,
+      theme: { colorPrimary: '#1677ff' },
+    } as Parameters<typeof uiRender>[0]);
+
+    const textBlock = rootElement.querySelector(`#text-${schema.id}`) as HTMLDivElement;
+
+    expect(textBlock.contentEditable).toBe('plaintext-only');
+    expect(textBlock.style.letterSpacing).toBe('12pt');
+    expect(textBlock.style.width).toBe('calc(100% + 16px)');
+  });
+
   it('renders split inline markdown form chunks as read-only', async () => {
     const rootElement = document.createElement('div');
     const onChange = vi.fn();

--- a/packages/schemas/src/text/uiRender.ts
+++ b/packages/schemas/src/text/uiRender.ts
@@ -356,6 +356,8 @@ export const buildStyledTextContainer = (
   const { schema, rootElement, mode } = arg;
 
   let dynamicFontSize: undefined | number = resolvedDynamicFontSize;
+  const characterSpacing = schema.characterSpacing ?? DEFAULT_CHARACTER_SPACING;
+  const editable = isEditable(mode, schema);
 
   if (dynamicFontSize === undefined && shouldUseDynamicFontSize(schema, arg.basePdf) && value) {
     dynamicFontSize = calculateDynamicFontSize({
@@ -408,7 +410,7 @@ export const buildStyledTextContainer = (
     justifyContent: mapVerticalAlignToFlex(verticalAlignment),
     width: '100%',
     height: '100%',
-    cursor: isEditable(mode, schema) ? 'text' : 'default',
+    cursor: editable ? 'text' : 'default',
   };
   Object.assign(container.style, containerStyle);
   rootElement.innerHTML = '';
@@ -424,7 +426,7 @@ export const buildStyledTextContainer = (
     fontFamily: schema.fontName ? `'${schema.fontName}'` : 'inherit',
     color: schema.fontColor ? schema.fontColor : DEFAULT_FONT_COLOR,
     fontSize: `${dynamicFontSize ?? schema.fontSize ?? DEFAULT_FONT_SIZE}pt`,
-    letterSpacing: `${schema.characterSpacing ?? DEFAULT_CHARACTER_SPACING}pt`,
+    letterSpacing: `${characterSpacing}pt`,
     lineHeight: `${schema.lineHeight ?? DEFAULT_LINE_HEIGHT}em`,
     textAlign: schema.alignment ?? DEFAULT_ALIGNMENT,
     whiteSpace: 'pre-wrap',
@@ -437,6 +439,8 @@ export const buildStyledTextContainer = (
     paddingTop: `${topAdjustment}px`,
     backgroundColor: 'transparent',
     textDecoration: textDecorations.join(' '),
+    // Browsers include the final letter-spacing in editable text wrapping, unlike PDF rendering.
+    ...(editable && characterSpacing > 0 ? { width: `calc(100% + ${characterSpacing}pt)` } : {}),
     ...(isTopAligned ? { height: '100%' } : {}),
   };
 


### PR DESCRIPTION
## Summary

- Compensate editable text width by one character-spacing unit so Form text wrapping matches Designer/PDF rendering.
- Reuse the resolved `characterSpacing` and editable state in the text UI renderer.
- Add a regression test for a high character-spacing Form field like the social insurance `code` schema.

## Root Cause

Editable browser text includes the final `letter-spacing` in line wrapping calculations, while the PDF/viewer rendering path does not. Narrow fields with large character spacing could wrap in Form mode even though they fit in Designer and PDF output.

## Validation

- `npm run test -w packages/schemas -- text.ui.test.ts`
- `npm run build -w packages/schemas`
- `npm run lint -w packages/schemas`
- Verified in playground with `Social Insurance Enrollment Form` that `code` remains on one line in Form mode.