### PR TITLE
revert: back out mobile canvas render clamps (#1549 partial, #1551)

### DIFF
--- a/packages/converter/__tests__/index.test.ts
+++ b/packages/converter/__tests__/index.test.ts
@@ -101,26 +101,6 @@ describe('pdf2img tests', () => {
     });
   });
 
-  test('maxCanvasPixels option - clamps render scale to stay within pixel budget', async () => {
-    const maxCanvasPixels = 2_000_000;
-    const renderFirstPage = (options: { maxCanvasPixels?: number }) =>
-      nodePdf2Img(pdfArrayBuffer, {
-        scale: 4,
-        imageType: 'png',
-        range: { start: 0, end: 0 },
-        ...options,
-      });
-
-    const [unclamped] = await renderFirstPage({});
-    const [clamped] = await renderFirstPage({ maxCanvasPixels });
-    const unclampedImage = await loadImage(Buffer.from(new Uint8Array(unclamped)));
-    const clampedImage = await loadImage(Buffer.from(new Uint8Array(clamped)));
-
-    expect(unclampedImage.width * unclampedImage.height).toBeGreaterThan(maxCanvasPixels);
-    expect(clampedImage.width * clampedImage.height).toBeLessThanOrEqual(maxCanvasPixels * 1.01);
-    expect(clampedImage.width).toBeLessThan(unclampedImage.width);
-  });
-
   test('invalid PDF input - should throw error', async () => {
     const invalidBuffer = new ArrayBuffer(10);
     await expect(nodePdf2Img(invalidBuffer, { scale: 1 })).rejects.toThrow('Invalid PDF');

--- a/packages/converter/__tests__/index.test.ts
+++ b/packages/converter/__tests__/index.test.ts
@@ -121,32 +121,6 @@ describe('pdf2img tests', () => {
     expect(clampedImage.width).toBeLessThan(unclampedImage.width);
   });
 
-  test('maxTotalCanvasPixels option - clamps scale uniformly across pages', async () => {
-    const maxTotalCanvasPixels = 8_000_000;
-    const unclamped = await nodePdf2Img(pdfArrayBuffer, { scale: 4, imageType: 'png' });
-    const clamped = await nodePdf2Img(pdfArrayBuffer, {
-      scale: 4,
-      imageType: 'png',
-      maxTotalCanvasPixels,
-    });
-
-    expect(clamped.length).toBe(unclamped.length);
-
-    const sizesOf = (buffers: ArrayBuffer[]) =>
-      Promise.all(buffers.map((b) => loadImage(Buffer.from(new Uint8Array(b)))));
-    const unclampedImages = await sizesOf(unclamped);
-    const clampedImages = await sizesOf(clamped);
-
-    const totalArea = (images: Awaited<ReturnType<typeof sizesOf>>) =>
-      images.reduce((acc, img) => acc + img.width * img.height, 0);
-
-    expect(totalArea(unclampedImages)).toBeGreaterThan(maxTotalCanvasPixels);
-    expect(totalArea(clampedImages)).toBeLessThanOrEqual(maxTotalCanvasPixels * 1.01);
-    clampedImages.forEach((img, i) => {
-      expect(img.width).toBeLessThan(unclampedImages[i].width);
-    });
-  });
-
   test('invalid PDF input - should throw error', async () => {
     const invalidBuffer = new ArrayBuffer(10);
     await expect(nodePdf2Img(invalidBuffer, { scale: 1 })).rejects.toThrow('Invalid PDF');

--- a/packages/converter/src/pdf2img.ts
+++ b/packages/converter/src/pdf2img.ts
@@ -18,14 +18,6 @@ export interface Pdf2ImgOptions {
     start?: number;
     end?: number;
   };
-  /**
-   * Upper bound for the rendered canvas area (width * height) per page.
-   * When rendering at `scale` would exceed this limit, the scale is reduced
-   * so the canvas stays within it. Useful to avoid exceeding browser canvas
-   * size limits and memory crashes on mobile devices (e.g. iOS Safari caps
-   * canvases around 16.7M pixels).
-   */
-  maxCanvasPixels?: number;
 }
 
 export async function pdf2img(
@@ -34,7 +26,7 @@ export async function pdf2img(
   env: Environment,
 ): Promise<ArrayBuffer[]> {
   try {
-    const { scale = 1, imageType = 'jpeg', range = {}, maxCanvasPixels } = options;
+    const { scale = 1, imageType = 'jpeg', range = {} } = options;
     const { start = 0, end = Infinity } = range;
 
     const { getDocument, destroyDocument, createCanvas, canvasToArrayBuffer } = env;
@@ -50,15 +42,7 @@ export async function pdf2img(
 
       for (let pageNum = startPage; pageNum <= endPage; pageNum++) {
         const page = await pdfDoc.getPage(pageNum);
-        let renderScale = scale;
-        if (maxCanvasPixels && maxCanvasPixels > 0) {
-          const baseViewport = page.getViewport({ scale: 1 });
-          const baseArea = baseViewport.width * baseViewport.height;
-          if (baseArea > 0) {
-            renderScale = Math.min(scale, Math.sqrt(maxCanvasPixels / baseArea));
-          }
-        }
-        const viewport = page.getViewport({ scale: renderScale });
+        const viewport = page.getViewport({ scale });
 
         const canvas = createCanvas(viewport.width, viewport.height);
         if (!canvas) {

--- a/packages/converter/src/pdf2img.ts
+++ b/packages/converter/src/pdf2img.ts
@@ -26,14 +26,6 @@ export interface Pdf2ImgOptions {
    * canvases around 16.7M pixels).
    */
   maxCanvasPixels?: number;
-  /**
-   * Upper bound for the summed canvas area (width * height) across all
-   * rendered pages. When rendering at `scale` would exceed this limit, the
-   * scale of every page is reduced uniformly so the total stays within it.
-   * This bounds the total image memory regardless of page count, which
-   * matters on memory-constrained mobile browsers.
-   */
-  maxTotalCanvasPixels?: number;
 }
 
 export async function pdf2img(
@@ -42,8 +34,7 @@ export async function pdf2img(
   env: Environment,
 ): Promise<ArrayBuffer[]> {
   try {
-    const { scale = 1, imageType = 'jpeg', range = {}, maxCanvasPixels, maxTotalCanvasPixels } =
-      options;
+    const { scale = 1, imageType = 'jpeg', range = {}, maxCanvasPixels } = options;
     const { start = 0, end = Infinity } = range;
 
     const { getDocument, destroyDocument, createCanvas, canvasToArrayBuffer } = env;
@@ -55,39 +46,19 @@ export async function pdf2img(
       const startPage = Math.max(start + 1, 1);
       const endPage = Math.min(end + 1, numPages);
 
-      const pages = [];
-      for (let pageNum = startPage; pageNum <= endPage; pageNum++) {
-        pages.push(await pdfDoc.getPage(pageNum));
-      }
-
-      const baseAreas = pages.map((page) => {
-        const { width, height } = page.getViewport({ scale: 1 });
-        return width * height;
-      });
-      const renderScales = baseAreas.map((baseArea) => {
-        if (maxCanvasPixels && maxCanvasPixels > 0 && baseArea > 0) {
-          return Math.min(scale, Math.sqrt(maxCanvasPixels / baseArea));
-        }
-        return scale;
-      });
-      if (maxTotalCanvasPixels && maxTotalCanvasPixels > 0) {
-        const totalArea = renderScales.reduce(
-          (acc, renderScale, i) => acc + baseAreas[i] * renderScale * renderScale,
-          0,
-        );
-        if (totalArea > maxTotalCanvasPixels) {
-          const shrink = Math.sqrt(maxTotalCanvasPixels / totalArea);
-          for (let i = 0; i < renderScales.length; i++) {
-            renderScales[i] *= shrink;
-          }
-        }
-      }
-
       const results: ArrayBuffer[] = [];
 
-      for (let i = 0; i < pages.length; i++) {
-        const page = pages[i];
-        const viewport = page.getViewport({ scale: renderScales[i] });
+      for (let pageNum = startPage; pageNum <= endPage; pageNum++) {
+        const page = await pdfDoc.getPage(pageNum);
+        let renderScale = scale;
+        if (maxCanvasPixels && maxCanvasPixels > 0) {
+          const baseViewport = page.getViewport({ scale: 1 });
+          const baseArea = baseViewport.width * baseViewport.height;
+          if (baseArea > 0) {
+            renderScale = Math.min(scale, Math.sqrt(maxCanvasPixels / baseArea));
+          }
+        }
+        const viewport = page.getViewport({ scale: renderScale });
 
         const canvas = createCanvas(viewport.width, viewport.height);
         if (!canvas) {

--- a/packages/ui/__tests__/hooks.test.tsx
+++ b/packages/ui/__tests__/hooks.test.tsx
@@ -91,50 +91,8 @@ test('useUIPreProcessor passes a canvas pixel budget to pdf2img', async () => {
 
   expect(pdf2imgMock).toHaveBeenCalledWith(
     expect.anything(),
-    expect.objectContaining({
-      scale: 5,
-      maxCanvasPixels: 4096 * 4096,
-      maxTotalCanvasPixels: undefined,
-    }),
+    expect.objectContaining({ scale: 5, maxCanvasPixels: 4096 * 4096 }),
   );
-});
-
-test('useUIPreProcessor uses a reduced pixel budget on mobile browsers', async () => {
-  const pdf2sizeMock = vi.mocked(converter.pdf2size);
-  const pdf2imgMock = vi.mocked(converter.pdf2img);
-
-  pdf2sizeMock.mockResolvedValue([PAGE_SIZE_PRESETS.A4]);
-  pdf2imgMock.mockResolvedValue([new Uint8Array([137, 80, 78, 71]).buffer]);
-
-  const userAgentSpy = vi
-    .spyOn(window.navigator, 'userAgent', 'get')
-    .mockReturnValue(
-      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
-    );
-
-  try {
-    const { result } = renderHook(() =>
-      useUIPreProcessor({
-        template: createTemplate(),
-        size: { width: 390, height: 844 },
-        zoomLevel: 1,
-        maxZoom: 5,
-      }),
-    );
-
-    await waitFor(() => expect(result.current.backgrounds.length).toBe(1));
-
-    expect(pdf2imgMock).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        scale: 5,
-        maxCanvasPixels: 2048 * 2048,
-        maxTotalCanvasPixels: 2048 * 2048 * 4,
-      }),
-    );
-  } finally {
-    userAgentSpy.mockRestore();
-  }
 });
 
 test('useUIPreProcessor keeps a positive base scale on narrow viewports', async () => {

--- a/packages/ui/__tests__/hooks.test.tsx
+++ b/packages/ui/__tests__/hooks.test.tsx
@@ -71,30 +71,6 @@ test('useUIPreProcessor runs pdf sizing and imaging in parallel with isolated bu
   await waitFor(() => expect(result.current.pageSizes).toEqual([PAGE_SIZE_PRESETS.A4]));
 });
 
-test('useUIPreProcessor passes a canvas pixel budget to pdf2img', async () => {
-  const pdf2sizeMock = vi.mocked(converter.pdf2size);
-  const pdf2imgMock = vi.mocked(converter.pdf2img);
-
-  pdf2sizeMock.mockResolvedValue([PAGE_SIZE_PRESETS.A4]);
-  pdf2imgMock.mockResolvedValue([new Uint8Array([137, 80, 78, 71]).buffer]);
-
-  const { result } = renderHook(() =>
-    useUIPreProcessor({
-      template: createTemplate(),
-      size: { width: 1200, height: 1200 },
-      zoomLevel: 1,
-      maxZoom: 5,
-    }),
-  );
-
-  await waitFor(() => expect(result.current.backgrounds.length).toBe(1));
-
-  expect(pdf2imgMock).toHaveBeenCalledWith(
-    expect.anything(),
-    expect.objectContaining({ scale: 5, maxCanvasPixels: 4096 * 4096 }),
-  );
-});
-
 test('useUIPreProcessor keeps a positive base scale on narrow viewports', async () => {
   const pdf2sizeMock = vi.mocked(converter.pdf2size);
   const pdf2imgMock = vi.mocked(converter.pdf2img);

--- a/packages/ui/src/hooks.ts
+++ b/packages/ui/src/hooks.ts
@@ -54,35 +54,10 @@ const getScale = (n: number, paper: number) =>
 // a scale of 0 or below would leave the UI stuck on the loading spinner.
 const MIN_BASE_SCALE = 0.01;
 
-// Mobile browsers (iOS Safari in particular) kill the page well before
-// desktop-class canvas/image memory usage is reached. Detect them so the
-// background rendering budget can be reduced accordingly.
-const isMobileBrowser = () => {
-  if (typeof navigator === 'undefined') return false;
-  if (/iPhone|iPad|iPod|Android/i.test(navigator.userAgent)) return true;
-  // iPadOS 13+ reports a macOS user agent but still exposes multi-touch.
-  return /Mac/i.test(navigator.userAgent) && navigator.maxTouchPoints > 1;
-};
-
-// Canvas area budgets for background rendering. Desktop keeps each page
-// within iOS Safari's historical per-canvas limit (~16.7M pixels = 4096 x
-// 4096); mobile devices crash from overall memory pressure long before that,
-// so they get a much smaller per-page budget plus a total budget across all
-// pages (RGBA decode cost: 16.7M px = ~67MB per page; 2048 x 2048 = ~17MB).
-const MAX_BACKGROUND_CANVAS_PIXELS_DESKTOP = 4096 * 4096;
-const MAX_BACKGROUND_CANVAS_PIXELS_MOBILE = 2048 * 2048;
-const MAX_TOTAL_BACKGROUND_CANVAS_PIXELS_MOBILE = MAX_BACKGROUND_CANVAS_PIXELS_MOBILE * 4;
-
-const getBackgroundPixelBudget = () =>
-  isMobileBrowser()
-    ? {
-        maxCanvasPixels: MAX_BACKGROUND_CANVAS_PIXELS_MOBILE,
-        maxTotalCanvasPixels: MAX_TOTAL_BACKGROUND_CANVAS_PIXELS_MOBILE,
-      }
-    : {
-        maxCanvasPixels: MAX_BACKGROUND_CANVAS_PIXELS_DESKTOP,
-        maxTotalCanvasPixels: undefined,
-      };
+// Per-page canvas area limit for background rendering. iOS Safari fails or
+// crashes with canvases above roughly 16.7M pixels (4096 x 4096), so cap the
+// render scale to keep each page background within that budget.
+const MAX_BACKGROUND_CANVAS_PIXELS = 4096 * 4096;
 
 type UIPreProcessorProps = { template: Template; size: Size; zoomLevel: number; maxZoom: number };
 
@@ -129,7 +104,7 @@ export const useUIPreProcessor = ({ template, size, zoomLevel, maxZoom }: UIPreP
           pdf2size(pageSizeBuffer),
           pdf2img(imageBuffer, {
             scale: maxZoom,
-            ...getBackgroundPixelBudget(),
+            maxCanvasPixels: MAX_BACKGROUND_CANVAS_PIXELS,
           }),
         ]);
         _pageSizes = _pages;

--- a/packages/ui/src/hooks.ts
+++ b/packages/ui/src/hooks.ts
@@ -54,11 +54,6 @@ const getScale = (n: number, paper: number) =>
 // a scale of 0 or below would leave the UI stuck on the loading spinner.
 const MIN_BASE_SCALE = 0.01;
 
-// Per-page canvas area limit for background rendering. iOS Safari fails or
-// crashes with canvases above roughly 16.7M pixels (4096 x 4096), so cap the
-// render scale to keep each page background within that budget.
-const MAX_BACKGROUND_CANVAS_PIXELS = 4096 * 4096;
-
 type UIPreProcessorProps = { template: Template; size: Size; zoomLevel: number; maxZoom: number };
 
 export const useUIPreProcessor = ({ template, size, zoomLevel, maxZoom }: UIPreProcessorProps) => {
@@ -102,10 +97,7 @@ export const useUIPreProcessor = ({ template, size, zoomLevel, maxZoom }: UIPreP
         const [pageSizeBuffer, imageBuffer] = [createPdfArrayBuffer(), createPdfArrayBuffer()];
         const [_pages, imgBuffers] = await Promise.all([
           pdf2size(pageSizeBuffer),
-          pdf2img(imageBuffer, {
-            scale: maxZoom,
-            maxCanvasPixels: MAX_BACKGROUND_CANVAS_PIXELS,
-          }),
+          pdf2img(imageBuffer, { scale: maxZoom }),
         ]);
         _pageSizes = _pages;
         paperWidth = _pageSizes[0].width * ZOOM;


### PR DESCRIPTION
## Summary

Backs out the mobile crash mitigation attempts, since neither resolved the real-device crashes for `designer?template=nenkin-shougai-respiratory-shindansho` / `designer?template=pedigree`:

- Reverts #1551 (`a994d459`): mobile-specific pixel budgets and the `maxTotalCanvasPixels` option in `pdf2img`.
- Removes the `maxCanvasPixels` option and per-page canvas clamp introduced in #1549, restoring `pdf2img` to its pre-#1549 behavior.

Kept from #1549 (confirmed working / harmless improvements):

- Infinite loading spinner fix: sidebar auto-close on narrow viewports, non-negative canvas width, strictly positive base scale.
- Chunked base64 encoding in `arrayBufferToBase64`.

`packages/converter` is now byte-identical to its pre-#1549 state.

## Test plan

- [ ] CI passes (converter 28 / ui 79 tests pass locally)
- [ ] After deploy, confirm the Designer still loads on mobile (spinner fix retained)