### PR TITLE
[codex] Skip unchanged preview refresh

### DIFF
--- a/packages/ui/__tests__/components/Preview.test.tsx
+++ b/packages/ui/__tests__/components/Preview.test.tsx
@@ -3,6 +3,7 @@ import { render, act, fireEvent, waitFor } from '@testing-library/react';
 import Preview from '../../src/components/Preview';
 import { I18nContext, FontContext, OptionsContext, PluginsRegistry } from '../../src/contexts';
 import { i18n } from '../../src/i18n';
+import * as hooks from '../../src/hooks';
 import { SELECTABLE_CLASSNAME } from '../../src/constants';
 import {
   CUSTOM_A4_PDF,
@@ -226,6 +227,40 @@ test('Preview(as Form) highlights the active editable renderer', async () => {
   await waitFor(() => {
     expect(field2.style.boxShadow).toBe('');
   });
+});
+
+test('Preview skips background refresh when dynamic template is unchanged', async () => {
+  const refresh = vi.fn(() => Promise.resolve());
+  vi.spyOn(hooks, 'useUIPreProcessor').mockImplementation(() => ({
+    backgrounds: ['data:image/png;base64,a...'],
+    pageSizes: [PAGE_SIZE_PRESETS.A4],
+    baseScale: 1,
+    scale: 1,
+    error: null,
+    refresh,
+  }));
+
+  const { container } = render(
+    <I18nContext.Provider value={i18n}>
+      <FontContext.Provider value={getDefaultFont()}>
+        <PluginsRegistry.Provider value={plugins}>
+          <Preview
+            template={{ ...getSampleTemplate(), basePdf: CUSTOM_A4_PDF }}
+            inputs={[{ field1: 'field1', field2: 'field2' }]}
+            size={{ width: 1200, height: 1200 }}
+          />
+        </PluginsRegistry.Provider>
+      </FontContext.Provider>
+    </I18nContext.Provider>,
+  );
+
+  await waitFor(() => {
+    expect(container.querySelectorAll('[data-pdfme-render-ready="true"]').length).toBeGreaterThan(
+      0,
+    );
+  });
+
+  expect(refresh).not.toHaveBeenCalled();
 });
 
 test('Preview(as Form) pushes lower schemas after list height changes for blank PDFs', async () => {

--- a/packages/ui/src/components/Preview.tsx
+++ b/packages/ui/src/components/Preview.tsx
@@ -134,7 +134,9 @@ const Preview = ({
           return;
         }
         setSchemasList(sl);
-        await currentRefresh(dynamicTemplate);
+        if (dynamicTemplate !== template) {
+          await currentRefresh(dynamicTemplate);
+        }
       })
       .catch((err) => console.error(`[@pdfme/ui] `, err));
   }, []);


### PR DESCRIPTION
## Summary

- Skip `Preview` background refresh when `getDynamicTemplate()` returns the original template unchanged.
- Add a regression test for custom PDF previews to verify unchanged dynamic templates do not trigger `refresh()`.

## Why

PDF-backed previews were doing redundant base PDF work during initialization and external input updates. When the dynamic template is unchanged, refreshing page backgrounds repeats `pdf2img`/`pdf2size` work without changing the rendered template.

## Validation

- `npm run test -w packages/ui -- Preview.test.tsx`
- `npm run test -w packages/ui`
- `npm run lint -w packages/ui`
- `npm run build -w packages/ui`

Manual playground measurement on `nenkin-shougai-seishin-shindansho-initial`:

- Initial load worker calls changed from `pdf2size: 3 / pdf2img: 2` to `pdf2size: 2 / pdf2img: 1`.
- External `setInputs()` worker calls changed from `pdf2size: 2 / pdf2img: 1` to `pdf2size: 1`.

Note: `npm run build -w packages/ui` still emits an existing third-party pure annotation warning, but exits successfully.