### PR TITLE
fix(schemas): render multiVariableText text when it has no variables

### DIFF
--- a/packages/schemas/__tests__/multiVariableText.ui.test.ts
+++ b/packages/schemas/__tests__/multiVariableText.ui.test.ts
@@ -606,3 +606,113 @@ describe('multiVariableText inline markdown UI rendering', () => {
     });
   });
 });
+
+describe('multiVariableText without variables', () => {
+  const renderReadOnlyMvt = async (
+    mode: 'viewer' | 'form',
+    schemaOverrides: Partial<MultiVariableTextSchema> = {},
+  ) => {
+    const rootElement = document.createElement('div');
+    const schema: MultiVariableTextSchema = {
+      ...getSchema(),
+      text: 'Just static text',
+      variables: [],
+      // When the last variable is removed the prop panel marks the field read-only and
+      // resets content to the empty variables map.
+      readOnly: true,
+      content: '{}',
+      textFormat: 'plain',
+      ...schemaOverrides,
+    };
+
+    await uiRender({
+      value: schema.content,
+      schema,
+      rootElement,
+      mode,
+      options: { font: getSampleFont() },
+      _cache: new Map(),
+      theme: { colorPrimary: '#1677ff' },
+    } as Parameters<typeof uiRender>[0]);
+
+    return rootElement.querySelector(`#text-${schema.id}`) as HTMLDivElement;
+  };
+
+  it('renders the static text in viewer mode instead of the variables map', async () => {
+    const textBlock = await renderReadOnlyMvt('viewer');
+    expect(textBlock.textContent).toBe('Just static text');
+    expect(textBlock.textContent).not.toContain('{}');
+  });
+
+  it('renders the static text in form mode instead of the variables map', async () => {
+    const textBlock = await renderReadOnlyMvt('form');
+    expect(textBlock.textContent).toBe('Just static text');
+    expect(textBlock.textContent).not.toContain('{}');
+  });
+
+  it('renders the static text for inline markdown fields', async () => {
+    const textBlock = await renderReadOnlyMvt('viewer', {
+      text: '**bold** static',
+      textFormat: 'inline-markdown',
+    });
+    expect(textBlock.textContent).toBe('bold static');
+    expect(textBlock.textContent).not.toContain('{}');
+  });
+
+  it('renders the resolved content snapshot for a read-only field that still has variables', async () => {
+    // A read-only MVT can keep its variables while content holds the already-substituted text
+    // (e.g. the jsx-invoice "locked" pattern). That snapshot must render, not the raw template.
+    const rootElement = document.createElement('div');
+    const schema: MultiVariableTextSchema = {
+      ...getSchema(),
+      text: '{company}\n{name}',
+      variables: ['company', 'name'],
+      readOnly: true,
+      content: 'Kumo Coffee\nAki Tanaka',
+      textFormat: 'plain',
+    };
+
+    await uiRender({
+      value: schema.content,
+      schema,
+      rootElement,
+      mode: 'viewer',
+      options: { font: getSampleFont() },
+      _cache: new Map(),
+      theme: { colorPrimary: '#1677ff' },
+    } as Parameters<typeof uiRender>[0]);
+
+    const textBlock = rootElement.querySelector(`#text-${schema.id}`) as HTMLDivElement;
+    expect(textBlock.textContent).toBe('Kumo Coffee\nAki Tanaka');
+    expect(textBlock.textContent).not.toContain('{company}');
+  });
+
+  it('keeps line breaks when the last variable is removed in the designer', async () => {
+    const rootElement = document.createElement('div');
+    const onChange = vi.fn();
+    const schema: MultiVariableTextSchema = {
+      ...getSchema(),
+      text: 'Hello {name}\nWorld',
+      variables: ['name'],
+      textFormat: 'plain',
+    };
+
+    await uiRender({
+      value: JSON.stringify({ name: 'NAME' }),
+      schema,
+      rootElement,
+      mode: 'designer',
+      onChange,
+      options: { font: getSampleFont() },
+      _cache: new Map(),
+      theme: { colorPrimary: '#1677ff' },
+    } as Parameters<typeof uiRender>[0]);
+
+    const textBlock = rootElement.querySelector(`#text-${schema.id}`) as HTMLDivElement;
+    // Simulate the user deleting the `{name}` placeholder while keeping the hard line break.
+    textBlock.innerText = 'Hello \nWorld';
+    textBlock.dispatchEvent(new KeyboardEvent('keyup', { key: 'Backspace' }));
+
+    expect(onChange).toHaveBeenCalledWith({ key: 'text', value: 'Hello \nWorld' });
+  });
+});

--- a/packages/schemas/src/multiVariableText/dynamicTemplate.ts
+++ b/packages/schemas/src/multiVariableText/dynamicTemplate.ts
@@ -26,7 +26,10 @@ export const getDynamicLayoutForMultiVariableText = async (
     return { heights: [schema.height] };
   }
 
-  let renderValue = value;
+  // A read-only MVT measures its already-resolved snapshot (value === content). Without variables
+  // that snapshot is just the empty variables map (e.g. "{}"), so measure the static template
+  // text instead to avoid sizing against "{}" (issue #1523).
+  let renderValue = schema.readOnly && schema.variables.length === 0 ? schema.text || '' : value;
   if (!schema.readOnly) {
     if (!validateVariables(value, schema)) {
       return { heights: [schema.height] };

--- a/packages/schemas/src/multiVariableText/dynamicTemplate.ts
+++ b/packages/schemas/src/multiVariableText/dynamicTemplate.ts
@@ -26,9 +26,6 @@ export const getDynamicLayoutForMultiVariableText = async (
     return { heights: [schema.height] };
   }
 
-  // A read-only MVT measures its already-resolved snapshot (value === content). Without variables
-  // that snapshot is just the empty variables map (e.g. "{}"), so measure the static template
-  // text instead to avoid sizing against "{}" (issue #1523).
   let renderValue = schema.readOnly && schema.variables.length === 0 ? schema.text || '' : value;
   if (!schema.readOnly) {
     if (!validateVariables(value, schema)) {

--- a/packages/schemas/src/multiVariableText/pdfRender.ts
+++ b/packages/schemas/src/multiVariableText/pdfRender.ts
@@ -12,7 +12,11 @@ export const pdfRender = async (arg: PDFRenderProps<MultiVariableTextSchema>) =>
   const { value, schema, ...rest } = arg;
 
   if (schema.readOnly) {
-    await parentPdfRender({ value, schema, ...rest });
+    // A read-only MVT renders its already-resolved snapshot (value === content). When it has no
+    // variables that snapshot is just the empty variables map (e.g. "{}"), so fall back to the
+    // static template text to avoid rendering "{}" (issue #1523).
+    const readOnlyValue = schema.variables.length > 0 ? value : schema.text || '';
+    await parentPdfRender({ value: readOnlyValue, schema, ...rest });
     return;
   }
 

--- a/packages/schemas/src/multiVariableText/pdfRender.ts
+++ b/packages/schemas/src/multiVariableText/pdfRender.ts
@@ -12,9 +12,6 @@ export const pdfRender = async (arg: PDFRenderProps<MultiVariableTextSchema>) =>
   const { value, schema, ...rest } = arg;
 
   if (schema.readOnly) {
-    // A read-only MVT renders its already-resolved snapshot (value === content). When it has no
-    // variables that snapshot is just the empty variables map (e.g. "{}"), so fall back to the
-    // static template text to avoid rendering "{}" (issue #1523).
     const readOnlyValue = schema.variables.length > 0 ? value : schema.text || '';
     await parentPdfRender({ value: readOnlyValue, schema, ...rest });
     return;

--- a/packages/schemas/src/multiVariableText/uiRender.ts
+++ b/packages/schemas/src/multiVariableText/uiRender.ts
@@ -28,8 +28,14 @@ export const uiRender = async (arg: UIRenderProps<MultiVariableTextSchema>) => {
   let numVariables = schema.variables.length;
   const renderResolvedValue = schema.readOnly === true && mode !== 'designer';
 
+  // A read-only MVT renders its already-resolved snapshot, passed in as `value` (the schema's
+  // content). When the field has no variables that snapshot is just the empty variables map
+  // (e.g. "{}"), so render the static template text instead — otherwise the field shows "{}"
+  // rather than its text (issue #1523).
   const renderValue = renderResolvedValue
-    ? value
+    ? numVariables > 0
+      ? value
+      : text
     : isInlineMarkdownTextSchema(schema)
       ? substituteVariablesAsInlineMarkdownLiterals(text, value)
       : substituteVariables(text, value);
@@ -63,7 +69,9 @@ export const uiRender = async (arg: UIRenderProps<MultiVariableTextSchema>) => {
 
   if (mode === 'designer') {
     textBlock.addEventListener('keyup', (event: KeyboardEvent) => {
-      text = textBlock.textContent || '';
+      // Read innerText (not textContent) so line breaks survive. textContent collapses
+      // <br>/<div> boundaries, which dropped newlines when a variable was removed (issue #1523).
+      text = readEditableText(textBlock);
       if (keyPressShouldBeChecked(event)) {
         const newNumVariables = countUniqueVariableNames(text);
         if (numVariables !== newNumVariables) {
@@ -671,6 +679,21 @@ const renderInlineMarkdownVariableSpans = (arg: {
       font,
     });
   });
+};
+
+/**
+ * Read the plain text of a contenteditable while preserving its line breaks. Mirrors the
+ * parent text renderer's blur handler: innerText keeps newlines, and contenteditable appends
+ * a trailing newline that we trim.
+ */
+const readEditableText = (element: HTMLElement): string => {
+  // innerText keeps the contenteditable's visual line breaks; textContent collapses
+  // <br>/<div> boundaries. Fall back to textContent where innerText is unavailable.
+  let text = element.innerText ?? element.textContent ?? '';
+  if (text.endsWith('\n')) {
+    text = text.slice(0, -1);
+  }
+  return text;
 };
 
 /**

--- a/packages/schemas/src/multiVariableText/uiRender.ts
+++ b/packages/schemas/src/multiVariableText/uiRender.ts
@@ -65,7 +65,7 @@ export const uiRender = async (arg: UIRenderProps<MultiVariableTextSchema>) => {
 
   if (mode === 'designer') {
     textBlock.addEventListener('keyup', (event: KeyboardEvent) => {
-      text = textBlock.textContent || '';
+      text = textBlock.innerText || '';
       if (keyPressShouldBeChecked(event)) {
         const newNumVariables = countUniqueVariableNames(text);
         if (numVariables !== newNumVariables) {

--- a/packages/schemas/src/multiVariableText/uiRender.ts
+++ b/packages/schemas/src/multiVariableText/uiRender.ts
@@ -28,10 +28,6 @@ export const uiRender = async (arg: UIRenderProps<MultiVariableTextSchema>) => {
   let numVariables = schema.variables.length;
   const renderResolvedValue = schema.readOnly === true && mode !== 'designer';
 
-  // A read-only MVT renders its already-resolved snapshot, passed in as `value` (the schema's
-  // content). When the field has no variables that snapshot is just the empty variables map
-  // (e.g. "{}"), so render the static template text instead — otherwise the field shows "{}"
-  // rather than its text (issue #1523).
   const renderValue = renderResolvedValue
     ? numVariables > 0
       ? value
@@ -69,9 +65,7 @@ export const uiRender = async (arg: UIRenderProps<MultiVariableTextSchema>) => {
 
   if (mode === 'designer') {
     textBlock.addEventListener('keyup', (event: KeyboardEvent) => {
-      // Read innerText (not textContent) so line breaks survive. textContent collapses
-      // <br>/<div> boundaries, which dropped newlines when a variable was removed (issue #1523).
-      text = readEditableText(textBlock);
+      text = textBlock.textContent || '';
       if (keyPressShouldBeChecked(event)) {
         const newNumVariables = countUniqueVariableNames(text);
         if (numVariables !== newNumVariables) {
@@ -679,21 +673,6 @@ const renderInlineMarkdownVariableSpans = (arg: {
       font,
     });
   });
-};
-
-/**
- * Read the plain text of a contenteditable while preserving its line breaks. Mirrors the
- * parent text renderer's blur handler: innerText keeps newlines, and contenteditable appends
- * a trailing newline that we trim.
- */
-const readEditableText = (element: HTMLElement): string => {
-  // innerText keeps the contenteditable's visual line breaks; textContent collapses
-  // <br>/<div> boundaries. Fall back to textContent where innerText is unavailable.
-  let text = element.innerText ?? element.textContent ?? '';
-  if (text.endsWith('\n')) {
-    text = text.slice(0, -1);
-  }
-  return text;
 };
 
 /**

--- a/packages/schemas/src/multiVariableText/uiRender.ts
+++ b/packages/schemas/src/multiVariableText/uiRender.ts
@@ -31,7 +31,7 @@ export const uiRender = async (arg: UIRenderProps<MultiVariableTextSchema>) => {
   const renderValue = renderResolvedValue
     ? numVariables > 0
       ? value
-      : text
+      : text || ''
     : isInlineMarkdownTextSchema(schema)
       ? substituteVariablesAsInlineMarkdownLiterals(text, value)
       : substituteVariables(text, value);


### PR DESCRIPTION
## Summary

Fixes #1523 — a `multiVariableText` without variables sometimes renders as `{}` instead of its text, in both the Designer and the generated PDF.

### Root cause

A read-only `multiVariableText` renders its already-resolved snapshot, which the generator/UI pass in as the `value` (the schema's `content`). When you add a variable and then delete it in the Designer, the prop panel (`mapDynamicVariables`) resets `content` to the empty variables map `"{}"` and flips `readOnly` to `true`. The read-only branches added in #1467 (dynamic height) then rendered that `"{}"` map directly — so the field showed `{}` in the canvas viewer, in Form/Viewer mode, and in the generated PDF.

### Fix

The read-only render paths now distinguish by `variables.length`:

- **has variables** → render the resolved `content` snapshot (e.g. the `jsx-invoice` "locked" pattern where `content` holds the substituted text). This restores the original #1467 behavior.
- **no variables** → `content` is just `"{}"`, so render the static `schema.text` instead.

Applied consistently in `pdfRender`, `uiRender`, and `dynamicTemplate`.

Also addresses a related report in the same issue: removing the last variable in the Designer dropped hard line breaks. The keyup handler now reads `innerText` (which preserves newlines) instead of `textContent` (which collapses `<br>`/`<div>` boundaries).

## Testing

- 5 new regression tests in `multiVariableText.ui.test.ts`:
  - read-only render in viewer / form / inline-markdown modes shows the text, not `{}`
  - read-only **with** variables still renders the resolved content snapshot (locks in `jsx-invoice`)
  - line breaks survive when the last variable is removed in the Designer
- Each new render/line-break test was verified to fail on the old code and pass on the fix.
- Full suite green: `schemas` (229), `generator` (104, incl. the `jsx-invoice` image snapshot), `ui` (132).
- Manually verified the repro in the playground.

🤖 Generated with [Claude Code](https://claude.com/claude-code)