### PR TITLE
[codex] add circle mark schema

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -100,10 +100,15 @@ jobs:
         working-directory: playground
         env:
           PUPPETEER_CACHE_DIR: ${{ github.workspace }}/.cache/puppeteer
+          PUPPETEER_SKIP_DOWNLOAD: false
+          PUPPETEER_CHROME_SKIP_DOWNLOAD: false
+          PUPPETEER_SKIP_CHROME_DOWNLOAD: false
           PUPPETEER_CHROME_HEADLESS_SHELL_SKIP_DOWNLOAD: true
         run: |
           node node_modules/puppeteer/install.mjs
-          node -e "console.log(require('puppeteer').executablePath())"
+          CHROME_PATH="$(node -e "process.stdout.write(require('puppeteer').executablePath())")"
+          test -x "$CHROME_PATH"
+          echo "$CHROME_PATH"
 
       - name: Run playground checks
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,37 +96,15 @@ jobs:
         run: |
           npm ci --prefix playground
 
-      - name: Install Puppeteer Chrome
-        working-directory: playground
-        env:
-          PUPPETEER_CACHE_DIR: ${{ github.workspace }}/.cache/puppeteer
+      - name: Configure Puppeteer Chrome
         run: |
-          node <<'NODE'
-          (async () => {
-            const { Browser, detectBrowserPlatform, install } = require('@puppeteer/browsers');
-            const { PUPPETEER_REVISIONS } = require('./node_modules/puppeteer-core/lib/cjs/puppeteer/revisions.js');
-
-            const platform = detectBrowserPlatform();
-            if (!platform) {
-              throw new Error('Unable to detect browser platform');
-            }
-
-            const result = await install({
-              browser: Browser.CHROME,
-              buildId: PUPPETEER_REVISIONS.chrome,
-              cacheDir: process.env.PUPPETEER_CACHE_DIR,
-              platform,
-              downloadProgressCallback: 'default',
-            });
-
-            console.log(`chrome (${result.buildId}) downloaded to ${result.path}`);
-          })().catch((error) => {
-            console.error(error);
-            process.exit(1);
-          });
-          NODE
-          CHROME_PATH="$(node -e "process.stdout.write(require('puppeteer').executablePath())")"
+          CHROME_PATH="$(command -v google-chrome || command -v google-chrome-stable || command -v chromium || command -v chromium-browser || true)"
+          if [ -z "$CHROME_PATH" ]; then
+            echo "No system Chrome executable found" >&2
+            exit 1
+          fi
           test -x "$CHROME_PATH"
+          echo "PUPPETEER_EXECUTABLE_PATH=$CHROME_PATH" >> "$GITHUB_ENV"
           echo "$CHROME_PATH"
 
       - name: Run playground checks
@@ -136,4 +114,3 @@ jobs:
           npm --prefix playground run test
         env:
           CI: true
-          PUPPETEER_CACHE_DIR: ${{ github.workspace }}/.cache/puppeteer

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,7 +98,12 @@ jobs:
 
       - name: Install Puppeteer Chrome
         working-directory: playground
-        run: ./node_modules/.bin/puppeteer browsers install chrome
+        env:
+          PUPPETEER_CACHE_DIR: ${{ github.workspace }}/.cache/puppeteer
+          PUPPETEER_CHROME_HEADLESS_SHELL_SKIP_DOWNLOAD: true
+        run: |
+          node node_modules/puppeteer/install.mjs
+          node -e "console.log(require('puppeteer').executablePath())"
 
       - name: Run playground checks
         run: |
@@ -107,3 +112,4 @@ jobs:
           npm --prefix playground run test
         env:
           CI: true
+          PUPPETEER_CACHE_DIR: ${{ github.workspace }}/.cache/puppeteer

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,7 +97,8 @@ jobs:
           npm ci --prefix playground
 
       - name: Install Puppeteer Chrome
-        run: npm --prefix playground exec -- puppeteer browsers install chrome
+        working-directory: playground
+        run: ./node_modules/.bin/puppeteer browsers install chrome
 
       - name: Run playground checks
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -100,12 +100,31 @@ jobs:
         working-directory: playground
         env:
           PUPPETEER_CACHE_DIR: ${{ github.workspace }}/.cache/puppeteer
-          PUPPETEER_SKIP_DOWNLOAD: false
-          PUPPETEER_CHROME_SKIP_DOWNLOAD: false
-          PUPPETEER_SKIP_CHROME_DOWNLOAD: false
-          PUPPETEER_CHROME_HEADLESS_SHELL_SKIP_DOWNLOAD: true
         run: |
-          node node_modules/puppeteer/install.mjs
+          node <<'NODE'
+          (async () => {
+            const { Browser, detectBrowserPlatform, install } = require('@puppeteer/browsers');
+            const { PUPPETEER_REVISIONS } = require('./node_modules/puppeteer-core/lib/cjs/puppeteer/revisions.js');
+
+            const platform = detectBrowserPlatform();
+            if (!platform) {
+              throw new Error('Unable to detect browser platform');
+            }
+
+            const result = await install({
+              browser: Browser.CHROME,
+              buildId: PUPPETEER_REVISIONS.chrome,
+              cacheDir: process.env.PUPPETEER_CACHE_DIR,
+              platform,
+              downloadProgressCallback: 'default',
+            });
+
+            console.log(`chrome (${result.buildId}) downloaded to ${result.path}`);
+          })().catch((error) => {
+            console.error(error);
+            process.exit(1);
+          });
+          NODE
           CHROME_PATH="$(node -e "process.stdout.write(require('puppeteer').executablePath())")"
           test -x "$CHROME_PATH"
           echo "$CHROME_PATH"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,12 @@ jobs:
           npm ci --prefix playground
       - name: Install Puppeteer Chrome
         working-directory: playground
-        run: ./node_modules/.bin/puppeteer browsers install chrome
+        env:
+          PUPPETEER_CACHE_DIR: ${{ github.workspace }}/.cache/puppeteer
+          PUPPETEER_CHROME_HEADLESS_SHELL_SKIP_DOWNLOAD: true
+        run: |
+          node node_modules/puppeteer/install.mjs
+          node -e "console.log(require('puppeteer').executablePath())"
       - name: Run playground checks
         run: |
           npm --prefix playground run lint
@@ -109,3 +114,4 @@ jobs:
           npm --prefix playground run test
         env:
           CI: true
+          PUPPETEER_CACHE_DIR: ${{ github.workspace }}/.cache/puppeteer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,37 +99,15 @@ jobs:
       - name: Install playground dependencies
         run: |
           npm ci --prefix playground
-      - name: Install Puppeteer Chrome
-        working-directory: playground
-        env:
-          PUPPETEER_CACHE_DIR: ${{ github.workspace }}/.cache/puppeteer
+      - name: Configure Puppeteer Chrome
         run: |
-          node <<'NODE'
-          (async () => {
-            const { Browser, detectBrowserPlatform, install } = require('@puppeteer/browsers');
-            const { PUPPETEER_REVISIONS } = require('./node_modules/puppeteer-core/lib/cjs/puppeteer/revisions.js');
-
-            const platform = detectBrowserPlatform();
-            if (!platform) {
-              throw new Error('Unable to detect browser platform');
-            }
-
-            const result = await install({
-              browser: Browser.CHROME,
-              buildId: PUPPETEER_REVISIONS.chrome,
-              cacheDir: process.env.PUPPETEER_CACHE_DIR,
-              platform,
-              downloadProgressCallback: 'default',
-            });
-
-            console.log(`chrome (${result.buildId}) downloaded to ${result.path}`);
-          })().catch((error) => {
-            console.error(error);
-            process.exit(1);
-          });
-          NODE
-          CHROME_PATH="$(node -e "process.stdout.write(require('puppeteer').executablePath())")"
+          CHROME_PATH="$(command -v google-chrome || command -v google-chrome-stable || command -v chromium || command -v chromium-browser || true)"
+          if [ -z "$CHROME_PATH" ]; then
+            echo "No system Chrome executable found" >&2
+            exit 1
+          fi
           test -x "$CHROME_PATH"
+          echo "PUPPETEER_EXECUTABLE_PATH=$CHROME_PATH" >> "$GITHUB_ENV"
           echo "$CHROME_PATH"
       - name: Run playground checks
         run: |
@@ -138,4 +116,3 @@ jobs:
           npm --prefix playground run test
         env:
           CI: true
-          PUPPETEER_CACHE_DIR: ${{ github.workspace }}/.cache/puppeteer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,8 @@ jobs:
         run: |
           npm ci --prefix playground
       - name: Install Puppeteer Chrome
-        run: npm --prefix playground exec -- puppeteer browsers install chrome
+        working-directory: playground
+        run: ./node_modules/.bin/puppeteer browsers install chrome
       - name: Run playground checks
         run: |
           npm --prefix playground run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,10 +103,15 @@ jobs:
         working-directory: playground
         env:
           PUPPETEER_CACHE_DIR: ${{ github.workspace }}/.cache/puppeteer
+          PUPPETEER_SKIP_DOWNLOAD: false
+          PUPPETEER_CHROME_SKIP_DOWNLOAD: false
+          PUPPETEER_SKIP_CHROME_DOWNLOAD: false
           PUPPETEER_CHROME_HEADLESS_SHELL_SKIP_DOWNLOAD: true
         run: |
           node node_modules/puppeteer/install.mjs
-          node -e "console.log(require('puppeteer').executablePath())"
+          CHROME_PATH="$(node -e "process.stdout.write(require('puppeteer').executablePath())")"
+          test -x "$CHROME_PATH"
+          echo "$CHROME_PATH"
       - name: Run playground checks
         run: |
           npm --prefix playground run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,12 +103,31 @@ jobs:
         working-directory: playground
         env:
           PUPPETEER_CACHE_DIR: ${{ github.workspace }}/.cache/puppeteer
-          PUPPETEER_SKIP_DOWNLOAD: false
-          PUPPETEER_CHROME_SKIP_DOWNLOAD: false
-          PUPPETEER_SKIP_CHROME_DOWNLOAD: false
-          PUPPETEER_CHROME_HEADLESS_SHELL_SKIP_DOWNLOAD: true
         run: |
-          node node_modules/puppeteer/install.mjs
+          node <<'NODE'
+          (async () => {
+            const { Browser, detectBrowserPlatform, install } = require('@puppeteer/browsers');
+            const { PUPPETEER_REVISIONS } = require('./node_modules/puppeteer-core/lib/cjs/puppeteer/revisions.js');
+
+            const platform = detectBrowserPlatform();
+            if (!platform) {
+              throw new Error('Unable to detect browser platform');
+            }
+
+            const result = await install({
+              browser: Browser.CHROME,
+              buildId: PUPPETEER_REVISIONS.chrome,
+              cacheDir: process.env.PUPPETEER_CACHE_DIR,
+              platform,
+              downloadProgressCallback: 'default',
+            });
+
+            console.log(`chrome (${result.buildId}) downloaded to ${result.path}`);
+          })().catch((error) => {
+            console.error(error);
+            process.exit(1);
+          });
+          NODE
           CHROME_PATH="$(node -e "process.stdout.write(require('puppeteer').executablePath())")"
           test -x "$CHROME_PATH"
           echo "$CHROME_PATH"

--- a/packages/cli/__tests__/doctor.test.ts
+++ b/packages/cli/__tests__/doctor.test.ts
@@ -146,7 +146,7 @@ describe('doctor command', () => {
     );
   });
 
-  it('returns field-level input hints for asset-like strings, barcode strings, table, date/time, select, checkbox, radioGroup, and multiVariableText discovery', () => {
+  it('returns field-level input hints for asset-like strings, barcode strings, table, date/time, select, checkbox, circleMark, radioGroup, and multiVariableText discovery', () => {
     const file = join(TMP, 'doctor-input-hints.json');
     writeFileSync(
       file,
@@ -183,6 +183,13 @@ describe('doctor command', () => {
               name: 'approved',
               type: 'checkbox',
               position: { x: 20, y: 95 },
+              width: 10,
+              height: 10,
+            },
+            {
+              name: 'applicableItem',
+              type: 'circleMark',
+              position: { x: 35, y: 95 },
               width: 10,
               height: 10,
             },
@@ -312,6 +319,15 @@ describe('doctor command', () => {
         expect.objectContaining({
           name: 'approved',
           type: 'checkbox',
+          expectedInput: {
+            kind: 'enumString',
+            allowedValues: ['false', 'true'],
+            example: 'true',
+          },
+        }),
+        expect.objectContaining({
+          name: 'applicableItem',
+          type: 'circleMark',
           expectedInput: {
             kind: 'enumString',
             allowedValues: ['false', 'true'],

--- a/packages/cli/__tests__/generate.test.ts
+++ b/packages/cli/__tests__/generate.test.ts
@@ -493,6 +493,49 @@ describe('generate command', () => {
     expect(parsed.error.message).toContain('Received boolean');
   });
 
+  it('returns structured EVALIDATE when circleMark input uses a boolean', () => {
+    const workDir = join(TMP, 'invalid-circle-mark-boolean');
+    mkdirSync(workDir, { recursive: true });
+
+    writeFileSync(
+      join(workDir, 'job.json'),
+      JSON.stringify({
+        template: {
+          basePdf: a4BasePdf(),
+          schemas: [
+            [
+              {
+                name: 'applicableItem',
+                type: 'circleMark',
+                position: { x: 20, y: 20 },
+                width: 10,
+                height: 10,
+              },
+            ],
+          ],
+        },
+        inputs: [{ applicableItem: true }],
+      }),
+    );
+
+    const result = runCli([
+      'generate',
+      join(workDir, 'job.json'),
+      '-o',
+      join(workDir, 'out.pdf'),
+      '--json',
+    ]);
+
+    expect(result.exitCode).toBe(1);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error.code).toBe('EVALIDATE');
+    expect(parsed.error.message).toContain('Field "applicableItem" (circleMark)');
+    expect(parsed.error.message).toContain('expects one of: "false", "true"');
+    expect(parsed.error.message).toContain('Example: "true"');
+    expect(parsed.error.message).toContain('Received boolean');
+  });
+
   it('returns structured EVALIDATE when radioGroup sets multiple fields in the same group to true', () => {
     const workDir = join(TMP, 'invalid-radio-group-selection');
     mkdirSync(workDir, { recursive: true });

--- a/packages/cli/__tests__/schema-plugins.test.ts
+++ b/packages/cli/__tests__/schema-plugins.test.ts
@@ -16,6 +16,7 @@ describe('schema plugin discovery', () => {
         'code128',
         'radioGroup',
         'checkbox',
+        'circleMark',
       ]),
     );
   });

--- a/packages/cli/__tests__/validate.test.ts
+++ b/packages/cli/__tests__/validate.test.ts
@@ -393,7 +393,7 @@ describe('validate command', () => {
     });
   });
 
-  it('returns field-level input hints for text, asset-like strings, barcode strings, table, date/time, select, checkbox, radioGroup, and multiVariableText', () => {
+  it('returns field-level input hints for text, asset-like strings, barcode strings, table, date/time, select, checkbox, circleMark, radioGroup, and multiVariableText', () => {
     const file = join(TMP, 'input-hints.json');
     writeFileSync(
       file,
@@ -430,6 +430,13 @@ describe('validate command', () => {
               name: 'approved',
               type: 'checkbox',
               position: { x: 20, y: 95 },
+              width: 10,
+              height: 10,
+            },
+            {
+              name: 'applicableItem',
+              type: 'circleMark',
+              position: { x: 35, y: 95 },
               width: 10,
               height: 10,
             },
@@ -561,6 +568,16 @@ describe('validate command', () => {
         expect.objectContaining({
           name: 'approved',
           type: 'checkbox',
+          pages: [1],
+          expectedInput: {
+            kind: 'enumString',
+            allowedValues: ['false', 'true'],
+            example: 'true',
+          },
+        }),
+        expect.objectContaining({
+          name: 'applicableItem',
+          type: 'circleMark',
           pages: [1],
           expectedInput: {
             kind: 'enumString',
@@ -892,6 +909,43 @@ describe('validate command', () => {
     expect(parsed.valid).toBe(false);
     expect(parsed.errors).toEqual(
       expect.arrayContaining([expect.stringContaining('Field "approved" (checkbox)')]),
+    );
+    expect(parsed.errors).toEqual(
+      expect.arrayContaining([expect.stringContaining('expects one of: "false", "true"')]),
+    );
+  });
+
+  it('marks unified jobs invalid when circleMark input uses a boolean', () => {
+    const file = join(TMP, 'job-invalid-circle-mark.json');
+    writeFileSync(
+      file,
+      JSON.stringify({
+        template: {
+          basePdf: a4BasePdf(),
+          schemas: [
+            [
+              {
+                name: 'applicableItem',
+                type: 'circleMark',
+                position: { x: 20, y: 20 },
+                width: 10,
+                height: 10,
+              },
+            ],
+          ],
+        },
+        inputs: [{ applicableItem: true }],
+      }),
+    );
+
+    const result = runCli(['validate', file, '--json']);
+    expect(result.exitCode).toBe(1);
+
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.valid).toBe(false);
+    expect(parsed.errors).toEqual(
+      expect.arrayContaining([expect.stringContaining('Field "applicableItem" (circleMark)')]),
     );
     expect(parsed.errors).toEqual(
       expect.arrayContaining([expect.stringContaining('expects one of: "false", "true"')]),

--- a/packages/cli/src/diagnostics.ts
+++ b/packages/cli/src/diagnostics.ts
@@ -402,7 +402,7 @@ function buildFieldInputHint(
     };
   }
 
-  if (type === 'checkbox') {
+  if (type === 'checkbox' || type === 'circleMark') {
     return {
       name: schema.name as string,
       type,

--- a/packages/common/__tests__/helper.test.ts
+++ b/packages/common/__tests__/helper.test.ts
@@ -222,17 +222,17 @@ describe('checkGenerateProps', () => {
       }
     };
 
-    expect(() => checkGenerateProps(invalidPluginProps)).toThrow("[@pdfme/common] Invalid argument:\n" +
-      "--------------------------\n" +
-      "ERROR POSITION: plugins.invalid.propPanel.defaultSchema.type\n" +
-      "ERROR MESSAGE: Invalid input: expected string, received undefined\n" +
-      "--------------------------\n" +
-      "ERROR POSITION: plugins.missingPanel.propPanel\n" +
-      "ERROR MESSAGE: Invalid input: expected object, received undefined\n" +
-      "--------------------------\n" +
-      "ERROR POSITION: plugins.missingDefaultSchema.propPanel.defaultSchema\n" +
-      "ERROR MESSAGE: Invalid input: expected object, received undefined\n" +
-      "--------------------------");
+    let errorMessage = '';
+    try {
+      checkGenerateProps(invalidPluginProps);
+    } catch (e) {
+      errorMessage = e instanceof Error ? e.message : String(e);
+    }
+
+    expect(errorMessage).toContain('[@pdfme/common] Invalid argument:');
+    expect(errorMessage).toContain('ERROR POSITION: plugins.invalid.propPanel.defaultSchema.type');
+    expect(errorMessage).toContain('ERROR POSITION: plugins.missingPanel.propPanel');
+    expect(errorMessage).toContain('ERROR POSITION: plugins.missingDefaultSchema.propPanel.defaultSchema');
   });
 
   test('calls checkFont when font option is provided', () => {

--- a/packages/schemas/__tests__/builtins.test.ts
+++ b/packages/schemas/__tests__/builtins.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { builtInPlugins, text } from '../src/index.js';
+import { builtInPlugins, circleMark, text } from '../src/index.js';
 
 describe('builtInPlugins', () => {
   it('keeps the default plugin surface text-only', () => {
     expect(Object.keys(builtInPlugins)).toEqual(['Text']);
     expect(builtInPlugins.Text).toBe(text);
+    expect(Object.values(builtInPlugins)).not.toContain(circleMark);
   });
 });

--- a/packages/schemas/__tests__/circleMark.test.ts
+++ b/packages/schemas/__tests__/circleMark.test.ts
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from 'vitest';
+import { BLANK_PDF, mm2pt, type PDFRenderProps, type UIRenderProps } from '@pdfme/common';
+import * as pdfLib from '@pdfme/pdf-lib';
+import { circleMark } from '../src/index.js';
+import type { CircleMarkSchema } from '../src/types.js';
+
+const getSchema = (overrides: Partial<CircleMarkSchema> = {}): CircleMarkSchema => ({
+  name: 'choice',
+  type: 'circleMark',
+  content: 'false',
+  position: { x: 10, y: 20 },
+  width: 30,
+  height: 40,
+  rotate: 15,
+  opacity: 0.5,
+  color: '#336699',
+  borderWidth: 2,
+  ...overrides,
+});
+
+const renderPdf = (schema: CircleMarkSchema, value: unknown, colorType?: 'rgb' | 'cmyk') => {
+  const page = {
+    getHeight: () => 300,
+    drawEllipse: vi.fn(),
+  };
+
+  circleMark.pdf({
+    value,
+    schema,
+    basePdf: BLANK_PDF,
+    pdfLib,
+    pdfDoc: {},
+    page,
+    options: colorType ? { colorType } : {},
+    _cache: new Map(),
+  } as unknown as PDFRenderProps<CircleMarkSchema>);
+
+  return page.drawEllipse;
+};
+
+const renderUi = (
+  schema: CircleMarkSchema,
+  value: unknown,
+  mode: UIRenderProps<CircleMarkSchema>['mode'] = 'form',
+) => {
+  const rootElement = document.createElement('div');
+  const onChange = vi.fn();
+
+  circleMark.ui({
+    value,
+    schema,
+    rootElement,
+    mode,
+    onChange,
+    basePdf: BLANK_PDF,
+    options: {},
+    theme: { colorPrimary: '#1677ff', colorPrimaryBg: '#e6f4ff', colorWhite: '#ffffff' },
+    i18n: (key: string) => key,
+    scale: 1,
+    _cache: new Map(),
+  } as unknown as UIRenderProps<CircleMarkSchema>);
+
+  return { rootElement, onChange };
+};
+
+describe('circleMark plugin', () => {
+  it('exports the expected default schema', () => {
+    expect(circleMark.propPanel.defaultSchema).toMatchObject({
+      type: 'circleMark',
+      content: 'false',
+      width: 10,
+      height: 10,
+      rotate: 0,
+      opacity: 1,
+      color: '#000000',
+      borderWidth: 1,
+    });
+  });
+
+  it('draws a native PDF ellipse only for the string value true', () => {
+    const schema = getSchema();
+    const drawEllipse = renderPdf(schema, 'true');
+
+    expect(drawEllipse).toHaveBeenCalledTimes(1);
+    expect(drawEllipse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        x: mm2pt(10) + mm2pt(30) / 2,
+        y: 300 - mm2pt(20) - mm2pt(40) + mm2pt(40) / 2,
+        xScale: mm2pt(30) / 2 - mm2pt(2) / 2,
+        yScale: mm2pt(40) / 2 - mm2pt(2) / 2,
+        rotate: { type: 'degrees', angle: -15 },
+        borderWidth: mm2pt(2),
+        borderColor: {
+          type: 'RGB',
+          red: 0.2,
+          green: 0.4,
+          blue: 0.6,
+        },
+        borderOpacity: 0.5,
+      }),
+    );
+
+    expect(renderPdf(schema, 'false')).not.toHaveBeenCalled();
+    expect(renderPdf(schema, '')).not.toHaveBeenCalled();
+    expect(renderPdf(schema, true)).not.toHaveBeenCalled();
+  });
+
+  it('uses CMYK color conversion for PDF output when requested', () => {
+    const drawEllipse = renderPdf(getSchema({ color: '#000000' }), 'true', 'cmyk');
+
+    expect(drawEllipse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        borderColor: { type: 'CMYK', cyan: 0, magenta: 0, yellow: 0, key: 1 },
+      }),
+    );
+  });
+
+  it('does not throw or draw when the mark style cannot produce a visible ellipse', () => {
+    expect(renderPdf(getSchema({ width: 0 }), 'true')).not.toHaveBeenCalled();
+    expect(renderPdf(getSchema({ height: 0 }), 'true')).not.toHaveBeenCalled();
+    expect(renderPdf(getSchema({ borderWidth: 0 }), 'true')).not.toHaveBeenCalled();
+    expect(renderPdf(getSchema({ color: '' }), 'true')).not.toHaveBeenCalled();
+    expect(renderPdf(getSchema({ color: 'invalid' }), 'true')).not.toHaveBeenCalled();
+    expect(renderPdf(getSchema({ width: 1, borderWidth: 2 }), 'true')).not.toHaveBeenCalled();
+  });
+
+  it('renders a clickable area while only showing the mark when selected', () => {
+    const selected = renderUi(getSchema(), 'true');
+    const selectedContainer = selected.rootElement.firstElementChild as HTMLDivElement;
+    const mark = selectedContainer.firstElementChild as HTMLDivElement;
+
+    expect(mark.style.borderRadius).toBe('50%');
+    expect(mark.style.borderStyle).toBe('solid');
+    expect(mark.style.borderColor).toBe('rgb(51, 102, 153)');
+
+    const unselected = renderUi(getSchema(), 'false');
+    const unselectedContainer = unselected.rootElement.firstElementChild as HTMLDivElement;
+
+    expect(unselectedContainer.childElementCount).toBe(0);
+    unselectedContainer.click();
+    expect(unselected.onChange).toHaveBeenCalledWith({ key: 'content', value: 'true' });
+  });
+
+  it('does not toggle read-only form fields', () => {
+    const { rootElement, onChange } = renderUi(getSchema({ readOnly: true }), 'false');
+
+    expect(rootElement.childElementCount).toBe(0);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/schemas/src/circleMark/index.ts
+++ b/packages/schemas/src/circleMark/index.ts
@@ -1,0 +1,120 @@
+import { mm2pt, Plugin, Schema } from '@pdfme/common';
+import { Circle } from 'lucide';
+import { HEX_COLOR_PATTERN } from '../constants.js';
+import { convertForPdfLayoutProps, createSvgStr, hex2PrintingColor, isEditable } from '../utils.js';
+
+export interface CircleMarkSchema extends Schema {
+  color: string;
+  borderWidth: number;
+}
+
+const HEX_COLOR_REGEXP = new RegExp(HEX_COLOR_PATTERN);
+
+const isSelected = (value: unknown) => value === 'true';
+
+const hasRenderableStyle = (schema: CircleMarkSchema) =>
+  schema.width > 0 &&
+  schema.height > 0 &&
+  schema.borderWidth > 0 &&
+  typeof schema.color === 'string' &&
+  HEX_COLOR_REGEXP.test(schema.color);
+
+const circleMark: Plugin<CircleMarkSchema> = {
+  ui: (arg) => {
+    const { schema, value, onChange, rootElement, mode } = arg;
+    const selected = isSelected(value);
+    const editable = isEditable(mode, schema);
+    const shouldRenderMark = selected && hasRenderableStyle(schema);
+    if (!editable && !shouldRenderMark) return;
+
+    const container = document.createElement('div');
+    container.style.width = '100%';
+    container.style.height = '100%';
+    container.style.boxSizing = 'border-box';
+
+    if (editable) {
+      container.style.cursor = 'pointer';
+      container.addEventListener('click', () => {
+        if (onChange) onChange({ key: 'content', value: selected ? 'false' : 'true' });
+      });
+    }
+
+    if (shouldRenderMark) {
+      const mark = document.createElement('div');
+      mark.style.width = '100%';
+      mark.style.height = '100%';
+      mark.style.boxSizing = 'border-box';
+      mark.style.borderRadius = '50%';
+      mark.style.borderWidth = `${schema.borderWidth}mm`;
+      mark.style.borderStyle = 'solid';
+      mark.style.borderColor = schema.color;
+      mark.style.pointerEvents = 'none';
+      container.appendChild(mark);
+    }
+
+    rootElement.appendChild(container);
+  },
+  pdf: (arg) => {
+    const { schema, value, page, options } = arg;
+    if (!isSelected(value) || !hasRenderableStyle(schema)) return;
+
+    const borderWidth = mm2pt(schema.borderWidth);
+    const pageHeight = page.getHeight();
+    const cArg = { schema, pageHeight };
+    const { width, height, rotate, opacity } = convertForPdfLayoutProps(cArg);
+    const {
+      position: { x, y },
+    } = convertForPdfLayoutProps({ ...cArg, applyRotateTranslate: false });
+
+    const xScale = width / 2 - borderWidth / 2;
+    const yScale = height / 2 - borderWidth / 2;
+    if (xScale <= 0 || yScale <= 0) return;
+
+    page.drawEllipse({
+      x: x + width / 2,
+      y: y + height / 2,
+      xScale,
+      yScale,
+      rotate,
+      borderWidth,
+      borderColor: hex2PrintingColor(schema.color, options.colorType),
+      borderOpacity: opacity,
+    });
+  },
+  propPanel: {
+    schema: ({ i18n }) => ({
+      color: {
+        title: i18n('schemas.color'),
+        type: 'string',
+        widget: 'color',
+        props: {
+          disabledAlpha: true,
+        },
+        required: true,
+        rules: [{ pattern: HEX_COLOR_PATTERN, message: i18n('validation.hexColor') }],
+      },
+      borderWidth: {
+        title: i18n('schemas.borderWidth'),
+        type: 'number',
+        widget: 'inputNumber',
+        props: { min: 0, step: 1 },
+        required: true,
+      },
+    }),
+    defaultSchema: {
+      name: '',
+      type: 'circleMark',
+      content: 'false',
+      position: { x: 0, y: 0 },
+      width: 10,
+      height: 10,
+      rotate: 0,
+      opacity: 1,
+      color: '#000000',
+      borderWidth: 1,
+    },
+  },
+  icon: createSvgStr(Circle),
+};
+
+export default circleMark;

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -14,6 +14,7 @@ import time from './date/time.js';
 import select from './select/index.js';
 import radioGroup from './radioGroup/index.js';
 import checkbox from './checkbox/index.js';
+import circleMark from './circleMark/index.js';
 export { builtInPlugins } from './builtins.js';
 
 export {
@@ -35,6 +36,7 @@ export {
   select,
   radioGroup,
   checkbox,
+  circleMark,
 };
 
 // Export utility functions

--- a/packages/schemas/src/types.ts
+++ b/packages/schemas/src/types.ts
@@ -34,4 +34,5 @@ export type { ShapeSchema } from './shapes/rectAndEllipse.js';
 export type { SelectSchema } from './select/index.js';
 export type { RadioGroupSchema } from './radioGroup/index.js';
 export type { CheckboxSchema } from './checkbox/index.js';
+export type { CircleMarkSchema } from './circleMark/index.js';
 export type { BuiltInDynamicLayoutSplitUnit } from './splitRange.js';

--- a/playground/src/plugins/index.ts
+++ b/playground/src/plugins/index.ts
@@ -16,6 +16,7 @@ import {
   select,
   checkbox,
   radioGroup,
+  circleMark,
 } from '@pdfme/schemas';
 
 export const getPlugins = () => {
@@ -37,6 +38,7 @@ export const getPlugins = () => {
     Select: select,
     Checkbox: checkbox,
     RadioGroup: radioGroup,
+    'Circle Mark': circleMark,
     // JAPANPOST: barcodes.japanpost,
     EAN13: barcodes.ean13,
     // EAN8: barcodes.ean8,


### PR DESCRIPTION
## Summary

- Add a `circleMark` schema plugin to `@pdfme/schemas`.
- Export `circleMark` and `CircleMarkSchema`, and register the plugin in the playground as `Circle Mark`.
- Teach CLI diagnostics to treat `circleMark` like `checkbox`, with enum string input values `"false"` and `"true"`.

## Behavior

- Designer/Form clicks toggle `content` between `"false"` and `"true"` when editable.
- Viewer/PDF output render the mark only when the resolved value is exactly `"true"`.
- PDF rendering uses native `page.drawEllipse` and respects size, rotation, opacity, and RGB/CMYK color conversion.

## Validation

- `npm run test -w packages/schemas -- __tests__/circleMark.test.ts __tests__/builtins.test.ts`
- `npm run build -w packages/schemas`
- `npm run lint -w packages/schemas`
- `npm run test -w packages/cli -- __tests__/schema-plugins.test.ts __tests__/validate.test.ts __tests__/doctor.test.ts __tests__/generate.test.ts`
- `npm --prefix playground run lint`
- `npm --prefix playground run build`