### PR TITLE
fix(ui): reduce background render budget on mobile to prevent tab crashes

### DIFF
--- a/packages/converter/__tests__/index.test.ts
+++ b/packages/converter/__tests__/index.test.ts
@@ -121,6 +121,32 @@ describe('pdf2img tests', () => {
     expect(clampedImage.width).toBeLessThan(unclampedImage.width);
   });
 
+  test('maxTotalCanvasPixels option - clamps scale uniformly across pages', async () => {
+    const maxTotalCanvasPixels = 8_000_000;
+    const unclamped = await nodePdf2Img(pdfArrayBuffer, { scale: 4, imageType: 'png' });
+    const clamped = await nodePdf2Img(pdfArrayBuffer, {
+      scale: 4,
+      imageType: 'png',
+      maxTotalCanvasPixels,
+    });
+
+    expect(clamped.length).toBe(unclamped.length);
+
+    const sizesOf = (buffers: ArrayBuffer[]) =>
+      Promise.all(buffers.map((b) => loadImage(Buffer.from(new Uint8Array(b)))));
+    const unclampedImages = await sizesOf(unclamped);
+    const clampedImages = await sizesOf(clamped);
+
+    const totalArea = (images: Awaited<ReturnType<typeof sizesOf>>) =>
+      images.reduce((acc, img) => acc + img.width * img.height, 0);
+
+    expect(totalArea(unclampedImages)).toBeGreaterThan(maxTotalCanvasPixels);
+    expect(totalArea(clampedImages)).toBeLessThanOrEqual(maxTotalCanvasPixels * 1.01);
+    clampedImages.forEach((img, i) => {
+      expect(img.width).toBeLessThan(unclampedImages[i].width);
+    });
+  });
+
   test('invalid PDF input - should throw error', async () => {
     const invalidBuffer = new ArrayBuffer(10);
     await expect(nodePdf2Img(invalidBuffer, { scale: 1 })).rejects.toThrow('Invalid PDF');

--- a/packages/converter/src/pdf2img.ts
+++ b/packages/converter/src/pdf2img.ts
@@ -26,6 +26,14 @@ export interface Pdf2ImgOptions {
    * canvases around 16.7M pixels).
    */
   maxCanvasPixels?: number;
+  /**
+   * Upper bound for the summed canvas area (width * height) across all
+   * rendered pages. When rendering at `scale` would exceed this limit, the
+   * scale of every page is reduced uniformly so the total stays within it.
+   * This bounds the total image memory regardless of page count, which
+   * matters on memory-constrained mobile browsers.
+   */
+  maxTotalCanvasPixels?: number;
 }
 
 export async function pdf2img(
@@ -34,7 +42,8 @@ export async function pdf2img(
   env: Environment,
 ): Promise<ArrayBuffer[]> {
   try {
-    const { scale = 1, imageType = 'jpeg', range = {}, maxCanvasPixels } = options;
+    const { scale = 1, imageType = 'jpeg', range = {}, maxCanvasPixels, maxTotalCanvasPixels } =
+      options;
     const { start = 0, end = Infinity } = range;
 
     const { getDocument, destroyDocument, createCanvas, canvasToArrayBuffer } = env;
@@ -46,19 +55,39 @@ export async function pdf2img(
       const startPage = Math.max(start + 1, 1);
       const endPage = Math.min(end + 1, numPages);
 
-      const results: ArrayBuffer[] = [];
-
+      const pages = [];
       for (let pageNum = startPage; pageNum <= endPage; pageNum++) {
-        const page = await pdfDoc.getPage(pageNum);
-        let renderScale = scale;
-        if (maxCanvasPixels && maxCanvasPixels > 0) {
-          const baseViewport = page.getViewport({ scale: 1 });
-          const baseArea = baseViewport.width * baseViewport.height;
-          if (baseArea > 0) {
-            renderScale = Math.min(scale, Math.sqrt(maxCanvasPixels / baseArea));
+        pages.push(await pdfDoc.getPage(pageNum));
+      }
+
+      const baseAreas = pages.map((page) => {
+        const { width, height } = page.getViewport({ scale: 1 });
+        return width * height;
+      });
+      const renderScales = baseAreas.map((baseArea) => {
+        if (maxCanvasPixels && maxCanvasPixels > 0 && baseArea > 0) {
+          return Math.min(scale, Math.sqrt(maxCanvasPixels / baseArea));
+        }
+        return scale;
+      });
+      if (maxTotalCanvasPixels && maxTotalCanvasPixels > 0) {
+        const totalArea = renderScales.reduce(
+          (acc, renderScale, i) => acc + baseAreas[i] * renderScale * renderScale,
+          0,
+        );
+        if (totalArea > maxTotalCanvasPixels) {
+          const shrink = Math.sqrt(maxTotalCanvasPixels / totalArea);
+          for (let i = 0; i < renderScales.length; i++) {
+            renderScales[i] *= shrink;
           }
         }
-        const viewport = page.getViewport({ scale: renderScale });
+      }
+
+      const results: ArrayBuffer[] = [];
+
+      for (let i = 0; i < pages.length; i++) {
+        const page = pages[i];
+        const viewport = page.getViewport({ scale: renderScales[i] });
 
         const canvas = createCanvas(viewport.width, viewport.height);
         if (!canvas) {

--- a/packages/ui/__tests__/hooks.test.tsx
+++ b/packages/ui/__tests__/hooks.test.tsx
@@ -91,8 +91,50 @@ test('useUIPreProcessor passes a canvas pixel budget to pdf2img', async () => {
 
   expect(pdf2imgMock).toHaveBeenCalledWith(
     expect.anything(),
-    expect.objectContaining({ scale: 5, maxCanvasPixels: 4096 * 4096 }),
+    expect.objectContaining({
+      scale: 5,
+      maxCanvasPixels: 4096 * 4096,
+      maxTotalCanvasPixels: undefined,
+    }),
   );
+});
+
+test('useUIPreProcessor uses a reduced pixel budget on mobile browsers', async () => {
+  const pdf2sizeMock = vi.mocked(converter.pdf2size);
+  const pdf2imgMock = vi.mocked(converter.pdf2img);
+
+  pdf2sizeMock.mockResolvedValue([PAGE_SIZE_PRESETS.A4]);
+  pdf2imgMock.mockResolvedValue([new Uint8Array([137, 80, 78, 71]).buffer]);
+
+  const userAgentSpy = vi
+    .spyOn(window.navigator, 'userAgent', 'get')
+    .mockReturnValue(
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+    );
+
+  try {
+    const { result } = renderHook(() =>
+      useUIPreProcessor({
+        template: createTemplate(),
+        size: { width: 390, height: 844 },
+        zoomLevel: 1,
+        maxZoom: 5,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.backgrounds.length).toBe(1));
+
+    expect(pdf2imgMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        scale: 5,
+        maxCanvasPixels: 2048 * 2048,
+        maxTotalCanvasPixels: 2048 * 2048 * 4,
+      }),
+    );
+  } finally {
+    userAgentSpy.mockRestore();
+  }
 });
 
 test('useUIPreProcessor keeps a positive base scale on narrow viewports', async () => {

--- a/packages/ui/src/hooks.ts
+++ b/packages/ui/src/hooks.ts
@@ -54,10 +54,35 @@ const getScale = (n: number, paper: number) =>
 // a scale of 0 or below would leave the UI stuck on the loading spinner.
 const MIN_BASE_SCALE = 0.01;
 
-// Per-page canvas area limit for background rendering. iOS Safari fails or
-// crashes with canvases above roughly 16.7M pixels (4096 x 4096), so cap the
-// render scale to keep each page background within that budget.
-const MAX_BACKGROUND_CANVAS_PIXELS = 4096 * 4096;
+// Mobile browsers (iOS Safari in particular) kill the page well before
+// desktop-class canvas/image memory usage is reached. Detect them so the
+// background rendering budget can be reduced accordingly.
+const isMobileBrowser = () => {
+  if (typeof navigator === 'undefined') return false;
+  if (/iPhone|iPad|iPod|Android/i.test(navigator.userAgent)) return true;
+  // iPadOS 13+ reports a macOS user agent but still exposes multi-touch.
+  return /Mac/i.test(navigator.userAgent) && navigator.maxTouchPoints > 1;
+};
+
+// Canvas area budgets for background rendering. Desktop keeps each page
+// within iOS Safari's historical per-canvas limit (~16.7M pixels = 4096 x
+// 4096); mobile devices crash from overall memory pressure long before that,
+// so they get a much smaller per-page budget plus a total budget across all
+// pages (RGBA decode cost: 16.7M px = ~67MB per page; 2048 x 2048 = ~17MB).
+const MAX_BACKGROUND_CANVAS_PIXELS_DESKTOP = 4096 * 4096;
+const MAX_BACKGROUND_CANVAS_PIXELS_MOBILE = 2048 * 2048;
+const MAX_TOTAL_BACKGROUND_CANVAS_PIXELS_MOBILE = MAX_BACKGROUND_CANVAS_PIXELS_MOBILE * 4;
+
+const getBackgroundPixelBudget = () =>
+  isMobileBrowser()
+    ? {
+        maxCanvasPixels: MAX_BACKGROUND_CANVAS_PIXELS_MOBILE,
+        maxTotalCanvasPixels: MAX_TOTAL_BACKGROUND_CANVAS_PIXELS_MOBILE,
+      }
+    : {
+        maxCanvasPixels: MAX_BACKGROUND_CANVAS_PIXELS_DESKTOP,
+        maxTotalCanvasPixels: undefined,
+      };
 
 type UIPreProcessorProps = { template: Template; size: Size; zoomLevel: number; maxZoom: number };
 
@@ -104,7 +129,7 @@ export const useUIPreProcessor = ({ template, size, zoomLevel, maxZoom }: UIPreP
           pdf2size(pageSizeBuffer),
           pdf2img(imageBuffer, {
             scale: maxZoom,
-            maxCanvasPixels: MAX_BACKGROUND_CANVAS_PIXELS,
+            ...getBackgroundPixelBudget(),
           }),
         ]);
         _pageSizes = _pages;


### PR DESCRIPTION
## Summary

Follow-up to #1549. Real-PDF templates still crash mobile Safari on real devices (reported with `designer?template=nenkin-shougai-respiratory-shindansho` and `designer?template=pedigree`), even though the fix from #1549 is live.

The 16.7M pixel (4096x4096) per-page cap keeps canvases under iOS Safari's per-canvas limit, but the resulting backgrounds still decode to ~67MB RGBA per page (nenkin: 2 pages = ~134MB; pedigree at scale 5: ~48MB). Combined with transient canvas memory during rendering, JPEG encoding, and pdf.js overhead, this exceeds the WebContent memory budget on real phones and repeatedly kills the tab ("Can't open this page").

Changes:

- **`@pdfme/converter`**: `pdf2img` gains a `maxTotalCanvasPixels` option. When the summed canvas area across all rendered pages would exceed the budget, every page's render scale is shrunk uniformly. This bounds total background image memory regardless of page count.
- **`@pdfme/ui`**: `useUIPreProcessor` now detects mobile browsers (iPhone/iPad/Android UA, plus iPadOS desktop-mode UA via multi-touch) and uses:
  - mobile: `2048x2048` per-page budget + `4x` that as the total budget (~17MB decoded per page, ~67MB max total)
  - desktop: unchanged `4096x4096` per-page cap

With this, on a phone:
- nenkin (822x1190pt x 2 pages): 16.77MP/page -> 4.19MP/page (1702x2465), ~34MB total decoded instead of ~134MB
- pedigree (612x792pt x 1 page): 12.1MP -> 4.19MP (1800x2330), ~17MB instead of ~48MB

## Verification

- New converter test renders a 4-page PDF and asserts the total pixel budget is enforced uniformly; existing `maxCanvasPixels` test still passes (30 tests).
- New ui test stubs an iPhone user agent and asserts the reduced budget is passed to `pdf2img`; desktop budget test updated (81 tests).
- `vp lint` clean.

## Test plan

- [ ] After deploy, open `designer?template=nenkin-shougai-respiratory-shindansho` on a real iPhone and confirm the tab no longer crashes
- [ ] Open `designer?template=pedigree` on a real iPhone and confirm it loads
- [ ] Confirm desktop Designer background sharpness is unchanged for real-PDF templates

Made with [Cursor](https://cursor.com)