### PR TITLE
fix(playground): surface load errors, harden PDF generation, and optimize loading

### DIFF
--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -23,7 +23,6 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^7.16.0",
         "react-toastify": "^11.1.0",
-        "signature_pad": "^5.1.3",
         "sucrase": "^3.35.1"
       },
       "devDependencies": {
@@ -54,10 +53,10 @@
         "@pdfme/pdf-lib": "*",
         "acorn": "^8.16.0",
         "buffer": "^6.0.3",
-        "zod": "^4.3.6"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
-        "@types/estree": "^1.0.6"
+        "@types/estree": "^1.0.9"
       }
     },
     "../packages/converter": {
@@ -129,11 +128,11 @@
       "dependencies": {
         "@pdfme/pdf-lib": "*",
         "air-datepicker": "^3.6.0",
-        "bwip-js": "^4.10.1",
-        "date-fns": "^4.1.0",
-        "dompurify": "^3.4.1",
+        "bwip-js": "^4.11.1",
+        "date-fns": "^4.4.0",
+        "dompurify": "^3.4.7",
         "fontkit": "^2.0.2",
-        "lucide": "^1.12.0",
+        "lucide": "^1.17.0",
         "signature_pad": "^5.1.3"
       },
       "devDependencies": {
@@ -159,11 +158,11 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@pdfme/converter": "*",
         "@scena/react-guides": "^0.28.2",
-        "antd": "^6.3.7",
-        "dompurify": "^3.4.1",
+        "antd": "^6.4.3",
+        "dompurify": "^3.4.7",
         "form-render": "^2.5.5",
-        "hotkeys-js": "^4.0.3",
-        "lucide-react": "^1.12.0",
+        "hotkeys-js": "^4.0.4",
+        "lucide-react": "^1.17.0",
         "rc-field-form": "^2.7.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -177,9 +176,9 @@
         "@testing-library/react": "^16.3.0",
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
-        "@vitejs/plugin-react": "^6.0.1",
+        "@vitejs/plugin-react": "^6.0.2",
         "csstype": "^3.2.3",
-        "vite": "^8.0.10",
+        "vite": "^8.0.14",
         "vite-plugin-css-injected-by-js": "^5.0.1",
         "vite-tsconfig-paths": "^6.1.1"
       },
@@ -6000,12 +5999,6 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/signature_pad": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-5.1.3.tgz",
-      "integrity": "sha512-zyxW5vuJVnQdGcU+kAj9FYl7WaAunY3kA5S7mPg0xJiujL9+sPAWfSQHS5tXaJXDUa4FuZeKhfdCDQ6K3wfkpQ==",
-      "license": "MIT"
     },
     "node_modules/sirv": {
       "version": "3.0.2",

--- a/playground/package.json
+++ b/playground/package.json
@@ -32,7 +32,6 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^7.16.0",
     "react-toastify": "^11.1.0",
-    "signature_pad": "^5.1.3",
     "sucrase": "^3.35.1"
   },
   "devDependencies": {

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -1,11 +1,14 @@
 import { Suspense, lazy } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import { ToastContainer } from 'react-toastify';
-import Designer from './routes/Designer';
-import FormAndViewer from './routes/FormAndViewer';
-import Templates, { WorkspaceApp } from './routes/Templates';
 import Header from './components/Header';
 
+const Designer = lazy(() => import('./routes/Designer'));
+const FormAndViewer = lazy(() => import('./routes/FormAndViewer'));
+const Templates = lazy(() => import('./routes/Templates'));
+const WorkspaceApp = lazy(() =>
+  import('./routes/Templates').then((module) => ({ default: module.WorkspaceApp })),
+);
 const JsxPlayground = lazy(() => import('./routes/JsxPlayground'));
 const Md2Pdf = lazy(() => import('./routes/Md2Pdf'));
 

--- a/playground/src/helper.ts
+++ b/playground/src/helper.ts
@@ -8,6 +8,8 @@ import {
 } from '@pdfme/common';
 import { Form, Viewer, Designer } from '@pdfme/ui';
 import { generate, generateForm } from '@pdfme/generator';
+import { toast } from 'react-toastify';
+import { getErrorMessage } from './lib/errors';
 import { getPlugins } from './plugins';
 
 const templateAssetSourceKinds = ['designer', 'jsx', 'md2pdf'] as const;
@@ -49,22 +51,25 @@ const getFormFontsData = (): Font =>
     ]),
   );
 
-export const readFile = (file: File | null, type: 'text' | 'dataURL' | 'arrayBuffer') => {
-  return new Promise<string | ArrayBuffer>((r) => {
+export const readFile = (file: File, type: 'text' | 'dataURL' | 'arrayBuffer') => {
+  return new Promise<string | ArrayBuffer>((resolve, reject) => {
     const fileReader = new FileReader();
-    fileReader.addEventListener('load', (e) => {
-      if (e && e.target && e.target.result && file !== null) {
-        r(e.target.result);
+    fileReader.addEventListener('load', () => {
+      if (fileReader.result != null) {
+        resolve(fileReader.result);
+      } else {
+        reject(new Error(`Failed to read file "${file.name}"`));
       }
     });
-    if (file !== null) {
-      if (type === 'text') {
-        fileReader.readAsText(file);
-      } else if (type === 'dataURL') {
-        fileReader.readAsDataURL(file);
-      } else if (type === 'arrayBuffer') {
-        fileReader.readAsArrayBuffer(file);
-      }
+    fileReader.addEventListener('error', () => {
+      reject(fileReader.error ?? new Error(`Failed to read file "${file.name}"`));
+    });
+    if (type === 'text') {
+      fileReader.readAsText(file);
+    } else if (type === 'dataURL') {
+      fileReader.readAsDataURL(file);
+    } else {
+      fileReader.readAsArrayBuffer(file);
     }
   });
 };
@@ -100,8 +105,8 @@ export const translations: { label: string; value: string }[] = [
 export const generatePDF = async (
   currentRef: Designer | Form | Viewer | null,
   output: 'pdf' | 'form' = 'pdf',
-) => {
-  if (!currentRef) return;
+): Promise<boolean> => {
+  if (!currentRef) return false;
   const template = currentRef.getTemplate();
   const options = currentRef.getOptions();
   const inputs =
@@ -122,11 +127,18 @@ export const generatePDF = async (
       plugins: getPlugins(),
     });
 
-    const blob = new Blob([pdf.buffer], { type: 'application/pdf' });
-    window.open(URL.createObjectURL(blob));
+    // Copy into a fresh Uint8Array so the Blob never picks up extra bytes
+    // when the result is a view over a larger ArrayBuffer.
+    const blob = new Blob([new Uint8Array(pdf)], { type: 'application/pdf' });
+    const url = URL.createObjectURL(blob);
+    window.open(url);
+    // Release the object URL once the new tab has had time to load it.
+    window.setTimeout(() => URL.revokeObjectURL(url), 60_000);
+    return true;
   } catch (e) {
-    alert(e + '\n\nCheck the console for full stack trace');
-    throw e;
+    console.error(e);
+    toast.error(`${getErrorMessage(e)} (check the console for the full stack trace)`);
+    return false;
   }
 };
 
@@ -151,11 +163,14 @@ export const getBlankTemplate = () =>
   }) as Template;
 
 export const getTemplateById = async (templateId: string): Promise<Template> => {
-  const template = await fetch(`/template-assets/${templateId}/template.json`).then((res) =>
-    res.json(),
-  );
+  const response = await fetch(`/template-assets/${templateId}/template.json`);
+  if (!response.ok) {
+    throw new Error(`Failed to load template "${templateId}": ${response.statusText}`);
+  }
+
+  const template = (await response.json()) as Template;
   checkTemplate(template);
-  return template as Template;
+  return template;
 };
 
 export const getTemplateMetadataById = async (

--- a/playground/src/index.tsx
+++ b/playground/src/index.tsx
@@ -8,10 +8,10 @@ import { initPdfmeAgentLoader } from './lib/pdfmeAgentLoader';
 
 initPdfmeAgentLoader();
 
-// Initialize Sentry
-Sentry.init({
-  dsn: import.meta.env.VITE_SENTRY_DSN || '',
-});
+const sentryDsn = import.meta.env.VITE_SENTRY_DSN;
+if (sentryDsn) {
+  Sentry.init({ dsn: sentryDsn });
+}
 
 const container = document.getElementById('root');
 if (!container) throw new Error('Root element not found');

--- a/playground/src/lib/playgroundProjects.ts
+++ b/playground/src/lib/playgroundProjects.ts
@@ -37,6 +37,8 @@ export type PlaygroundProjectStorage = {
   clearActiveProjectId: () => Promise<void>;
   deleteProject: (projectId: string) => Promise<void>;
   getActiveProjectId: () => Promise<string | null>;
+  /** Optional fast path for single-project lookups; falls back to readProjects. */
+  getProject?: (projectId: string) => Promise<unknown>;
   putProject: (project: PlaygroundProject) => Promise<void>;
   readProjects: () => Promise<unknown[]>;
   setActiveProjectId: (projectId: string) => Promise<void>;
@@ -235,6 +237,15 @@ const defaultProjectStorage: PlaygroundProjectStorage = {
       db.close();
     }
   },
+  getProject: async (projectId: string) => {
+    const db = await openProjectsDb();
+    try {
+      const transaction = db.transaction(PROJECTS_STORE_NAME, 'readonly');
+      return await idbRequest<unknown>(transaction.objectStore(PROJECTS_STORE_NAME).get(projectId));
+    } finally {
+      db.close();
+    }
+  },
   putProject: async (project: PlaygroundProject) => {
     const db = await openProjectsDb();
     try {
@@ -251,9 +262,7 @@ const defaultProjectStorage: PlaygroundProjectStorage = {
     const db = await openProjectsDb();
     try {
       const transaction = db.transaction(PROJECTS_STORE_NAME, 'readonly');
-      return await idbRequest<unknown[]>(
-        transaction.objectStore(PROJECTS_STORE_NAME).getAll(),
-      );
+      return await idbRequest<unknown[]>(transaction.objectStore(PROJECTS_STORE_NAME).getAll());
     } finally {
       db.close();
     }
@@ -295,8 +304,21 @@ export const readPlaygroundProjects = async (
 export const getPlaygroundProject = async (
   projectId: string,
   storage: PlaygroundProjectStorage = defaultProjectStorage,
-): Promise<PlaygroundProject | null> =>
-  (await readPlaygroundProjects(storage)).find((project) => project.id === projectId) ?? null;
+): Promise<PlaygroundProject | null> => {
+  if (storage.getProject) {
+    try {
+      const project = parseProject(await storage.getProject(projectId));
+      return project?.id === projectId ? project : null;
+    } catch (error) {
+      console.error(error);
+      return null;
+    }
+  }
+
+  return (
+    (await readPlaygroundProjects(storage)).find((project) => project.id === projectId) ?? null
+  );
+};
 
 export const savePlaygroundProject = async (
   input: SavePlaygroundProjectInput,
@@ -304,8 +326,7 @@ export const savePlaygroundProject = async (
 ): Promise<PlaygroundProject> => {
   checkTemplate(input.template);
 
-  const projects = await readPlaygroundProjects(storage);
-  const existing = input.id ? projects.find((project) => project.id === input.id) : undefined;
+  const existing = input.id ? await getPlaygroundProject(input.id, storage) : null;
   const now = Date.now();
   let savedProject: PlaygroundProject = {
     createdAt: existing?.createdAt ?? now,
@@ -350,8 +371,7 @@ export const renamePlaygroundProject = async (
   title: string,
   storage: PlaygroundProjectStorage = defaultProjectStorage,
 ) => {
-  const projects = await readPlaygroundProjects(storage);
-  const project = projects.find((item) => item.id === projectId);
+  const project = await getPlaygroundProject(projectId, storage);
   if (!project) return null;
 
   const updatedProject: PlaygroundProject = {

--- a/playground/src/routes/Designer.tsx
+++ b/playground/src/routes/Designer.tsx
@@ -461,7 +461,6 @@ function DesignerApp() {
             getTemplateById(templateIdFromQuery),
             getTemplateMetadataById(templateIdFromQuery),
           ]);
-          checkTemplate(templateJson);
           template = templateJson;
           currentMetadataRef.current = metadata;
           setCurrentProjectTitle(metadata.title);
@@ -571,6 +570,7 @@ function DesignerApp() {
         projectRef.current = null;
         setActiveFileWorkspaceEntry(null, null);
         console.error(error);
+        toast.error(getErrorMessage(error));
         return null;
       }
     },
@@ -724,7 +724,9 @@ function DesignerApp() {
         if (nextMetadata) {
           const currentEntry = fileWorkspaceEntryRef.current;
           if (!currentEntry) {
-            throw new Error('AI metadata update was not saved because the mounted template closed.');
+            throw new Error(
+              'AI metadata update was not saved because the mounted template closed.',
+            );
           }
           const updatedEntry = await writeTemplateEntryMetadata(currentEntry, nextMetadata);
           fileWorkspaceEntryRef.current = updatedEntry;
@@ -1144,7 +1146,8 @@ function DesignerApp() {
             onClick={async (e) => {
               const output = e.altKey ? 'form' : 'pdf';
               const startTimer = performance.now();
-              await generatePDF(designer.current, output);
+              const generated = await generatePDF(designer.current, output);
+              if (!generated) return;
               const endTimer = performance.now();
               toast.info(
                 `Generated ${output === 'form' ? 'Form' : 'PDF'} in ${Math.round(

--- a/playground/src/routes/FormAndViewer.tsx
+++ b/playground/src/routes/FormAndViewer.tsx
@@ -2,7 +2,7 @@ import { useRef, useState, useEffect, useCallback } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { Pencil } from 'lucide-react';
-import { Template, checkTemplate, getInputFromTemplate, Lang } from '@pdfme/common';
+import { Template, getInputFromTemplate, Lang } from '@pdfme/common';
 import { Form, Viewer } from '@pdfme/ui';
 import {
   getFontsData,
@@ -16,10 +16,8 @@ import {
 import { getPlugins } from '../plugins';
 import PlaygroundButton from '../components/PlaygroundButton';
 import { NavItem, NavBar } from '../components/NavBar';
-import {
-  getActivePlaygroundProject,
-  getPlaygroundProject,
-} from '../lib/playgroundProjects';
+import { getErrorMessage } from '../lib/errors';
+import { getActivePlaygroundProject, getPlaygroundProject } from '../lib/playgroundProjects';
 import {
   FileWorkspaceTemplateDeletedError,
   FileWorkspaceTemplateInvalidError,
@@ -47,7 +45,9 @@ function FormAndViewerApp() {
   const currentTemplateRef = useRef<Template | null>(null);
   const currentInputsRef = useRef<Record<string, string>[] | null>(null);
 
-  const [mode, setMode] = useState<Mode>((localStorage.getItem('mode') as Mode) ?? 'form');
+  const [mode, setMode] = useState<Mode>(() =>
+    localStorage.getItem('mode') === 'viewer' ? 'viewer' : 'form',
+  );
   const [fileWorkspaceEntry, setFileWorkspaceEntry] = useState<FileWorkspaceTemplateEntry | null>(
     null,
   );
@@ -125,9 +125,7 @@ function FormAndViewerApp() {
           diskVersionRef.current = null;
           setFileWorkspaceEntry(null);
           setFileWorkspaceStatus(null);
-          const templateJson = await getTemplateById(templateIdFromQuery);
-          checkTemplate(templateJson);
-          template = templateJson;
+          template = await getTemplateById(templateIdFromQuery);
         } else {
           fileWorkspaceEntryRef.current = null;
           diskVersionRef.current = null;
@@ -176,6 +174,7 @@ function FormAndViewerApp() {
         currentTemplateRef.current = null;
         currentInputsRef.current = null;
         console.error(error);
+        toast.error(getErrorMessage(error));
       }
     },
     [destroyCurrentUi, searchParams],
@@ -345,7 +344,8 @@ function FormAndViewerApp() {
           onClick={async (e) => {
             const output = e.altKey ? 'form' : 'pdf';
             const startTimer = performance.now();
-            await generatePDF(ui.current, output);
+            const generated = await generatePDF(ui.current, output);
+            if (!generated) return;
             const endTimer = performance.now();
             toast.info(
               `Generated ${output === 'form' ? 'Form' : 'PDF'} in ${Math.round(

--- a/playground/src/routes/JsxPlayground.tsx
+++ b/playground/src/routes/JsxPlayground.tsx
@@ -372,12 +372,12 @@ export default function JsxPlayground() {
     const startTimer = performance.now();
     setIsGeneratingPdf(true);
     try {
-      await generatePDF(previewRef.current);
-      const duration = Math.round(performance.now() - startTimer);
-      setPdfDuration(duration);
-      toast.info(`Generated PDF in ${duration}ms`);
-    } catch (error) {
-      toast.error(getErrorMessage(error));
+      const generated = await generatePDF(previewRef.current);
+      if (generated) {
+        const duration = Math.round(performance.now() - startTimer);
+        setPdfDuration(duration);
+        toast.info(`Generated PDF in ${duration}ms`);
+      }
     } finally {
       setIsGeneratingPdf(false);
     }

--- a/playground/src/routes/Md2Pdf.tsx
+++ b/playground/src/routes/Md2Pdf.tsx
@@ -217,10 +217,12 @@ export default function Md2Pdf() {
     const startTimer = performance.now();
     setIsGeneratingPdf(true);
     try {
-      await generatePDF(viewerRef.current);
-      const duration = Math.round(performance.now() - startTimer);
-      setPdfDuration(duration);
-      toast.info(`Generated PDF in ${duration}ms`);
+      const generated = await generatePDF(viewerRef.current);
+      if (generated) {
+        const duration = Math.round(performance.now() - startTimer);
+        setPdfDuration(duration);
+        toast.info(`Generated PDF in ${duration}ms`);
+      }
     } finally {
       setIsGeneratingPdf(false);
     }

--- a/playground/src/routes/Templates.tsx
+++ b/playground/src/routes/Templates.tsx
@@ -94,6 +94,10 @@ type AuthoringPreset = {
 // Constants
 const DEVIN_AI_AUTHOR = 'Devin AI';
 const DEVIN_INVITE_URL = 'https://app.devin.ai/invite/KyOTXVPrlFl2TjcT';
+
+// GitHub serves user/org avatars at this URL, so no rate-limited API call is needed.
+const getAuthorAvatarUrl = (author: string) =>
+  author === DEVIN_AI_AUTHOR ? '/imgs/devin.svg' : `https://github.com/${author}.png?size=56`;
 const tagSortOrder = [
   'Invoice',
   'Quote',
@@ -716,7 +720,6 @@ function TemplatesApp({ view = 'templates' }: TemplatesAppProps) {
   const fileWorkspaceSupported = isFileWorkspaceSupported();
 
   const [templates, setTemplates] = useState<TemplateData[]>([]);
-  const [avatarUrlMap, setAvatarUrlMap] = useState<{ [key: string]: string }>({});
   const [projects, setProjects] = useState<PlaygroundProject[]>([]);
   const [isLoadingProjects, setIsLoadingProjects] = useState(true);
   const [mountedCollection, setMountedCollection] = useState<FileWorkspaceCollection | null>(null);
@@ -882,34 +885,23 @@ function TemplatesApp({ view = 'templates' }: TemplatesAppProps) {
     );
   }, [mountedCollection?.rootHandle, shouldSkipMountedCollectionRefresh, showWorkspace]);
 
-  // Fetch templates and author avatars
+  // Fetch templates
   useEffect(() => {
     if (!showTemplateGallery) return;
 
     fetch('/template-assets/index.json')
-      .then((response) => response.json())
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to load templates: ${response.statusText}`);
+        }
+        return response.json();
+      })
       .then((data: TemplateData[]) => {
         setTemplates(data);
-
-        const authors = new Set(data.map(({ author }) => author));
-        const avatarUrlMap: { [key: string]: string } = {};
-
-        Promise.all(
-          Array.from(authors).map((author) => {
-            if (author === DEVIN_AI_AUTHOR) {
-              avatarUrlMap[author] = '/imgs/devin.svg';
-              return Promise.resolve();
-            } else {
-              return fetch(`https://api.github.com/users/${author}`)
-                .then((res) => res.json())
-                .then((ghData) => {
-                  avatarUrlMap[author] = ghData.avatar_url;
-                });
-            }
-          }),
-        ).then(() => {
-          setAvatarUrlMap(avatarUrlMap);
-        });
+      })
+      .catch((error) => {
+        console.error(error);
+        toast.error(error instanceof Error ? error.message : 'Failed to load templates');
       });
   }, [showTemplateGallery]);
 
@@ -1118,18 +1110,13 @@ function TemplatesApp({ view = 'templates' }: TemplatesAppProps) {
       const draft = await createTemplateFromPdfFile(file);
       const thumbnail = await createTemplateThumbnailDataUrl(draft.template).catch(() => undefined);
       const { nextCollection, nextEntry } = await runMountedCollectionWrite(async () => {
-        const entry = await createTemplateEntryFromTemplate(
-          collection,
-          draft.template,
-          title,
-          {
-            description: `A template created from ${draft.fileName}.`,
-            sourceKind: 'designer',
-            sourcePdf: file,
-            tags: ['PDF', 'Designer'],
-            thumbnailDataUrl: thumbnail,
-          },
-        );
+        const entry = await createTemplateEntryFromTemplate(collection, draft.template, title, {
+          description: `A template created from ${draft.fileName}.`,
+          sourceKind: 'designer',
+          sourcePdf: file,
+          tags: ['PDF', 'Designer'],
+          thumbnailDataUrl: thumbnail,
+        });
         const collectionAfterCreate = await refreshTemplateCollection({
           ...collection,
           selectedTemplateName: entry.name,
@@ -1458,8 +1445,8 @@ function TemplatesApp({ view = 'templates' }: TemplatesAppProps) {
                 </div>
                 {!fileWorkspaceSupported && (
                   <div className="mt-4 rounded-md border border-dashed border-green-300 bg-white px-4 py-4 text-sm text-green-900">
-                    Folder workspaces need a Chromium browser in a secure context. Browser
-                    projects, JSON import, and JSON download are still available.
+                    Folder workspaces need a Chromium browser in a secure context. Browser projects,
+                    JSON import, and JSON download are still available.
                   </div>
                 )}
                 {mountedCollection && (
@@ -1560,149 +1547,151 @@ function TemplatesApp({ view = 'templates' }: TemplatesAppProps) {
         )}
         {showTemplateGallery && (
           <section>
-          <div className="border-b border-dashed border-gray-200 pb-2">
-            <div>
-              <h2 className="text-2xl font-bold text-gray-900">Templates</h2>
-              <p className="mt-2 max-w-3xl text-sm text-gray-600">
-                Choose a Designer sample, JSX starter, or md2pdf starter from the same gallery.
-              </p>
-            </div>
-          </div>
-          <div className="mt-4 rounded-lg border border-gray-200 bg-gray-50 p-3">
-            <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-              <div className="min-w-0 flex-1 space-y-3">
-                <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-                  <span className="w-24 text-xs font-semibold uppercase tracking-wide text-gray-500">
-                    Type
-                  </span>
-                  <div className="flex flex-wrap gap-2">
-                    {generationFilters.map((filter) => (
-                      <PlaygroundButton
-                        key={filter.value}
-                        className="px-2 py-1 text-xs sm:px-2"
-                        variant={generationFilter === filter.value ? 'primary' : 'secondary'}
-                        onClick={() => setGenerationFilter(filter.value)}
-                      >
-                        {filter.label}
-                      </PlaygroundButton>
-                    ))}
-                  </div>
-                </div>
-                <div className="flex flex-col gap-2 sm:flex-row sm:items-start">
-                  <span className="w-24 pt-1 text-xs font-semibold uppercase tracking-wide text-gray-500">
-                    Tags
-                  </span>
-                  <div className="flex flex-wrap gap-2">
-                    <PlaygroundButton
-                      className="px-2 py-1 text-xs sm:px-2"
-                      variant={tagFilter === 'all' ? 'primary' : 'secondary'}
-                      onClick={() => setTemplateTagFilter('all')}
-                    >
-                      All
-                    </PlaygroundButton>
-                    {tagOptions.map((tag) => (
-                      <PlaygroundButton
-                        key={tag}
-                        className="px-2 py-1 text-xs sm:px-2"
-                        variant={tagFilter === tag ? 'primary' : 'secondary'}
-                        onClick={() => setTemplateTagFilter(tag)}
-                      >
-                        {tag}
-                      </PlaygroundButton>
-                    ))}
-                  </div>
-                </div>
+            <div className="border-b border-dashed border-gray-200 pb-2">
+              <div>
+                <h2 className="text-2xl font-bold text-gray-900">Templates</h2>
+                <p className="mt-2 max-w-3xl text-sm text-gray-600">
+                  Choose a Designer sample, JSX starter, or md2pdf starter from the same gallery.
+                </p>
               </div>
-              {hasActiveTemplateFilter && (
-                <PlaygroundButton variant="ghost" onClick={clearTemplateFilters}>
-                  Clear
-                </PlaygroundButton>
-              )}
             </div>
-          </div>
-          <div className="mt-8 grid grid-cols-1 gap-y-8 sm:grid-cols-2 sm:gap-x-6 lg:grid-cols-4 xl:gap-x-8">
-            {filteredTemplates.map((template, index) => {
-              const { name, author } = template;
-              const authoringPreset = getAuthoringPreset(template);
-              const title = template.title;
-              const generation = getTemplateGeneration(template);
-              const tag = getGenerationLabel(generation);
-              const tags = getTemplateTags(template);
+            <div className="mt-4 rounded-lg border border-gray-200 bg-gray-50 p-3">
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                <div className="min-w-0 flex-1 space-y-3">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                    <span className="w-24 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                      Type
+                    </span>
+                    <div className="flex flex-wrap gap-2">
+                      {generationFilters.map((filter) => (
+                        <PlaygroundButton
+                          key={filter.value}
+                          className="px-2 py-1 text-xs sm:px-2"
+                          variant={generationFilter === filter.value ? 'primary' : 'secondary'}
+                          onClick={() => setGenerationFilter(filter.value)}
+                        >
+                          {filter.label}
+                        </PlaygroundButton>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start">
+                    <span className="w-24 pt-1 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                      Tags
+                    </span>
+                    <div className="flex flex-wrap gap-2">
+                      <PlaygroundButton
+                        className="px-2 py-1 text-xs sm:px-2"
+                        variant={tagFilter === 'all' ? 'primary' : 'secondary'}
+                        onClick={() => setTemplateTagFilter('all')}
+                      >
+                        All
+                      </PlaygroundButton>
+                      {tagOptions.map((tag) => (
+                        <PlaygroundButton
+                          key={tag}
+                          className="px-2 py-1 text-xs sm:px-2"
+                          variant={tagFilter === tag ? 'primary' : 'secondary'}
+                          onClick={() => setTemplateTagFilter(tag)}
+                        >
+                          {tag}
+                        </PlaygroundButton>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+                {hasActiveTemplateFilter && (
+                  <PlaygroundButton variant="ghost" onClick={clearTemplateFilters}>
+                    Clear
+                  </PlaygroundButton>
+                )}
+              </div>
+            </div>
+            <div className="mt-8 grid grid-cols-1 gap-y-8 sm:grid-cols-2 sm:gap-x-6 lg:grid-cols-4 xl:gap-x-8">
+              {filteredTemplates.map((template, index) => {
+                const { name, author } = template;
+                const authoringPreset = getAuthoringPreset(template);
+                const title = template.title;
+                const generation = getTemplateGeneration(template);
+                const tag = getGenerationLabel(generation);
+                const tags = getTemplateTags(template);
 
-              return (
-                <React.Fragment key={name}>
-                  {index === 3 && (
-                    <div
-                      data-ea-publisher="pdfmecom"
-                      data-ea-type="image"
-                      style={{ width: '100%', display: 'flex', justifyContent: 'center' }}
-                    />
-                  )}
-                  <GalleryCard
-                    tag={tag}
-                    title={title}
-                    tags={tags}
-                    description={
-                      <div className="space-y-3">
-                        <p>{template.description}</p>
-                        <p className="flex items-center gap-2 text-xs text-gray-500">
-                          by{' '}
-                          {avatarUrlMap[author] && (
+                return (
+                  <React.Fragment key={name}>
+                    {index === 3 && (
+                      <div
+                        data-ea-publisher="pdfmecom"
+                        data-ea-type="image"
+                        style={{ width: '100%', display: 'flex', justifyContent: 'center' }}
+                      />
+                    )}
+                    <GalleryCard
+                      tag={tag}
+                      title={title}
+                      tags={tags}
+                      description={
+                        <div className="space-y-3">
+                          <p>{template.description}</p>
+                          <p className="flex items-center gap-2 text-xs text-gray-500">
+                            by{' '}
                             <img
-                              src={avatarUrlMap[author]}
+                              src={getAuthorAvatarUrl(author)}
                               alt={author}
+                              loading="lazy"
                               className="inline-block size-7 rounded-full bg-gray-100"
                             />
-                          )}
-                          <AuthorLink author={author} />
-                        </p>
-                      </div>
-                    }
-                    thumbnail={
-                      <img
-                        id={`template-img-${name}`}
-                        onClick={() =>
-                          authoringPreset
-                            ? navigateToAuthoringPreset(authoringPreset)
-                            : navigateTo(name, 'designer')
-                        }
-                        alt={title}
-                        src={`/template-assets/${name}/thumbnail.png`}
-                        className="h-72 w-full cursor-pointer object-contain"
-                      />
-                    }
-                    actions={
-                      authoringPreset ? (
-                        <PlaygroundButton
-                          fullWidth
-                          onClick={() => navigateToAuthoringPreset(authoringPreset)}
-                        >
-                          Open Starter
-                        </PlaygroundButton>
-                      ) : (
-                        <div className="space-y-2">
-                          <PlaygroundButton fullWidth onClick={() => navigateTo(name, 'designer')}>
-                            Designer
-                          </PlaygroundButton>
+                            <AuthorLink author={author} />
+                          </p>
+                        </div>
+                      }
+                      thumbnail={
+                        <img
+                          id={`template-img-${name}`}
+                          onClick={() =>
+                            authoringPreset
+                              ? navigateToAuthoringPreset(authoringPreset)
+                              : navigateTo(name, 'designer')
+                          }
+                          alt={title}
+                          src={`/template-assets/${name}/thumbnail.png`}
+                          className="h-72 w-full cursor-pointer object-contain"
+                        />
+                      }
+                      actions={
+                        authoringPreset ? (
                           <PlaygroundButton
                             fullWidth
-                            onClick={() => navigateTo(name, 'form-viewer')}
+                            onClick={() => navigateToAuthoringPreset(authoringPreset)}
                           >
-                            Form/Viewer
+                            Open Starter
                           </PlaygroundButton>
-                        </div>
-                      )
-                    }
-                  />
-                </React.Fragment>
-              );
-            })}
-            {filteredTemplates.length === 0 && (
-              <div className="rounded-lg border border-dashed border-gray-300 bg-white p-6 text-sm text-gray-600 sm:col-span-2 lg:col-span-4">
-                No templates match the selected filters.
-              </div>
-            )}
-          </div>
+                        ) : (
+                          <div className="space-y-2">
+                            <PlaygroundButton
+                              fullWidth
+                              onClick={() => navigateTo(name, 'designer')}
+                            >
+                              Designer
+                            </PlaygroundButton>
+                            <PlaygroundButton
+                              fullWidth
+                              onClick={() => navigateTo(name, 'form-viewer')}
+                            >
+                              Form/Viewer
+                            </PlaygroundButton>
+                          </div>
+                        )
+                      }
+                    />
+                  </React.Fragment>
+                );
+              })}
+              {filteredTemplates.length === 0 && (
+                <div className="rounded-lg border border-dashed border-gray-300 bg-white p-6 text-sm text-gray-600 sm:col-span-2 lg:col-span-4">
+                  No templates match the selected filters.
+                </div>
+              )}
+            </div>
           </section>
         )}
       </div>

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -2,17 +2,29 @@ import { sentryVitePlugin } from '@sentry/vite-plugin';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const sentryAuthToken = process.env.SENTRY_AUTH_TOKEN;
+
 // https://vitejs.dev/config/
 export default defineConfig({
   build: {
     target: 'esnext',
-    sourcemap: true, // Enable source maps for production builds
+    // Source maps are only needed for the Sentry upload; emitting them without a
+    // token would just publish them with the deployed bundle.
+    sourcemap: Boolean(sentryAuthToken),
   },
   plugins: [
     react(),
-    sentryVitePlugin({
-      org: 'hand-dot',
-      project: 'playground-pdfme',
-    }),
+    ...(sentryAuthToken
+      ? [
+          sentryVitePlugin({
+            org: 'hand-dot',
+            project: 'playground-pdfme',
+            authToken: sentryAuthToken,
+            sourcemaps: {
+              filesToDeleteAfterUpload: ['dist/**/*.js.map'],
+            },
+          }),
+        ]
+      : []),
   ],
 });


### PR DESCRIPTION
## Summary

Fixes a batch of bugs and inefficiencies found while reviewing the `playground` directory.

### Error handling (bug fixes)
- Show a toast when Designer / Form / Viewer template loading fails — previously errors (e.g. unmounted workspace folder, missing project) were only logged to the console, leaving a silently blank editor
- `generatePDF`: copy the result into a fresh `Uint8Array` before creating the `Blob` (avoids corrupt output when the result is a view over a larger `ArrayBuffer`), revoke object URLs after use, replace `alert` with a toast, and return success to callers so timing toasts only show on success
- `readFile` now rejects on read errors instead of hanging forever, and template fetches check `response.ok` so a 404 produces a clear message
- `Md2Pdf` PDF generation no longer triggers an unhandled promise rejection on failure

### Reliability
- Load GitHub avatars directly from `github.com/<user>.png` instead of the unauthenticated GitHub API (60 req/h rate limit, and a single failed request previously hid all avatars)
- Validate the persisted Form/Viewer `mode` value read from `localStorage`

### Performance
- Add a single-project IndexedDB lookup (`store.get(id)`) so getting/saving/renaming a Browser Project no longer deserializes every stored project (templates + thumbnail data URLs)
- Lazy-load all routes; Designer / Templates / Form&Viewer / CodeEditor are now split out of the initial bundle

### Build / config
- Only enable the Sentry Vite plugin and sourcemaps when `SENTRY_AUTH_TOKEN` is set, and delete sourcemaps after upload so they are no longer published with the deployed bundle
- Skip `Sentry.init` when no DSN is configured
- Remove unused `signature_pad` dependency

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes (remaining warnings are pre-existing in `e2e/index.test.ts`)
- [x] Playground unit tests pass (41/41 across 8 files, excluding browser image-snapshot e2e)
- [x] `npm run build` succeeds; route chunks are split and no `.map` files are emitted without a Sentry token
- [ ] Manual check of Designer / Form/Viewer / JSX / md2pdf flows in the playground

Made with [Cursor](https://cursor.com)