### PR TITLE
[codex] bulk update same-type selected schemas

### DIFF
--- a/packages/ui/__tests__/components/ButtonGroupWidget.test.tsx
+++ b/packages/ui/__tests__/components/ButtonGroupWidget.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { BLANK_PDF, type PropPanelWidgetProps, type SchemaForUI } from '@pdfme/common';
+import ButtonGroupWidget from '../../src/components/Designer/RightSidebar/DetailView/ButtonGroupWidget';
+
+const icon = '<svg xmlns="http://www.w3.org/2000/svg"><path stroke="currentColor" d="M1 1h10" /></svg>';
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      addEventListener: vi.fn(),
+      addListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      matches: false,
+      media: query,
+      onchange: null,
+      removeEventListener: vi.fn(),
+      removeListener: vi.fn(),
+    })),
+  });
+});
+
+const schema = (id: string, underline: boolean): SchemaForUI => ({
+  content: '',
+  height: 6,
+  id,
+  name: id,
+  position: { x: 10, y: 20 },
+  type: 'text',
+  underline,
+  width: 30,
+});
+
+const element = (id: string) => {
+  const div = document.createElement('div');
+  div.id = id;
+  return div;
+};
+
+const renderButtonGroup = (schemas: SchemaForUI[]) => {
+  const changeSchemas = vi.fn();
+  const props = {
+    activeElements: schemas.map(({ id }) => element(id)),
+    activeSchema: schemas[0],
+    basePdf: BLANK_PDF,
+    changeSchemas,
+    i18n: (key: string) => key,
+    options: {},
+    rootElement: document.createElement('div'),
+    schema: {
+      buttons: [{ key: 'underline', icon, type: 'boolean' }],
+    },
+    schemas,
+    theme: {
+      colorPrimary: '#1677ff',
+      colorPrimaryBg: '#e6f4ff',
+      colorWhite: '#ffffff',
+    },
+  } as PropPanelWidgetProps;
+
+  return { ...render(<ButtonGroupWidget {...props} />), changeSchemas };
+};
+
+describe('ButtonGroupWidget', () => {
+  it('turns a partial boolean selection on for every same-type schema', () => {
+    const { container, changeSchemas } = renderButtonGroup([
+      schema('field-1', true),
+      schema('field-2', false),
+    ]);
+
+    fireEvent.click(container.querySelector('button')!);
+
+    expect(changeSchemas).toHaveBeenCalledWith([
+      { key: 'underline', value: true, schemaId: 'field-1' },
+      { key: 'underline', value: true, schemaId: 'field-2' },
+    ]);
+  });
+});

--- a/packages/ui/__tests__/schemaChangeHelpers.test.ts
+++ b/packages/ui/__tests__/schemaChangeHelpers.test.ts
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'vitest';
+import type { ChangeSchemaItem, SchemaForUI } from '@pdfme/common';
+import {
+  expandSameTypeBulkUpdateChanges,
+  getSameTypeBulkUpdateSchemas,
+  isSingleSchemaOnlyChange,
+} from '../src/components/Designer/RightSidebar/DetailView/schemaChangeHelpers.js';
+
+const schema = (id: string, type = 'text'): SchemaForUI => ({
+  content: '',
+  height: 6,
+  id,
+  name: id,
+  position: { x: 10, y: 20 },
+  type,
+  width: 30,
+});
+
+describe('schema change helpers', () => {
+  it('targets every selected schema when the selection has one schema type', () => {
+    const activeSchema = schema('field-1');
+    const activeSchemas = [activeSchema, schema('field-2')];
+
+    assert.deepEqual(
+      getSameTypeBulkUpdateSchemas({ activeSchema, activeSchemas }).map(({ id }) => id),
+      ['field-1', 'field-2'],
+    );
+  });
+
+  it('targets only the active schema when selected schema types are mixed', () => {
+    const activeSchema = schema('field-1');
+    const activeSchemas = [activeSchema, schema('field-2', 'image')];
+
+    assert.deepEqual(getSameTypeBulkUpdateSchemas({ activeSchema, activeSchemas }), [activeSchema]);
+  });
+
+  it('expands bulk-safe active schema changes to the same-type selection', () => {
+    const activeSchema = schema('field-1');
+    const changes: ChangeSchemaItem[] = [
+      { key: 'fontSize', value: 14, schemaId: activeSchema.id },
+    ];
+
+    assert.deepEqual(
+      expandSameTypeBulkUpdateChanges({
+        activeSchema,
+        activeSchemas: [activeSchema, schema('field-2')],
+        changes,
+      }),
+      [
+        { key: 'fontSize', value: 14, schemaId: 'field-1' },
+        { key: 'fontSize', value: 14, schemaId: 'field-2' },
+      ],
+    );
+  });
+
+  it('keeps identity, content, type, and position changes scoped to one schema', () => {
+    ['id', 'name', 'type', 'content', 'position', 'position.x', 'position.y'].forEach((key) => {
+      assert.equal(isSingleSchemaOnlyChange(key), true);
+    });
+
+    const activeSchema = schema('field-1');
+    const changes: ChangeSchemaItem[] = [
+      { key: 'name', value: 'renamed', schemaId: activeSchema.id },
+      { key: 'position.x', value: 42, schemaId: activeSchema.id },
+    ];
+
+    assert.deepEqual(
+      expandSameTypeBulkUpdateChanges({
+        activeSchema,
+        activeSchemas: [activeSchema, schema('field-2')],
+        changes,
+      }),
+      changes,
+    );
+  });
+
+  it('keeps a mixed batch scoped when it includes a single-schema-only change', () => {
+    const activeSchema = schema('field-1');
+    const changes: ChangeSchemaItem[] = [
+      { key: 'fontSize', value: 14, schemaId: activeSchema.id },
+      { key: 'name', value: 'renamed', schemaId: activeSchema.id },
+    ];
+
+    assert.deepEqual(
+      expandSameTypeBulkUpdateChanges({
+        activeSchema,
+        activeSchemas: [activeSchema, schema('field-2')],
+        changes,
+      }),
+      changes,
+    );
+  });
+
+  it('keeps dependent widget batches scoped when content is updated with metadata', () => {
+    const activeSchema = schema('field-1', 'multiVariableText');
+    const changes: ChangeSchemaItem[] = [
+      { key: 'content', value: '{"name":"Alice"}', schemaId: activeSchema.id },
+      { key: 'variables', value: ['name'], schemaId: activeSchema.id },
+      { key: 'readOnly', value: false, schemaId: activeSchema.id },
+    ];
+
+    assert.deepEqual(
+      expandSameTypeBulkUpdateChanges({
+        activeSchema,
+        activeSchemas: [activeSchema, schema('field-2', 'multiVariableText')],
+        changes,
+      }),
+      changes,
+    );
+  });
+
+  it('does not expand changes that already target multiple schemas', () => {
+    const activeSchema = schema('field-1');
+    const changes: ChangeSchemaItem[] = [
+      { key: 'alignment', value: 'center', schemaId: activeSchema.id },
+      { key: 'alignment', value: 'center', schemaId: 'field-2' },
+    ];
+
+    assert.deepEqual(
+      expandSameTypeBulkUpdateChanges({
+        activeSchema,
+        activeSchemas: [activeSchema, schema('field-2')],
+        changes,
+      }),
+      changes,
+    );
+  });
+});

--- a/packages/ui/src/components/Designer/RightSidebar/DetailView/ButtonGroupWidget.tsx
+++ b/packages/ui/src/components/Designer/RightSidebar/DetailView/ButtonGroupWidget.tsx
@@ -1,6 +1,7 @@
 import { Space, Button, Form, theme } from 'antd';
 import React from 'react';
 import type { PropPanelWidgetProps, SchemaForUI } from '@pdfme/common';
+import { getSameTypeBulkUpdateSchemas } from './schemaChangeHelpers.js';
 interface ButtonConfig {
   key: string;
   icon: string;
@@ -9,37 +10,49 @@ interface ButtonConfig {
 }
 
 const ButtonGroupWidget = (props: PropPanelWidgetProps) => {
-  const { activeElements, changeSchemas, schemas, schema } = props;
+  const { activeElements, activeSchema, changeSchemas, schemas, schema } = props;
   const { token } = theme.useToken();
   const buttons = Array.isArray(schema?.buttons) ? (schema.buttons as ButtonConfig[]) : [];
 
-  const apply = (btn: ButtonConfig) => {
-    const key = btn.key;
-    const type = btn.type;
+  const getSelectedSchemas = () => {
     const ids = activeElements.map((ae) => ae.id);
-    const ass = schemas.filter((s) => ids.includes(s.id));
-    changeSchemas(
-      ass.map((s: SchemaForUI) => {
-        const oldValue = Boolean((s as Record<string, unknown>)[key] ?? false);
-        const newValue = type === 'boolean' ? !oldValue : btn.value;
-        return { key, value: newValue, schemaId: s.id };
-      }),
+    return schemas.filter((s) => ids.includes(s.id));
+  };
+
+  const getTargetSchemas = () =>
+    getSameTypeBulkUpdateSchemas({
+      activeSchema,
+      activeSchemas: getSelectedSchemas(),
+    });
+
+  const getButtonValue = (btn: ButtonConfig, targetSchemas: SchemaForUI[]) => {
+    if (btn.type !== 'boolean') return btn.value;
+
+    const isActive = targetSchemas.every((s) =>
+      Boolean((s as Record<string, unknown>)[btn.key] ?? false),
     );
+    return !isActive;
+  };
+
+  const apply = (btn: ButtonConfig) => {
+    const targetSchemas = getTargetSchemas();
+    const value = getButtonValue(btn, targetSchemas);
+    changeSchemas(targetSchemas.map((s: SchemaForUI) => ({ key: btn.key, value, schemaId: s.id })));
   };
 
   const isActive = (btn: ButtonConfig) => {
     const key = btn.key;
     const type = btn.type;
-    let active = false;
-    const ids = activeElements.map((ae) => ae.id);
-    const ass = schemas.filter((s) => ids.includes(s.id));
-    ass.forEach((s: SchemaForUI) => {
+    const targetSchemas = getTargetSchemas();
+    if (targetSchemas.length === 0) return false;
+
+    return targetSchemas.every((s: SchemaForUI) => {
       // Cast schema to Record to safely access dynamic properties
       const schemaRecord = s as Record<string, unknown>;
-      active =
-        type === 'boolean' ? Boolean(schemaRecord[key] ?? false) : schemaRecord[key] === btn.value;
+      return type === 'boolean'
+        ? Boolean(schemaRecord[key] ?? false)
+        : schemaRecord[key] === btn.value;
     });
-    return active;
   };
 
   const replaceCurrentColor = (svgString: string, color?: string) =>

--- a/packages/ui/src/components/Designer/RightSidebar/DetailView/index.tsx
+++ b/packages/ui/src/components/Designer/RightSidebar/DetailView/index.tsx
@@ -20,6 +20,7 @@ import { theme, Typography, Button, Divider } from 'antd';
 import AlignWidget from './AlignWidget.js';
 import WidgetRenderer from './WidgetRenderer.js';
 import ButtonGroupWidget from './ButtonGroupWidget.js';
+import { expandSameTypeBulkUpdateChanges } from './schemaChangeHelpers.js';
 import { InternalNamePath, ValidateErrorEntity } from 'rc-field-form/es/interface.js';
 import { SidebarBody, SidebarFrame, SidebarHeader, SIDEBAR_H_PADDING_PX } from '../layout.js';
 
@@ -45,6 +46,7 @@ type DetailViewProps = Pick<
 };
 
 type WidgetMap = Record<string, (props: PropPanelWidgetProps) => React.JSX.Element>;
+const getElementIds = (elements: HTMLElement[]) => elements.map(({ id }) => id);
 
 const DetailView = (props: DetailViewProps) => {
   const { token } = theme.useToken();
@@ -59,6 +61,23 @@ const DetailView = (props: DetailViewProps) => {
   const pluginsRegistry = useContext(PluginsRegistry);
   const options = useContext(OptionsContext);
 
+  const activeSchemas = useMemo(() => {
+    const ids = new Set(props.activeElements.map((element) => element.id));
+    return props.schemas.filter((schema) => ids.has(schema.id));
+  }, [props.activeElements, props.schemas]);
+
+  const changeSchemasWithSameTypeSelection = useCallback(
+    (changes: ChangeSchemaItem[]) =>
+      changeSchemas(
+        expandSameTypeBulkUpdateChanges({
+          activeSchema,
+          activeSchemas,
+          changes,
+        }),
+      ),
+    [activeSchema, activeSchemas, changeSchemas],
+  );
+
   // Define a type-safe i18n function that accepts string keys
   const typedI18n = useCallback(
     (key: string): string => {
@@ -70,11 +89,25 @@ const DetailView = (props: DetailViewProps) => {
 
   const widgets = useMemo<WidgetMap>(() => {
     const newWidgets: WidgetMap = {
-      AlignWidget: (p) => <AlignWidget {...p} {...props} options={options} />,
+      AlignWidget: (p) => (
+        <AlignWidget
+          {...p}
+          {...props}
+          changeSchemas={changeSchemasWithSameTypeSelection}
+          options={options}
+        />
+      ),
       Divider: () => (
         <Divider style={{ marginTop: token.marginXS, marginBottom: token.marginXS }} />
       ),
-      ButtonGroup: (p) => <ButtonGroupWidget {...p} {...props} options={options} />,
+      ButtonGroup: (p) => (
+        <ButtonGroupWidget
+          {...p}
+          {...props}
+          changeSchemas={changeSchemasWithSameTypeSelection}
+          options={options}
+        />
+      ),
     };
     for (const plugin of pluginsRegistry.values()) {
       const pluginWidgets = (plugin.propPanel.widgets ?? {}) as Record<
@@ -86,6 +119,7 @@ const DetailView = (props: DetailViewProps) => {
           <WidgetRenderer
             {...p}
             {...props}
+            changeSchemas={changeSchemasWithSameTypeSelection}
             options={options}
             theme={token}
             i18n={typedI18n}
@@ -95,7 +129,7 @@ const DetailView = (props: DetailViewProps) => {
       });
     }
     return newWidgets;
-  }, [options, pluginsRegistry, props, token, typedI18n]);
+  }, [changeSchemasWithSameTypeSelection, options, pluginsRegistry, props, token, typedI18n]);
 
   useEffect(() => form.resetFields(), [activeSchema.id, form]);
 
@@ -178,6 +212,8 @@ const DetailView = (props: DetailViewProps) => {
 
     let changes: ChangeSchemaItem[] = [];
     for (const key in formSchema) {
+      // `id` is UI-only and `content` is edited by schema renderers/widgets, not this form watcher.
+      // Other active-schema-only keys are handled by expandSameTypeBulkUpdateChanges.
       if (['id', 'content'].includes(key)) continue;
 
       let value = formSchema[key];
@@ -220,7 +256,7 @@ const DetailView = (props: DetailViewProps) => {
       // Only commit these schema changes if they have passed form validation
       form
         .validateFields()
-        .then(() => changeSchemas(changes))
+        .then(() => changeSchemasWithSameTypeSelection(changes))
         .catch((reason: ValidateErrorEntity) => {
           if (reason.errorFields.length) {
             changes = changes.filter(
@@ -231,7 +267,7 @@ const DetailView = (props: DetailViewProps) => {
             );
           }
           if (changes.length) {
-            changeSchemas(changes);
+            changeSchemasWithSameTypeSelection(changes);
           }
         });
     }
@@ -402,16 +438,8 @@ const DetailView = (props: DetailViewProps) => {
 
   if (typeof activePropPanelSchema === 'function') {
     // Create a new object without the schemasList property
-    const {
-      size,
-      schemas,
-      pageSize,
-      basePdf,
-      changeSchemas,
-      activeElements,
-      deselectSchema,
-      activeSchema,
-    } = props;
+    const { size, schemas, pageSize, basePdf, activeElements, deselectSchema, activeSchema } =
+      props;
     const propPanelProps = {
       size,
       schemas,
@@ -500,7 +528,11 @@ const DetailView = (props: DetailViewProps) => {
 };
 
 const propsAreUnchanged = (prevProps: DetailViewProps, nextProps: DetailViewProps) => {
-  return JSON.stringify(prevProps.activeSchema) == JSON.stringify(nextProps.activeSchema);
+  return (
+    JSON.stringify(prevProps.activeSchema) === JSON.stringify(nextProps.activeSchema) &&
+    JSON.stringify(getElementIds(prevProps.activeElements)) ===
+      JSON.stringify(getElementIds(nextProps.activeElements))
+  );
 };
 
 export default React.memo(DetailView, propsAreUnchanged);

--- a/packages/ui/src/components/Designer/RightSidebar/DetailView/schemaChangeHelpers.ts
+++ b/packages/ui/src/components/Designer/RightSidebar/DetailView/schemaChangeHelpers.ts
@@ -1,0 +1,49 @@
+import type { ChangeSchemaItem, SchemaForUI } from '@pdfme/common';
+
+// Keep identity, content, type, and coordinates scoped to the active schema. Bulk-applying
+// these can duplicate names, rewrite field values, replace schema shapes, or stack fields.
+const singleSchemaOnlyChangeKeys = new Set(['id', 'name', 'type', 'content', 'position']);
+
+export const getSameTypeBulkUpdateSchemas = ({
+  activeSchema,
+  activeSchemas,
+}: {
+  activeSchema: SchemaForUI;
+  activeSchemas: SchemaForUI[];
+}): SchemaForUI[] => {
+  if (
+    activeSchemas.length > 1 &&
+    activeSchemas.every((schema) => schema.type === activeSchema.type)
+  ) {
+    return activeSchemas;
+  }
+
+  return [activeSchema];
+};
+
+export const isSingleSchemaOnlyChange = (key: string) =>
+  singleSchemaOnlyChangeKeys.has(key) || key.startsWith('position.');
+
+export const expandSameTypeBulkUpdateChanges = ({
+  activeSchema,
+  activeSchemas,
+  changes,
+}: {
+  activeSchema: SchemaForUI;
+  activeSchemas: SchemaForUI[];
+  changes: ChangeSchemaItem[];
+}): ChangeSchemaItem[] => {
+  const targetSchemas = getSameTypeBulkUpdateSchemas({ activeSchema, activeSchemas });
+  if (targetSchemas.length <= 1) return changes;
+
+  const isActiveSchemaOnlyChange = changes.every((change) => change.schemaId === activeSchema.id);
+  if (!isActiveSchemaOnlyChange) return changes;
+
+  // Some widgets send dependent updates in one batch. If any part of that batch must stay
+  // single-schema-only, keep the whole batch together to avoid partial cross-schema state.
+  if (changes.some((change) => isSingleSchemaOnlyChange(change.key))) return changes;
+
+  return changes.flatMap((change) => {
+    return targetSchemas.map((schema) => ({ ...change, schemaId: schema.id }));
+  });
+};


### PR DESCRIPTION
## Summary

- Apply Designer property panel changes to all selected schemas when the entire selection has the same schema type.
- Keep identity/content/layout-position changes scoped to the active schema so bulk edits do not duplicate names, change types, overwrite content, or stack fields on the same coordinates.
- Route plugin widgets and text formatter button groups through the same same-type bulk update behavior.
- Add focused helper and ButtonGroup tests for same-type expansion, mixed-type fallback, single-schema-only keys, dependent widget batches, pre-expanded changes, and partial boolean selections.

## Impact

Users can select multiple schemas of the same type in Designer and edit shared style, size, and plugin properties once from the right sidebar. Mixed-type selections continue to update only the active schema.

## Validation

- `npm run test -w packages/ui -- schemaChangeHelpers ButtonGroupWidget`
- `npm run test -w packages/ui -- Designer.test.tsx`
- `npm run typecheck`
- `npm run lint -w packages/ui`