### PR TITLE
fix(ui): override form-render color widget for React 19 compat

### DIFF
--- a/packages/ui/src/components/Designer/RightSidebar/DetailView/ColorWidget.tsx
+++ b/packages/ui/src/components/Designer/RightSidebar/DetailView/ColorWidget.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { ColorPicker, Input, Space } from 'antd';
+import type { Color } from 'antd/es/color-picker';
+
+// form-render passes these props to a field widget. We override the built-in
+// `color` widget because form-render's bundled `rc-color-picker` relies on
+// ReactDOM.unstable_renderSubtreeIntoContainer, which was removed in React 19.
+export interface ColorWidgetProps {
+  value?: string;
+  onChange?: (value: string | undefined) => void;
+  schema?: { format?: string };
+  disabled?: boolean;
+  disabledAlpha?: boolean;
+  readOnly?: boolean;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+const DEFAULT_COLOR = '#000000';
+
+const ColorWidget = (props: ColorWidgetProps) => {
+  const { value, onChange, disabled, disabledAlpha, readOnly, className, style } = props;
+
+  if (readOnly) {
+    return <span style={style}>{value || ''}</span>;
+  }
+
+  return (
+    <Space.Compact style={style} block>
+      <ColorPicker
+        value={value || DEFAULT_COLOR}
+        disabled={disabled}
+        disabledAlpha={disabledAlpha}
+        format="hex"
+        onChange={(color) => onChange?.(color.toHexString())}
+      />
+      <Input
+        className={className}
+        placeholder={DEFAULT_COLOR}
+        disabled={disabled}
+        value={value}
+        onChange={(ev) => onChange?.(ev.target.value)}
+      />
+    </Space.Compact>
+  );
+};
+
+export default ColorWidget;

--- a/packages/ui/src/components/Designer/RightSidebar/DetailView/ColorWidget.tsx
+++ b/packages/ui/src/components/Designer/RightSidebar/DetailView/ColorWidget.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { ColorPicker, Input, Space } from 'antd';
 
 // form-render passes these props to a field widget. We override the built-in
@@ -16,13 +16,36 @@ export interface ColorWidgetProps {
 }
 
 const DEFAULT_COLOR = '#000000';
+// 6-digit hex, or 8-digit hex when a field opts into alpha (disabledAlpha={false}).
+const HEX_COLOR_REGEXP = /^#(?:[0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$/;
+
+// A value is safe to forward to the schema only when it is a valid hex color or
+// empty (clearing the field). This keeps invalid free-text out of PDF rendering.
+const isCommittableColor = (value: string) => value === '' || HEX_COLOR_REGEXP.test(value);
 
 const ColorWidget = (props: ColorWidgetProps) => {
-  const { value, onChange, disabled, disabledAlpha, readOnly, className, style } = props;
+  // Default alpha off so the picker emits 6-digit hex; fields can opt in with
+  // disabledAlpha={false}, in which case 8-digit hex is intentional.
+  const { value, onChange, disabled, disabledAlpha = true, readOnly, className, style } = props;
+
+  // Keep a local copy so the text input stays responsive while the user types an
+  // intermediate value (e.g. "#ff00") that is not yet a valid color.
+  const [inputValue, setInputValue] = useState(value ?? '');
+
+  useEffect(() => {
+    setInputValue(value ?? '');
+  }, [value]);
 
   if (readOnly) {
     return <span style={style}>{value || ''}</span>;
   }
+
+  const commit = (next: string) => {
+    setInputValue(next);
+    if (isCommittableColor(next)) {
+      onChange?.(next === '' ? undefined : next);
+    }
+  };
 
   return (
     <Space.Compact style={style} block>
@@ -31,14 +54,14 @@ const ColorWidget = (props: ColorWidgetProps) => {
         disabled={disabled}
         disabledAlpha={disabledAlpha}
         format="hex"
-        onChange={(color) => onChange?.(color.toHexString())}
+        onChange={(color) => commit(color.toHexString())}
       />
       <Input
         className={className}
         placeholder={DEFAULT_COLOR}
         disabled={disabled}
-        value={value}
-        onChange={(ev) => onChange?.(ev.target.value)}
+        value={inputValue}
+        onChange={(ev) => commit(ev.target.value)}
       />
     </Space.Compact>
   );

--- a/packages/ui/src/components/Designer/RightSidebar/DetailView/ColorWidget.tsx
+++ b/packages/ui/src/components/Designer/RightSidebar/DetailView/ColorWidget.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { ColorPicker, Input, Space } from 'antd';
-import type { Color } from 'antd/es/color-picker';
 
 // form-render passes these props to a field widget. We override the built-in
 // `color` widget because form-render's bundled `rc-color-picker` relies on

--- a/packages/ui/src/components/Designer/RightSidebar/DetailView/index.tsx
+++ b/packages/ui/src/components/Designer/RightSidebar/DetailView/index.tsx
@@ -20,6 +20,8 @@ import { theme, Typography, Button, Divider } from 'antd';
 import AlignWidget from './AlignWidget.js';
 import WidgetRenderer from './WidgetRenderer.js';
 import ButtonGroupWidget from './ButtonGroupWidget.js';
+import ColorWidget from './ColorWidget.js';
+import type { ColorWidgetProps } from './ColorWidget.js';
 import { expandSameTypeBulkUpdateChanges } from './schemaChangeHelpers.js';
 import { InternalNamePath, ValidateErrorEntity } from 'rc-field-form/es/interface.js';
 import { SidebarBody, SidebarFrame, SidebarHeader, SIDEBAR_H_PADDING_PX } from '../layout.js';
@@ -108,6 +110,8 @@ const DetailView = (props: DetailViewProps) => {
           options={options}
         />
       ),
+      // Override form-render's built-in `color` widget
+      color: (p) => <ColorWidget {...(p as unknown as ColorWidgetProps)} />,
     };
     for (const plugin of pluginsRegistry.values()) {
       const pluginWidgets = (plugin.propPanel.widgets ?? {}) as Record<


### PR DESCRIPTION
- #1561 

<img width="316" height="432" alt="SCR-20260625-jwhx" src="https://github.com/user-attachments/assets/63c6b623-391c-4ac3-aeac-0cb5f0df66cc" />
