### PR TITLE
fix(schemas): skip text decoration for empty values

### DIFF
--- a/packages/schemas/__tests__/text.test.ts
+++ b/packages/schemas/__tests__/text.test.ts
@@ -39,6 +39,7 @@ import { mergeTextLineRangeValue } from '../src/text/measure.js';
 import { shouldUseDynamicFontSize } from '../src/text/overflow.js';
 import { propPanel as textPropPanel } from '../src/text/propPanel.js';
 import { getDynamicLayoutForMultiVariableText } from '../src/multiVariableText/dynamicTemplate.js';
+import { pdfRender } from '../src/text/pdfRender.js';
 
 import { FontWidthCalcValues, TextSchema } from '../src/text/types.js';
 import type { MultiVariableTextSchema } from '../src/multiVariableText/types.js';
@@ -123,6 +124,26 @@ const getOverflowOptionValues = (schema: Record<string, PropPanelSchema>) => {
   };
   return overflow.props.options.map((option) => option.value);
 };
+
+describe('text pdfRender', () => {
+  it('does not draw background decoration for empty values', async () => {
+    const drawRectangle = vi.fn();
+    const schema = getTextSchema();
+
+    await pdfRender({
+      value: '',
+      schema,
+      pdfDoc: {} as never,
+      pdfLib: {} as never,
+      page: { getHeight: () => mm2pt(297), drawRectangle } as never,
+      options: { font: getSampleFont() },
+      basePdf: { width: 210, height: 297, padding: [0, 0, 0, 0] },
+      _cache: new Map(),
+    });
+
+    expect(drawRectangle).not.toHaveBeenCalled();
+  });
+});
 
 describe('parseInlineMarkdown', () => {
   it('parses supported inline markdown styles', () => {

--- a/packages/schemas/src/text/pdfRender.ts
+++ b/packages/schemas/src/text/pdfRender.ts
@@ -138,8 +138,8 @@ export const pdfRender = async (arg: PDFRenderProps<TextSchema>) => {
 
   const pivotPoint = { x: x + width / 2, y: pageHeight - mm2pt(schema.position.y) - height / 2 };
 
-  drawTextBoxDecoration({ page, schema, colorType, x, y, width, height, rotate, pivotPoint });
   if (!value) return;
+  drawTextBoxDecoration({ page, schema, colorType, x, y, width, height, rotate, pivotPoint });
 
   const fontName = schema.fontName ? schema.fontName : getFallbackFontName(font);
   const enableInlineMarkdown = isInlineMarkdownTextSchema(schema);


### PR DESCRIPTION
## Summary
- Skip text field decoration when the submitted value is empty
- Add regression coverage for empty text values with a background color

Fixes #1527

## Test Plan
- `node packages/common/set-version.js`
- `npm run test -w packages/schemas -- __tests__/text.test.ts`
- `npm run lint -w packages/schemas`
- `git diff --check`
