### PR TITLE
fix(ui): keep designer controls fixed while zooming

### DIFF
--- a/packages/ui/__tests__/components/Designer.test.tsx
+++ b/packages/ui/__tests__/components/Designer.test.tsx
@@ -83,6 +83,50 @@ test('Designer keeps toolbar zoom interactive when options.zoomLevel is only an 
   });
 });
 
+test('Designer keeps canvas controls at a constant screen size when zoomed', async () => {
+  setupUIMock();
+  const { container } = render(
+    <I18nContext.Provider value={i18n}>
+      <FontContext.Provider value={getDefaultFont()}>
+        <PluginsRegistry.Provider value={pluginRegistry(plugins)}>
+          <OptionsContext.Provider value={{ zoomLevel: 3, maxZoom: 400 }}>
+            <Designer
+              template={getSampleTemplate()}
+              onSaveTemplate={console.log}
+              onChangeTemplate={console.log}
+              size={{ width: 1200, height: 1200 }}
+              onPageCursorChange={() => undefined}
+            />
+          </OptionsContext.Provider>
+        </PluginsRegistry.Provider>
+      </FontContext.Provider>
+    </I18nContext.Provider>,
+  );
+
+  await waitFor(() => {
+    expect(container).toHaveTextContent('300%');
+  });
+
+  const moveable = container.querySelector('.moveable-control-box') as HTMLDivElement;
+  expect(Number(moveable.style.getPropertyValue('--zoom'))).toBeCloseTo(1 / 3);
+
+  const schema = container.querySelector(`.${SELECTABLE_CLASSNAME}`) as HTMLDivElement;
+  fireEvent.mouseDown(schema);
+  fireEvent.mouseUp(schema);
+
+  const deleteButton = await waitFor(() => {
+    const button = container.querySelector(
+      `.${DESIGNER_CLASSNAME}delete-button`,
+    ) as HTMLButtonElement | null;
+    expect(button).toBeInTheDocument();
+    return button!;
+  });
+
+  expect(deleteButton.style.transform).toBe(`scale(${1 / 3})`);
+  const schemaRight = Number.parseFloat(schema.style.left) + Number.parseFloat(schema.style.width);
+  expect(Number.parseFloat(deleteButton.style.left) - schemaRight).toBeCloseTo(10 / 3);
+});
+
 test('Designer does not reapply options.zoomLevel when changing pages', async () => {
   setupUIMock(2);
   const { container } = render(

--- a/packages/ui/src/components/Designer/Canvas/Moveable.tsx
+++ b/packages/ui/src/components/Designer/Canvas/Moveable.tsx
@@ -11,6 +11,7 @@ import { theme } from 'antd';
 
 type Props = {
   target: HTMLElement[];
+  controlScale: number;
   bounds: { left: number; top: number; bottom: number; right: number };
   horizontalGuidelines: number[];
   verticalGuidelines: number[];
@@ -53,6 +54,7 @@ const Moveable = (props: Props, ref: Ref<MoveableComponent>) => {
     <MoveableView
       className={uniqueClassName}
       rootContainer={document ? document.body : undefined}
+      zoom={props.controlScale}
       snappable
       draggable
       rotatable={props.rotatable}

--- a/packages/ui/src/components/Designer/Canvas/index.tsx
+++ b/packages/ui/src/components/Designer/Canvas/index.tsx
@@ -42,12 +42,20 @@ const fmt = (prop: string) => round(fmt4Num(prop) / ZOOM, 2);
 const isTopLeftResize = (d: string) => d === '-1,-1' || d === '-1,0' || d === '0,-1';
 const normalizeRotate = (angle: number) => ((angle % 360) + 360) % 360;
 
-const DeleteButton = ({ activeElements: aes }: { activeElements: HTMLElement[] }) => {
+const DeleteButton = ({
+  activeElements: aes,
+  controlScale,
+}: {
+  activeElements: HTMLElement[];
+  controlScale: number;
+}) => {
   const { token } = theme.useToken();
 
   const size = 26;
   const top = Math.min(...aes.map(({ style }) => fmt4Num(style.top)));
-  const left = Math.max(...aes.map(({ style }) => fmt4Num(style.left) + fmt4Num(style.width))) + 10;
+  const left =
+    Math.max(...aes.map(({ style }) => fmt4Num(style.left) + fmt4Num(style.width))) +
+    10 * controlScale;
 
   return (
     <Button
@@ -67,6 +75,8 @@ const DeleteButton = ({ activeElements: aes }: { activeElements: HTMLElement[] }
         borderRadius: token.borderRadius,
         color: token.colorWhite,
         background: token.colorPrimary,
+        transform: `scale(${controlScale})`,
+        transformOrigin: 'top left',
       }}
     >
       <X style={{ pointerEvents: 'none' }} />
@@ -126,6 +136,7 @@ const Canvas = (props: Props, ref: Ref<HTMLDivElement>) => {
   const verticalGuides = useRef<GuidesInterface[]>([]);
   const horizontalGuides = useRef<GuidesInterface[]>([]);
   const moveable = useRef<MoveableComponent>(null);
+  const controlScale = scale > 0 ? 1 / scale : 1;
 
   const [isPressShiftKey, setIsPressShiftKey] = useState(false);
   const [editing, setEditing] = useState(false);
@@ -429,7 +440,7 @@ const Canvas = (props: Props, ref: Ref<HTMLDivElement>) => {
         renderPaper={({ index, paperSize }) => (
           <>
             {!editing && activeElements.length > 0 && pageCursor === index && (
-              <DeleteButton activeElements={activeElements} />
+              <DeleteButton activeElements={activeElements} controlScale={controlScale} />
             )}
             <Padding basePdf={basePdf} />
             <StaticSchema
@@ -460,6 +471,7 @@ const Canvas = (props: Props, ref: Ref<HTMLDivElement>) => {
                 <Moveable
                   ref={moveable}
                   target={activeElements}
+                  controlScale={controlScale}
                   bounds={{ left: 0, top: 0, bottom: paperSize.height, right: paperSize.width }}
                   horizontalGuidelines={getGuideLines(horizontalGuides.current, index)}
                   verticalGuidelines={getGuideLines(verticalGuides.current, index)}


### PR DESCRIPTION
## Summary

- keep Designer resize and rotation controls at a constant screen size while zooming
- keep the delete button size and its spacing from the selected schema constant
- add a regression test covering the controls at 300% zoom

## Root cause

The Designer scales the entire paper with CSS `transform: scale(...)`. Moveable controls and the delete button live inside that scaled subtree, so they were enlarged together with the PDF content and became difficult to operate at high zoom levels.

## Implementation

- apply the inverse canvas scale through react-moveable's `zoom` option
- apply the same inverse scale to the delete button
- scale the delete-button offset so the on-screen gap remains constant

## Validation

- `npm run test -w packages/ui` — 83 tests passed
- `npm run lint -w packages/ui`
- `npm run build -w packages/ui`
- verified in the playground at 100% and 300%:
  - Moveable controls remained 14 × 14 px
  - delete button remained 26 × 26 px
  - dragging a selected schema continued to update its position

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only Designer overlay behavior with a focused regression test; no auth, data, or API changes.
> 
> **Overview**
> Fixes Designer **resize/rotate handles** and the **delete button** growing with the canvas when zoom is above 100%. The paper is still scaled with CSS `transform`, but overlay controls now use an inverse scale so they stay the same on-screen size.
> 
> `Canvas` derives `controlScale` as `1 / scale` and passes it to `Moveable` (via react-moveable’s `zoom` prop) and to `DeleteButton`, which applies `transform: scale(controlScale)` with `transformOrigin: top left` and scales the horizontal gap (`10 * controlScale`) so spacing from the selection stays constant.
> 
> Adds a **Designer** test at 300% zoom that asserts moveable `--zoom`, delete-button transform, and button offset relative to the selected schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d616ee838afb31c3d46cf8d17cba510b0f127d3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->