### PR TITLE
fix(ui): prevent infinite loading spinner and mobile crashes in Designer

### DIFF
--- a/packages/converter/__tests__/index.test.ts
+++ b/packages/converter/__tests__/index.test.ts
@@ -101,6 +101,26 @@ describe('pdf2img tests', () => {
     });
   });
 
+  test('maxCanvasPixels option - clamps render scale to stay within pixel budget', async () => {
+    const maxCanvasPixels = 2_000_000;
+    const renderFirstPage = (options: { maxCanvasPixels?: number }) =>
+      nodePdf2Img(pdfArrayBuffer, {
+        scale: 4,
+        imageType: 'png',
+        range: { start: 0, end: 0 },
+        ...options,
+      });
+
+    const [unclamped] = await renderFirstPage({});
+    const [clamped] = await renderFirstPage({ maxCanvasPixels });
+    const unclampedImage = await loadImage(Buffer.from(new Uint8Array(unclamped)));
+    const clampedImage = await loadImage(Buffer.from(new Uint8Array(clamped)));
+
+    expect(unclampedImage.width * unclampedImage.height).toBeGreaterThan(maxCanvasPixels);
+    expect(clampedImage.width * clampedImage.height).toBeLessThanOrEqual(maxCanvasPixels * 1.01);
+    expect(clampedImage.width).toBeLessThan(unclampedImage.width);
+  });
+
   test('invalid PDF input - should throw error', async () => {
     const invalidBuffer = new ArrayBuffer(10);
     await expect(nodePdf2Img(invalidBuffer, { scale: 1 })).rejects.toThrow('Invalid PDF');

--- a/packages/converter/src/pdf2img.ts
+++ b/packages/converter/src/pdf2img.ts
@@ -18,6 +18,14 @@ export interface Pdf2ImgOptions {
     start?: number;
     end?: number;
   };
+  /**
+   * Upper bound for the rendered canvas area (width * height) per page.
+   * When rendering at `scale` would exceed this limit, the scale is reduced
+   * so the canvas stays within it. Useful to avoid exceeding browser canvas
+   * size limits and memory crashes on mobile devices (e.g. iOS Safari caps
+   * canvases around 16.7M pixels).
+   */
+  maxCanvasPixels?: number;
 }
 
 export async function pdf2img(
@@ -26,7 +34,7 @@ export async function pdf2img(
   env: Environment,
 ): Promise<ArrayBuffer[]> {
   try {
-    const { scale = 1, imageType = 'jpeg', range = {} } = options;
+    const { scale = 1, imageType = 'jpeg', range = {}, maxCanvasPixels } = options;
     const { start = 0, end = Infinity } = range;
 
     const { getDocument, destroyDocument, createCanvas, canvasToArrayBuffer } = env;
@@ -42,7 +50,15 @@ export async function pdf2img(
 
       for (let pageNum = startPage; pageNum <= endPage; pageNum++) {
         const page = await pdfDoc.getPage(pageNum);
-        const viewport = page.getViewport({ scale });
+        let renderScale = scale;
+        if (maxCanvasPixels && maxCanvasPixels > 0) {
+          const baseViewport = page.getViewport({ scale: 1 });
+          const baseArea = baseViewport.width * baseViewport.height;
+          if (baseArea > 0) {
+            renderScale = Math.min(scale, Math.sqrt(maxCanvasPixels / baseArea));
+          }
+        }
+        const viewport = page.getViewport({ scale: renderScale });
 
         const canvas = createCanvas(viewport.width, viewport.height);
         if (!canvas) {

--- a/packages/ui/__tests__/hooks.test.tsx
+++ b/packages/ui/__tests__/hooks.test.tsx
@@ -71,6 +71,54 @@ test('useUIPreProcessor runs pdf sizing and imaging in parallel with isolated bu
   await waitFor(() => expect(result.current.pageSizes).toEqual([PAGE_SIZE_PRESETS.A4]));
 });
 
+test('useUIPreProcessor passes a canvas pixel budget to pdf2img', async () => {
+  const pdf2sizeMock = vi.mocked(converter.pdf2size);
+  const pdf2imgMock = vi.mocked(converter.pdf2img);
+
+  pdf2sizeMock.mockResolvedValue([PAGE_SIZE_PRESETS.A4]);
+  pdf2imgMock.mockResolvedValue([new Uint8Array([137, 80, 78, 71]).buffer]);
+
+  const { result } = renderHook(() =>
+    useUIPreProcessor({
+      template: createTemplate(),
+      size: { width: 1200, height: 1200 },
+      zoomLevel: 1,
+      maxZoom: 5,
+    }),
+  );
+
+  await waitFor(() => expect(result.current.backgrounds.length).toBe(1));
+
+  expect(pdf2imgMock).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({ scale: 5, maxCanvasPixels: 4096 * 4096 }),
+  );
+});
+
+test('useUIPreProcessor keeps a positive base scale on narrow viewports', async () => {
+  const pdf2sizeMock = vi.mocked(converter.pdf2size);
+  const pdf2imgMock = vi.mocked(converter.pdf2img);
+
+  pdf2sizeMock.mockResolvedValue([PAGE_SIZE_PRESETS.A4]);
+  pdf2imgMock.mockResolvedValue([new Uint8Array([137, 80, 78, 71]).buffer]);
+
+  // Simulates a smartphone viewport where the open sidebars consume more
+  // width than the screen provides.
+  const { result } = renderHook(() =>
+    useUIPreProcessor({
+      template: createTemplate(),
+      size: { width: -55, height: 600 },
+      zoomLevel: 1,
+      maxZoom: 2,
+    }),
+  );
+
+  await waitFor(() => expect(result.current.backgrounds.length).toBe(1));
+
+  expect(result.current.baseScale).toBeGreaterThan(0);
+  expect(result.current.scale).toBeGreaterThan(0);
+});
+
 test('useInitEvents paste ignores missing DOM nodes instead of storing null active elements', () => {
   vi.useFakeTimers();
 

--- a/packages/ui/src/components/Designer/index.tsx
+++ b/packages/ui/src/components/Designer/index.tsx
@@ -58,6 +58,10 @@ const scaleDragPosAdjustment = (adjustment: number, scale: number): number => {
   return 0;
 };
 
+// Minimum canvas width (px) that should remain visible next to an open
+// right sidebar for the Designer to stay usable.
+const MIN_CANVAS_WIDTH = 100;
+
 const TemplateEditor = ({
   template,
   size,
@@ -86,18 +90,26 @@ const TemplateEditor = ({
   const options = useContext(OptionsContext);
   const maxZoom = useMaxZoom();
 
+  const canvasWidth = size.width - LEFT_SIDEBAR_WIDTH;
+
   const [hoveringSchemaId, setHoveringSchemaId] = useState<string | null>(null);
   const [activeElements, setActiveElements] = useState<HTMLElement[]>([]);
   const [schemasList, setSchemasList] = useState<SchemaForUI[][]>([[]] as SchemaForUI[][]);
   const [pageCursor, setPageCursor] = useState(0);
-  const [sidebarOpen, setSidebarOpen] = useState(options.sidebarOpen ?? true);
+  // Close the sidebar by default on narrow viewports (e.g. smartphones) where
+  // it would not leave any usable canvas width.
+  const [sidebarOpen, setSidebarOpen] = useState(
+    options.sidebarOpen ?? canvasWidth - RIGHT_SIDEBAR_WIDTH >= MIN_CANVAS_WIDTH,
+  );
   const [canvasHeight, setCanvasHeight] = useState(0);
   const [prevTemplate, setPrevTemplate] = useState<Template | null>(null);
 
-  const canvasWidth = size.width - LEFT_SIDEBAR_WIDTH;
   const sizeExcSidebars = useMemo(
     () => ({
-      width: sidebarOpen ? canvasWidth - RIGHT_SIDEBAR_WIDTH : canvasWidth,
+      // Never let the width go negative; on narrow viewports the open sidebar
+      // can be wider than the screen, which previously produced a negative
+      // base scale and left the Designer stuck on the loading spinner.
+      width: Math.max(sidebarOpen ? canvasWidth - RIGHT_SIDEBAR_WIDTH : canvasWidth, 0),
       height: size.height,
     }),
     [canvasWidth, sidebarOpen, size.height],

--- a/packages/ui/src/helper.ts
+++ b/packages/ui/src/helper.ts
@@ -248,13 +248,19 @@ export const arrayBufferToBase64 = (arrayBuffer: ArrayBuffer): string => {
   // Detect the MIME type
   const mimeType = detectMimeType(arrayBuffer);
 
-  // Convert ArrayBuffer to raw Base64
+  // Convert ArrayBuffer to raw Base64. Convert in chunks instead of byte by
+  // byte: per-byte string concatenation generates a huge number of
+  // intermediate strings, which can exhaust memory on mobile devices when
+  // encoding multi-megabyte page background images.
   const bytes = new Uint8Array(arrayBuffer);
-  let binary = '';
-  for (let i = 0; i < bytes.length; i++) {
-    binary += String.fromCharCode(bytes[i]);
+  const chunkSize = 0x8000;
+  const chunks: string[] = [];
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    chunks.push(
+      String.fromCharCode.apply(null, bytes.subarray(i, i + chunkSize) as unknown as number[]),
+    );
   }
-  const base64String = btoa(binary);
+  const base64String = btoa(chunks.join(''));
 
   // Optionally prepend a data: URL if a known MIME type is found;
   // otherwise just return the raw Base64.

--- a/packages/ui/src/hooks.ts
+++ b/packages/ui/src/hooks.ts
@@ -49,6 +49,16 @@ export const usePrevious = <T>(value: T) => {
 const getScale = (n: number, paper: number) =>
   Math.floor((n / paper > 1 ? 1 : n / paper) * 100) / 100;
 
+// Keep the base scale strictly positive. When the visible area is extremely
+// narrow (e.g. mobile viewports where the sidebars consume the whole width),
+// a scale of 0 or below would leave the UI stuck on the loading spinner.
+const MIN_BASE_SCALE = 0.01;
+
+// Per-page canvas area limit for background rendering. iOS Safari fails or
+// crashes with canvases above roughly 16.7M pixels (4096 x 4096), so cap the
+// render scale to keep each page background within that budget.
+const MAX_BACKGROUND_CANVAS_PIXELS = 4096 * 4096;
+
 type UIPreProcessorProps = { template: Template; size: Size; zoomLevel: number; maxZoom: number };
 
 export const useUIPreProcessor = ({ template, size, zoomLevel, maxZoom }: UIPreProcessorProps) => {
@@ -92,7 +102,10 @@ export const useUIPreProcessor = ({ template, size, zoomLevel, maxZoom }: UIPreP
         const [pageSizeBuffer, imageBuffer] = [createPdfArrayBuffer(), createPdfArrayBuffer()];
         const [_pages, imgBuffers] = await Promise.all([
           pdf2size(pageSizeBuffer),
-          pdf2img(imageBuffer, { scale: maxZoom }),
+          pdf2img(imageBuffer, {
+            scale: maxZoom,
+            maxCanvasPixels: MAX_BACKGROUND_CANVAS_PIXELS,
+          }),
         ]);
         _pageSizes = _pages;
         paperWidth = _pageSizes[0].width * ZOOM;
@@ -100,9 +113,12 @@ export const useUIPreProcessor = ({ template, size, zoomLevel, maxZoom }: UIPreP
         _backgrounds = imgBuffers.map(arrayBufferToBase64);
       }
 
-      const _scale = Math.min(
-        getScale(size.width, paperWidth),
-        getScale(size.height - RULER_HEIGHT, paperHeight),
+      const _scale = Math.max(
+        MIN_BASE_SCALE,
+        Math.min(
+          getScale(size.width, paperWidth),
+          getScale(size.height - RULER_HEIGHT, paperHeight),
+        ),
       );
 
       return {


### PR DESCRIPTION
## Summary

Fixes two mobile (real device) issues with the playground Designer (e.g. `https://playground.pdfme.com/designer?template=invoice`):

- **Infinite loading spinner on narrow viewports**: on screens narrower than ~445px, the open right sidebar (400px) plus the left sidebar (45px) consumed more width than available, producing a negative canvas width and a negative base scale. `useZoom` pins `displayScale` to `0` for non-positive base scales, leaving the Designer stuck on the spinner forever.
  - The right sidebar now auto-closes by default when it would not leave at least 100px of usable canvas width.
  - `sizeExcSidebars.width` is clamped to a non-negative value.
  - The base scale computed in `useUIPreProcessor` is kept strictly positive (`MIN_BASE_SCALE = 0.01`).
- **Tab crash on iOS Safari with real-PDF templates** (e.g. `?template=nenkin-shougai-respiratory-shindansho`): page backgrounds were rendered via `pdf2img` at the `maxZoom` scale (5x with the playground's `maxZoom: 500`). For the A3-sized 2-page PDF this created 4110x5953 canvases (~24.5M pixels each), exceeding iOS Safari's ~16.7M pixel per-canvas limit and exhausting memory, repeatedly killing the tab ("Can't open this page").
  - `pdf2img` accepts a new optional `maxCanvasPixels` option that clamps the per-page render scale to stay within the pixel budget.
  - The UI caps background rendering at `4096 * 4096` pixels per page.
  - `arrayBufferToBase64` now encodes in 32KB chunks instead of byte-by-byte string concatenation, reducing peak memory while encoding multi-megabyte background images.

## Verification

- Added tests: `maxCanvasPixels` clamping in `@pdfme/converter`, pixel-budget pass-through and positive base scale on narrow viewports in `@pdfme/ui`.
- All tests pass: converter (29) and ui (80); `npm run lint` clean.
- Verified in a 390x844 (DPR 3) mobile-emulated browser against the local playground:
  - `designer?template=invoice` renders without the spinner, sidebar auto-closed.
  - `designer?template=nenkin-shougai-respiratory-shindansho` renders both pages; backgrounds clamped to 3403x4929 (16.77M px, previously 4110x5953 = 24.5M px).

## Test plan

- [ ] Open `playground.pdfme.com/designer?template=invoice` on a real smartphone and confirm the Designer renders instead of spinning forever
- [ ] Open `designer?template=nenkin-shougai-respiratory-shindansho` on iOS Safari and confirm the page no longer crashes
- [ ] Confirm desktop Designer behavior (zoom up to maxZoom, sidebar toggle) is unchanged

Made with [Cursor](https://cursor.com)