### PR TITLE
fix(schemas): use per-run fontSize for inline markdown {+N} spans

### DIFF
--- a/packages/schemas/src/multiVariableText/helper.ts
+++ b/packages/schemas/src/multiVariableText/helper.ts
@@ -34,8 +34,9 @@ export const substituteVariables = (
     });
   }
 
-  // Remove any variables that were not substituted from inputs
-  substitutedText = substitutedText.replace(/{[^{}]+}/g, '');
+  // Remove any variables that were not substituted from inputs, but preserve
+  // inline markdown delimiters ({+N}, {/}, {#color}) which are valid syntax.
+  substitutedText = substitutedText.replace(/{(?![+#/}])[^{}]+}/g, '');
 
   return substitutedText;
 };

--- a/packages/schemas/src/text/inlineMarkdown.ts
+++ b/packages/schemas/src/text/inlineMarkdown.ts
@@ -12,7 +12,8 @@ const sameStyle = (a: InlineStyle, b: InlineStyle) =>
   Boolean(a.italic) === Boolean(b.italic) &&
   Boolean(a.strikethrough) === Boolean(b.strikethrough) &&
   Boolean(a.code) === Boolean(b.code) &&
-  a.href === b.href;
+  a.href === b.href &&
+  a.fontSize === b.fontSize;
 
 const appendRun = (runs: RichTextRun[], text: string, style: InlineStyle) => {
   if (!text) return;
@@ -30,6 +31,7 @@ const appendRun = (runs: RichTextRun[], text: string, style: InlineStyle) => {
     ...(style.strikethrough ? { strikethrough: true } : {}),
     ...(style.code ? { code: true } : {}),
     ...(style.href ? { href: style.href } : {}),
+    ...(style.fontSize !== undefined ? { fontSize: style.fontSize } : {}),
   });
 };
 

--- a/packages/schemas/src/text/inlineMarkdown.ts
+++ b/packages/schemas/src/text/inlineMarkdown.ts
@@ -63,6 +63,8 @@ const getDelimiter = (value: string, index: number) => {
   if (value.startsWith('**', index)) return '**';
   if (value.startsWith('~~', index)) return '~~';
   if (value[index] === '*') return '*';
+  const sizeMatch = value.slice(index).match(/^\{\+(\d+)\}/);
+  if (sizeMatch) return sizeMatch[0];
   return '';
 };
 
@@ -138,6 +140,10 @@ const mergeStyle = (style: InlineStyle, delimiter: string): InlineStyle => {
   }
   if (delimiter === '~~') {
     return { ...style, strikethrough: true };
+  }
+  const sizeMatch = delimiter.match(/^\{\+(\d+)\}$/);
+  if (sizeMatch) {
+    return { ...style, fontSize: Number(sizeMatch[1]) };
   }
   return style;
 };

--- a/packages/schemas/src/text/measure.ts
+++ b/packages/schemas/src/text/measure.ts
@@ -214,5 +214,5 @@ const measureRichTextLineHeights = (
 
 const getRichTextLineHeight = (line: RichTextLine, fontSize: number) => {
   if (line.runs.length === 0) return fontSize;
-  return Math.max(...line.runs.map((run) => heightOfFontAtSize(run.fontKitFont, fontSize)));
+  return Math.max(...line.runs.map((run) => heightOfFontAtSize(run.fontKitFont, run.fontSize || fontSize)));
 };

--- a/packages/schemas/src/text/richText.ts
+++ b/packages/schemas/src/text/richText.ts
@@ -160,15 +160,16 @@ const measureRunText = (
   fontSize: number,
   characterSpacing: number,
 ) => {
+  const effectiveFontSize = run.fontSize ?? fontSize;
   const syntheticBoldWidth = run.syntheticBold
-    ? fontSize * SYNTHETIC_BOLD_OFFSET_RATIO * SYNTHETIC_BOLD_PDF_EXTRA_DRAWS
+    ? effectiveFontSize * SYNTHETIC_BOLD_OFFSET_RATIO * SYNTHETIC_BOLD_PDF_EXTRA_DRAWS
     : 0;
   const syntheticItalicWidth = run.syntheticItalic
-    ? heightOfFontAtSize(run.fontKitFont, fontSize) *
+    ? heightOfFontAtSize(run.fontKitFont, effectiveFontSize) *
       Math.tan((SYNTHETIC_ITALIC_SKEW_DEGREES * Math.PI) / 180)
     : 0;
   return (
-    widthOfTextAtSize(text, run.fontKitFont, fontSize, characterSpacing) +
+    widthOfTextAtSize(text, run.fontKitFont, effectiveFontSize, characterSpacing) +
     syntheticBoldWidth +
     syntheticItalicWidth +
     (run.code ? CODE_HORIZONTAL_PADDING * 2 : 0)
@@ -211,7 +212,8 @@ const canMergeRichTextRuns = (a: ResolvedRichTextRun, b: ResolvedRichTextRun) =>
   a.italic === b.italic &&
   a.strikethrough === b.strikethrough &&
   a.code === b.code &&
-  a.href === b.href;
+  a.href === b.href &&
+  a.fontSize === b.fontSize;
 
 const measurePiecesWidth = (
   pieces: RichTextRunPiece[],

--- a/packages/schemas/src/text/richText.ts
+++ b/packages/schemas/src/text/richText.ts
@@ -432,7 +432,7 @@ const measureParagraphWidths = (
 
 const getLineHeightAtSize = (line: RichTextLine, fontSize: number) => {
   if (line.runs.length === 0) return fontSize;
-  return Math.max(...line.runs.map((run) => heightOfFontAtSize(run.fontKitFont, fontSize)));
+  return Math.max(...line.runs.map((run) => heightOfFontAtSize(run.fontKitFont, run.fontSize || fontSize)));
 };
 
 export const calculateDynamicRichTextFontSize = async (arg: {

--- a/packages/schemas/src/text/richTextPdfRender.ts
+++ b/packages/schemas/src/text/richTextPdfRender.ts
@@ -29,16 +29,16 @@ import { getTextLineRange } from '../splitRange.js';
 type TextColor = ReturnType<typeof hex2PrintingColor>;
 
 const getSyntheticBoldWidth = (run: RichTextLineRun, fontSize: number) =>
-  run.syntheticBold ? fontSize * SYNTHETIC_BOLD_OFFSET_RATIO * SYNTHETIC_BOLD_PDF_EXTRA_DRAWS : 0;
+  run.syntheticBold ? (run.fontSize || fontSize) * SYNTHETIC_BOLD_OFFSET_RATIO * SYNTHETIC_BOLD_PDF_EXTRA_DRAWS : 0;
 
 const getSyntheticItalicWidth = (run: RichTextLineRun, fontSize: number) =>
   run.syntheticItalic
-    ? heightOfFontAtSize(run.fontKitFont, fontSize) *
+    ? heightOfFontAtSize(run.fontKitFont, run.fontSize || fontSize) *
       Math.tan((SYNTHETIC_ITALIC_SKEW_DEGREES * Math.PI) / 180)
     : 0;
 
 const getRunWidth = (run: RichTextLineRun, fontSize: number, characterSpacing: number) =>
-  widthOfTextAtSize(run.text, run.fontKitFont, fontSize, characterSpacing) +
+  widthOfTextAtSize(run.text, run.fontKitFont, run.fontSize || fontSize, characterSpacing) +
   getSyntheticBoldWidth(run, fontSize) +
   getSyntheticItalicWidth(run, fontSize) +
   (run.code ? CODE_HORIZONTAL_PADDING * 2 : 0);
@@ -125,8 +125,9 @@ const getLinkAnnotationRect = (arg: {
   fontSize: number;
 }): LinkAnnotationRect => {
   const { run, x, y, width, rotate, pivotPoint, fontSize } = arg;
-  const textHeight = heightOfFontAtSize(run.fontKitFont, fontSize);
-  const descent = getFontDescentInPt(run.fontKitFont, fontSize);
+  const runFontSize = run.fontSize || fontSize;
+  const textHeight = heightOfFontAtSize(run.fontKitFont, runFontSize);
+  const descent = getFontDescentInPt(run.fontKitFont, runFontSize);
   const rectY = y + descent;
   const rectHeight = textHeight - descent;
 
@@ -180,7 +181,8 @@ const drawRun = (arg: {
   const codePadding = run.code ? CODE_HORIZONTAL_PADDING : 0;
   const textX = x + codePadding;
   const textWidth = runWidth - codePadding * 2;
-  const textHeight = heightOfFontAtSize(run.fontKitFont, fontSize);
+  const runFontSize = run.fontSize || fontSize;
+  const textHeight = heightOfFontAtSize(run.fontKitFont, runFontSize);
 
   if (run.code) {
     const bgX = x;
@@ -208,7 +210,7 @@ const drawRun = (arg: {
       width: textWidth,
       rotate,
       pivotPoint,
-      fontSize,
+      fontSize: runFontSize,
       color,
       opacity,
     });
@@ -222,7 +224,7 @@ const drawRun = (arg: {
       width: textWidth,
       rotate,
       pivotPoint,
-      fontSize,
+      fontSize: runFontSize,
       color,
       opacity,
     });
@@ -235,9 +237,9 @@ const drawRun = (arg: {
       x: point.x,
       y: point.y,
       rotate,
-      size: fontSize,
+      size: runFontSize,
       color,
-      lineHeight: lineHeight * fontSize,
+      lineHeight: lineHeight * runFontSize,
       font: pdfFont,
       opacity,
       ...(run.syntheticItalic ? { ySkew: pdfLib.degrees(SYNTHETIC_ITALIC_SKEW_DEGREES) } : {}),
@@ -246,7 +248,7 @@ const drawRun = (arg: {
 
   drawAt(textX);
   if (run.syntheticBold) {
-    const offset = fontSize * SYNTHETIC_BOLD_OFFSET_RATIO;
+    const offset = runFontSize * SYNTHETIC_BOLD_OFFSET_RATIO;
     for (let i = 1; i <= SYNTHETIC_BOLD_PDF_EXTRA_DRAWS; i++) {
       drawAt(textX + offset * i);
     }
@@ -364,8 +366,11 @@ export const renderInlineMarkdownText = async (arg: {
     page.pushOperators(pdfLib.setCharacterSpacing(spacing));
 
     if (schema.strikethrough || schema.underline) {
+      const maxRunFontSize = Math.max(
+        ...line.runs.map((run) => run.fontSize || fontSize),
+      );
       const textHeight = Math.max(
-        ...line.runs.map((run) => heightOfFontAtSize(run.fontKitFont, fontSize)),
+        ...line.runs.map((run) => heightOfFontAtSize(run.fontKitFont, run.fontSize || fontSize)),
       );
       if (schema.strikethrough) {
         drawDecorationLine({
@@ -375,7 +380,7 @@ export const renderInlineMarkdownText = async (arg: {
           width: textWidth,
           rotate,
           pivotPoint,
-          fontSize,
+          fontSize: maxRunFontSize,
           color,
           opacity,
         });
@@ -388,7 +393,7 @@ export const renderInlineMarkdownText = async (arg: {
           width: textWidth,
           rotate,
           pivotPoint,
-          fontSize,
+          fontSize: maxRunFontSize,
           color,
           opacity,
         });

--- a/packages/schemas/src/text/types.ts
+++ b/packages/schemas/src/text/types.ts
@@ -23,6 +23,7 @@ export type RichTextRun = {
   strikethrough?: boolean;
   code?: boolean;
   href?: string;
+  fontSize?: number;
 };
 
 export type FontWidthCalcValues = {


### PR DESCRIPTION
## Summary

When inline markdown text contains \{+N}\ font-size spans, the per-run fontSize was not being propagated correctly through the rendering pipeline. This caused all text to render at the base schema fontSize, ignoring the \{+N}\ overrides.

## Root Causes

Three bugs prevented inline markdown font-size spans from working:

1. **\^GppendRun\ dropped fontSize**: The \^GppendRun\ function in \inlineMarkdown.ts\ did not include \ontSize\ in the run object, so parsed font-size information was lost.

2. **\sameStyle\ ignored fontSize**: The \sameStyle\ function did not compare \ontSize\, causing runs with different font sizes to be merged into a single run.

3. **\substituteVariables\ stripped delimiters**: The \{[^{}]+}\ regex removed ALL \{...}\ patterns after variable substitution, including \{+N}\, \{/\}, and \{#color}\ inline markdown delimiters.

## Changes

### \packages/schemas/src/text/inlineMarkdown.ts\
- \sameStyle\: Added \ontSize\ comparison to prevent merging runs with different sizes
- \^GppendRun\: Include \ontSize\ in run objects when present

### \packages/schemas/src/text/richText.ts\
- \getLineHeightAtSize\: Use \un.fontSize || fontSize\ for line height calculation

### \packages/schemas/src/text/measure.ts\
- \getRichTextLineHeight\: Use \un.fontSize || fontSize\ for rich text line height

### \packages/schemas/src/text/richTextPdfRender.ts\
- \getSyntheticBoldWidth\: Use \un.fontSize || fontSize\ for width calculation
- \getSyntheticItalicWidth\: Use \un.fontSize || fontSize\ for width calculation
- \getRunWidth\: Use \un.fontSize || fontSize\ for text width measurement
- \getLinkAnnotationRect\: Use \un.fontSize || fontSize\ for annotation sizing
- \drawRun\: Use \un.fontSize\ for text size, decoration lines, synthetic bold/italic
- \enderInlineMarkdownText\: Line-level decoration thickness scales with max run fontSize

### \packages/schemas/src/multiVariableText/helper.ts\
- \substituteVariables\: Changed regex from \/{[^{}]+}/g\ to \/{(?![+#/}])[^{}]+}/g\ to preserve inline markdown delimiters

## Testing

A regression test was added in the consuming project that:
1. Verifies \parseInlineMarkdown\ splits \{+N}\ spans with correct per-run fontSize
2. Generates a PDF with mixed font sizes via \multiVariableText\ schema
3. Asserts the \BIG\ text (20pt) is notably taller than \	iny\ text (8pt) via pdfjs text extraction
4. Asserts all text items share the same baseline Y coordinate

All existing tests pass with no regressions.

## Issue linkage

Related to #564 as incremental rich-text rendering work. Per-run font sizes and preserved inline-markdown delimiters support mixed formatting within a field; this PR does not implement all of the editor and highlighting use cases in that issue.
