### PR TITLE
fix(schemas): apply anti-orphan line-wrap filtering to all scripts, not just Japanese

### DIFF
--- a/packages/schemas/__tests__/text.test.ts
+++ b/packages/schemas/__tests__/text.test.ts
@@ -1231,6 +1231,21 @@ describe('universal punctuation kinsoku (script-independent, non-CJK text)', () 
       ).toEqual(['delivered in March ', '(see appendix A)']);
     });
 
+    it('keeps a possessive apostrophe intact on the Japanese path too (mixed JP+Latin)', () => {
+      // The JP set is used for the whole batch when any line contains Japanese.
+      // Straight quotes must not be in that set either, or "IBM's" at a line
+      // end loses its apostrophe to the next line.
+      const input = ["これはIBM's", 'obligations'];
+      expect(filterEnd(input, LINE_END_FORBIDDEN_CHARS)).toEqual(input);
+    });
+
+    it('leaves a line whose only content is a forbidden char intact, even with leading whitespace', () => {
+      // "  (" is one character of content; moving it would leave a
+      // whitespace-only line behind.
+      const input = ['  (', 'bar'];
+      expect(filterEnd(input, LINE_END_FORBIDDEN_UNIVERSAL)).toEqual(input);
+    });
+
     it('does NOT treat a straight apostrophe as an opener (possessives stay intact)', () => {
       const input = ["companies'", 'obligations'];
       expect(filterEnd(input, LINE_END_FORBIDDEN_UNIVERSAL)).toEqual(input);

--- a/packages/schemas/__tests__/text.test.ts
+++ b/packages/schemas/__tests__/text.test.ts
@@ -11,8 +11,9 @@ import {
   getFontDescentInPt,
   getFontKitFont,
   getSplittedLines,
-  filterStartJP,
-  filterEndJP,
+  filterStart,
+  filterEnd,
+  splitTextToSize,
   widthOfTextAtSize,
 } from '../src/text/helper.js';
 import {
@@ -31,6 +32,8 @@ import {
 import {
   LINE_START_FORBIDDEN_CHARS,
   LINE_END_FORBIDDEN_CHARS,
+  LINE_START_FORBIDDEN_UNIVERSAL,
+  LINE_END_FORBIDDEN_UNIVERSAL,
   TEXT_OVERFLOW_EXPAND,
   TEXT_OVERFLOW_VISIBLE,
 } from '../src/text/constants.js';
@@ -1093,39 +1096,39 @@ describe('getBrowserVerticalFontAdjustments test', () => {
   });
 });
 
-describe('filterStartJP', () => {
+describe('filterStart (Japanese kinsoku set)', () => {
   test('空の配列を渡すと空の配列を返す', () => {
-    expect(filterStartJP([])).toEqual([]);
+    expect(filterStart([], LINE_START_FORBIDDEN_CHARS)).toEqual([]);
   });
 
   test('禁則文字を含まない行はそのまま返す', () => {
     const input = ['これは', '普通の', '文章です。'];
-    expect(filterStartJP(input)).toEqual(input);
+    expect(filterStart(input, LINE_START_FORBIDDEN_CHARS)).toEqual(input);
   });
 
   test('行頭の禁則文字を前の行の末尾に移動する', () => {
     const input = ['これは', '。文章', 'です'];
     const expected = ['これは。', '文章', 'です'];
-    expect(filterStartJP(input)).toEqual(expected);
+    expect(filterStart(input, LINE_START_FORBIDDEN_CHARS)).toEqual(expected);
   });
 
   test('複数の禁則文字を正しく処理する', () => {
     const input = ['これは', '。とても', '、長い', '」文章', 'です'];
     const expected = ['これは。', 'とても、', '長い」', '文章', 'です'];
-    expect(filterStartJP(input)).toEqual(expected);
+    expect(filterStart(input, LINE_START_FORBIDDEN_CHARS)).toEqual(expected);
   });
 
   test('空の行を保持する', () => {
     const input = ['これは', '', '。文章', 'です'];
     const expected = ['これは。', '', '文章', 'です'];
-    expect(filterStartJP(input)).toEqual(expected);
+    expect(filterStart(input, LINE_START_FORBIDDEN_CHARS)).toEqual(expected);
   });
 
   test('1文字の行（禁則文字のみ）はそのまま保持する', () => {
     const input = ['これは', '。', '文章', 'です'];
     // const expected = ['これは。', '文章', 'です'];
     const expected = ['これは', '。', '文章', 'です'];
-    expect(filterStartJP(input)).toEqual(expected);
+    expect(filterStart(input, LINE_START_FORBIDDEN_CHARS)).toEqual(expected);
   });
 
   test('すべての禁則文字を正しく処理する', () => {
@@ -1134,43 +1137,43 @@ describe('filterStartJP', () => {
       'この' + char,
       '文字',
     ]).flat();
-    expect(filterStartJP(input)).toEqual(expected);
+    expect(filterStart(input, LINE_START_FORBIDDEN_CHARS)).toEqual(expected);
   });
 });
 
-describe('filterEndJP', () => {
+describe('filterEnd (Japanese kinsoku set)', () => {
   test('空の配列を渡すと空の配列を返す', () => {
-    expect(filterEndJP([])).toEqual([]);
+    expect(filterEnd([], LINE_END_FORBIDDEN_CHARS)).toEqual([]);
   });
 
   test('禁則文字を含まない行はそのまま返す', () => {
     const input = ['これは', '普通の', '文章です。'];
-    expect(filterEndJP(input)).toEqual(input);
+    expect(filterEnd(input, LINE_END_FORBIDDEN_CHARS)).toEqual(input);
   });
 
   test('行末の禁則文字を次の行の先頭に移動する', () => {
     const input = ['これは「', '文章', 'です。'];
     const expected = ['これは', '「文章', 'です。'];
-    expect(filterEndJP(input)).toEqual(expected);
+    expect(filterEnd(input, LINE_END_FORBIDDEN_CHARS)).toEqual(expected);
   });
 
   test('複数の禁則文字を正しく処理する', () => {
     const input = ['これは「', '長い『', '文章（', 'です。'];
     const expected = ['これは', '「長い', '『文章', '（です。'];
-    expect(filterEndJP(input)).toEqual(expected);
+    expect(filterEnd(input, LINE_END_FORBIDDEN_CHARS)).toEqual(expected);
   });
 
   // Cant understand purpose of this test...
   // test('空の行を保持する', () => {
   //   const input = ['これは「', '', '文章', 'です。'];
   //   const expected = ['これは', '「', '', '文章', 'です。'];
-  //   expect(filterEndJP(input)).toEqual(expected);
+  //   expect(filterEnd(input, LINE_END_FORBIDDEN_CHARS)).toEqual(expected);
   // });
 
   test('1文字の行（禁則文字のみ）はそのまま保持する', () => {
     const input = ['これは', '「', '文章', 'です。'];
     const expected = ['これは', '「', '文章', 'です。'];
-    expect(filterEndJP(input)).toEqual(expected);
+    expect(filterEnd(input, LINE_END_FORBIDDEN_CHARS)).toEqual(expected);
   });
 
   test('すべての禁則文字を正しく処理する', () => {
@@ -1179,12 +1182,86 @@ describe('filterEndJP', () => {
       'これは',
       char + '文章',
     ]).flat();
-    expect(filterEndJP(input)).toEqual(expected);
+    expect(filterEnd(input, LINE_END_FORBIDDEN_CHARS)).toEqual(expected);
   });
 
   test('最後の行の禁則文字は移動しない', () => {
     const input = ['これは「', '文章「', 'です「'];
     const expected = ['これは', '「文章', '「です「'];
-    expect(filterEndJP(input)).toEqual(expected);
+    expect(filterEnd(input, LINE_END_FORBIDDEN_CHARS)).toEqual(expected);
+  });
+});
+
+describe('universal punctuation kinsoku (script-independent, non-CJK text)', () => {
+  // A mock font where every glyph is exactly 1pt wide at fontSize 12, so a
+  // boxWidthInPt of N fits N characters per line (mirrors the mock used by the
+  // getSplitPosition tests above).
+  const mockedAdvanceWidth = 1000 / 12;
+  const mockedFont = {
+    unitsPerEm: 1000,
+    layout: (text: string) => ({
+      glyphs: Array.from(text, () => ({ advanceWidth: mockedAdvanceWidth })),
+    }),
+  } as unknown as FontKitFont;
+  const wrap = (value: string, boxWidthInPt: number) =>
+    splitTextToSize({ value, characterSpacing: 0, fontSize: 12, fontKitFont: mockedFont, boxWidthInPt });
+
+  describe('filterStart', () => {
+    it('moves closing punctuation off the start of a line onto the previous line', () => {
+      expect(filterStart(['foo', ',bar'], LINE_START_FORBIDDEN_UNIVERSAL)).toEqual(['foo,', 'bar']);
+      expect(filterStart(['see', ')more'], LINE_START_FORBIDDEN_UNIVERSAL)).toEqual(['see)', 'more']);
+    });
+
+    it('leaves ordinary leading characters untouched', () => {
+      const input = ['plain', 'english', 'text'];
+      expect(filterStart(input, LINE_START_FORBIDDEN_UNIVERSAL)).toEqual(input);
+    });
+  });
+
+  describe('filterEnd', () => {
+    it('moves an opening bracket off the end of a line onto the next line', () => {
+      expect(filterEnd(['foo (', 'bar'], LINE_END_FORBIDDEN_UNIVERSAL)).toEqual(['foo ', '(bar']);
+    });
+
+    it('detects an opener even when the packer left trailing whitespace', () => {
+      // The word segmenter emits "(" as its own segment, so the previous line
+      // can end with "... 2026 ( " — the opener is only visible after trimEnd().
+      expect(
+        filterEnd(['delivered in March ( ', 'see appendix A)'], LINE_END_FORBIDDEN_UNIVERSAL),
+      ).toEqual(['delivered in March ', '(see appendix A)']);
+    });
+
+    it('does NOT treat a straight apostrophe as an opener (possessives stay intact)', () => {
+      const input = ["companies'", 'obligations'];
+      expect(filterEnd(input, LINE_END_FORBIDDEN_UNIVERSAL)).toEqual(input);
+    });
+
+    it('does NOT treat a straight double quote as an opener', () => {
+      const input = ['titled "Q1 Results"', 'and was approved.'];
+      expect(filterEnd(input, LINE_END_FORBIDDEN_UNIVERSAL)).toEqual(input);
+    });
+  });
+
+  describe('end-to-end via splitTextToSize', () => {
+    it('does not strand an opening parenthesis at the end of a wrapped Latin line', () => {
+      // Without the universal filter the packer yields ['one (', 'two'].
+      expect(wrap('one (two', 5)).toEqual(['one', '(two\n']);
+    });
+
+    it('keeps a possessive apostrophe at a line end instead of tearing it off', () => {
+      // "companies'" ends the first line. If a straight apostrophe were treated
+      // as an opener it would be moved, yielding ['companies', "'obligations"].
+      expect(wrap("companies' obligations", 11)).toEqual(["companies'", 'obligations\n']);
+    });
+
+    it('leaves a short line untouched', () => {
+      expect(wrap("it's", 20)).toEqual(["it's\n"]);
+    });
+
+    it('still applies Japanese kinsoku (behaviour unchanged for CJK)', () => {
+      // '「' must not be stranded at the end of a wrapped Japanese line.
+      const lines = wrap('あ「いうえ', 2);
+      expect(lines.some((line) => line.trimEnd().endsWith('「'))).toBe(false);
+    });
   });
 });

--- a/packages/schemas/src/text/constants.ts
+++ b/packages/schemas/src/text/constants.ts
@@ -125,12 +125,13 @@ export const LINE_END_FORBIDDEN_CHARS = [
   '“',
   '｟',
   '«',
-  // 欧文の始め括弧・約物（Latin opening punctuation）
+  // 欧文の始め括弧・約物（Latin opening punctuation）. Straight ASCII quotes are
+  // deliberately NOT here for the same reason they are excluded from the
+  // universal set below: they are open/close-ambiguous and ' marks possessives,
+  // so a mixed JP+Latin line ending in "IBM's" must keep its apostrophe.
   '(',
   '[',
   '{',
-  '"',
-  "'",
   '„',
   '¿',
   '¡',

--- a/packages/schemas/src/text/constants.ts
+++ b/packages/schemas/src/text/constants.ts
@@ -61,6 +61,7 @@ export const LINE_START_FORBIDDEN_CHARS = [
   '】',
   '>',
   '≫',
+  '»',
   ']',
 
   // 記号
@@ -124,4 +125,27 @@ export const LINE_END_FORBIDDEN_CHARS = [
   '“',
   '｟',
   '«',
+  // 欧文の始め括弧・約物（Latin opening punctuation）
+  '(',
+  '[',
+  '{',
+  '"',
+  "'",
+  '„',
+  '¿',
+  '¡',
 ];
+
+// Universal (script-independent) kinsoku sets. Unlike LINE_*_FORBIDDEN_CHARS,
+// these are applied to every line regardless of whether it contains Japanese,
+// so ordinary Latin text is protected from stranded punctuation as well.
+
+// A line must not START with these closing/trailing marks.
+export const LINE_START_FORBIDDEN_UNIVERSAL = [')', ']', '}', '»', ',', '.', ';', ':', '!', '?'];
+
+// A line must not END with these opening marks. Straight ASCII quotes (" and ')
+// are deliberately excluded: the same glyph both opens and closes a quotation,
+// and ' also marks a possessive, so treating a line-final one as an opener
+// corrupts routine English text (e.g. "companies' obligations" would split into
+// "companies" / "'obligations"). Curly quotes are excluded for the same reason.
+export const LINE_END_FORBIDDEN_UNIVERSAL = ['(', '[', '{', '«', '„', '¿', '¡'];

--- a/packages/schemas/src/text/helper.ts
+++ b/packages/schemas/src/text/helper.ts
@@ -25,6 +25,8 @@ import {
   VERTICAL_ALIGN_TOP,
   LINE_END_FORBIDDEN_CHARS,
   LINE_START_FORBIDDEN_CHARS,
+  LINE_END_FORBIDDEN_UNIVERSAL,
+  LINE_START_FORBIDDEN_UNIVERSAL,
 } from './constants.js';
 
 export const getBrowserVerticalFontAdjustments = (
@@ -501,11 +503,13 @@ const getSplittedLinesBySegmenter = (line: string, calcValues: FontWidthCalcValu
     }
   }
 
-  if (lines.some(containsJapanese)) {
-    return adjustEndOfLine(filterEndJP(filterStartJP(lines)));
-  } else {
-    return adjustEndOfLine(lines);
-  }
+  // Anti-orphan kinsoku filtering. The full Japanese kinsoku set is only
+  // meaningful for CJK text, but the universal set (Latin brackets, closing
+  // punctuation, etc.) applies to every script, so it runs unconditionally.
+  const hasJapanese = lines.some(containsJapanese);
+  const startForbidden = hasJapanese ? LINE_START_FORBIDDEN_CHARS : LINE_START_FORBIDDEN_UNIVERSAL;
+  const endForbidden = hasJapanese ? LINE_END_FORBIDDEN_CHARS : LINE_END_FORBIDDEN_UNIVERSAL;
+  return adjustEndOfLine(filterEnd(filterStart(lines, startForbidden), endForbidden));
 };
 
 // add a newline if the line is the end of the paragraph
@@ -527,8 +531,9 @@ function containsJapanese(text: string): boolean {
 //
 // https://www.morisawa.co.jp/blogs/MVP/8760
 //
-// 行頭禁則
-export const filterStartJP = (lines: string[]): string[] => {
+// 行頭禁則 — a line must not start with any of forbiddenChars; such a
+// character is moved to the tail of the previous line.
+export const filterStart = (lines: string[], forbiddenChars: string[]): string[] => {
   const filtered: string[] = [];
   let charToAppend: string | null = null;
 
@@ -540,7 +545,7 @@ export const filterStartJP = (lines: string[]): string[] => {
         filtered.push('');
       } else {
         const charAtStart: string = line.charAt(0);
-        if (LINE_START_FORBIDDEN_CHARS.includes(charAtStart)) {
+        if (forbiddenChars.includes(charAtStart)) {
           if (line.trim().length === 1) {
             filtered.push(line);
             charToAppend = null;
@@ -574,8 +579,11 @@ export const filterStartJP = (lines: string[]): string[] => {
   }
 };
 
-// 行末禁則
-export const filterEndJP = (lines: string[]): string[] => {
+// 行末禁則 — a line must not end with any of forbiddenChars; such a character
+// is moved to the head of the next line. The end is inspected after trimEnd()
+// because the word packer can leave trailing whitespace after a stranded
+// opener (e.g. "... 2026 ( "), which would otherwise hide the forbidden char.
+export const filterEnd = (lines: string[], forbiddenChars: string[]): string[] => {
   const filtered: string[] = [];
   let charToPrepend: string | null = null;
 
@@ -583,17 +591,18 @@ export const filterEndJP = (lines: string[]): string[] => {
     if (line.trim().length === 0) {
       filtered.push('');
     } else {
-      const chartAtEnd = line.slice(-1);
+      const trimmedLine = line.trimEnd();
+      const chartAtEnd = trimmedLine.slice(-1);
 
-      if (LINE_END_FORBIDDEN_CHARS.includes(chartAtEnd)) {
-        if (line.trim().length === 1) {
+      if (forbiddenChars.includes(chartAtEnd)) {
+        if (trimmedLine.length === 1) {
           filtered.push(line);
           charToPrepend = null;
         } else {
           if (charToPrepend) {
-            filtered.push(charToPrepend + line.slice(0, -1));
+            filtered.push(charToPrepend + trimmedLine.slice(0, -1));
           } else {
-            filtered.push(line.slice(0, -1));
+            filtered.push(trimmedLine.slice(0, -1));
           }
           charToPrepend = chartAtEnd;
         }

--- a/packages/schemas/src/text/helper.ts
+++ b/packages/schemas/src/text/helper.ts
@@ -595,7 +595,9 @@ export const filterEnd = (lines: string[], forbiddenChars: string[]): string[] =
       const chartAtEnd = trimmedLine.slice(-1);
 
       if (forbiddenChars.includes(chartAtEnd)) {
-        if (trimmedLine.length === 1) {
+        // Fully-trimmed length: a line like "  (" is still just one character
+        // of content, and moving it would leave a whitespace-only line behind.
+        if (line.trim().length === 1) {
           filtered.push(line);
           charToPrepend = null;
         } else {


### PR DESCRIPTION
Text wrapping can leave an opening bracket dangling at the end of a line:

```
Consulting services delivered in March
(see appendix A), as agreed in the
```

...is what you'd want, but what actually renders is:

```
Consulting services delivered in March (
see appendix A), as agreed in the
```

This happens for any non-Japanese text. The wrapper splits lines on
`Intl.Segmenter(undefined, { granularity: 'word' })` segments, and the
segmenter emits an opening bracket as its own segment (even with no space
around it), so the packer is free to break right after it. The kinsoku
filters (`filterStartJP` / `filterEndJP`) fix exactly this class of problem,
but `getSplittedLinesBySegmenter` only calls them when the line contains
Japanese:

```ts
if (lines.some(containsJapanese)) {
  return adjustEndOfLine(filterEndJP(filterStartJP(lines)));
} else {
  return adjustEndOfLine(lines); // Latin text: no anti-orphan pass at all
}
```

### What this PR does

- Adds two script-independent sets in `packages/schemas/src/text/constants.ts`
  and applies them to every line:
  - `LINE_END_FORBIDDEN_UNIVERSAL` — a line shouldn't end with an opener:
    `( [ { « „ ¿ ¡`
  - `LINE_START_FORBIDDEN_UNIVERSAL` — a line shouldn't start with a closer:
    `) ] } » , . ; : ! ?`
- Renames `filterStartJP` / `filterEndJP` to `filterStart` / `filterEnd`
  taking the forbidden set as a parameter. Lines containing Japanese get the
  full kinsoku set (extended with the universal characters, so a mixed
  JP+Latin line ending in `(` is fixed too); everything else gets the
  universal set.
- `filterEnd` now checks `line.trimEnd()` rather than the raw last character.
  The packer usually leaves a trailing space after a stranded opener
  (`"... March ( "`), which used to hide it from the filter. The moved
  character is prepended to the next line, and the terminal `charToPrepend`
  is re-appended, so no character is ever dropped.

### Why straight quotes are not in the list

`"` and `'` open *and* close, and `'` also marks possessives. If a line-final
straight quote were treated as an opener, ordinary English would get mangled:
`companies' obligations` would wrap as `companies` / `'obligations`. So the
universal end-set only contains characters that are unambiguously openers,
and there's a regression test making sure a possessive at a line boundary
stays attached to its word. Curly quotes are left out for the same reason.

### Behaviour changes

- Latin (and other non-CJK) text: now gets the anti-orphan pass — that's the fix.
- Japanese text: kinsoku unchanged; all pre-existing kinsoku tests pass as-is
  against the renamed filters.
- Mixed JP+Latin lines: previously only the JP characters were protected; now
  a Latin opener at the end of such a line is moved as well. This is the one
  intentional behaviour change on the JP path.
- The renamed helpers are internal (imported only by tests), not part of the
  public entry point. `@pdfme/ui` re-bundles this code, so the Designer
  preview and the generated PDF stay in sync automatically.

### Tests

Added next to the existing kinsoku tests in
`packages/schemas/__tests__/text.test.ts`:

- an opener is moved off the end of a line, including the trailing-whitespace
  case the packer produces;
- a possessive apostrophe at a line end stays put;
- a straight double quote at a line end stays put;
- closing punctuation is moved off the start of a line;
- end-to-end through `splitTextToSize`: `one (two` → `['one', '(two\n']`;
- a short string is untouched;
- Japanese kinsoku behaves as before.

`vitest` in `packages/schemas`: 234 passed. Root `typecheck`, package lint
and `oxfmt --check` clean; the package builds and the change is present in
the emitted bundle.

### Related work

Closes #1115.

This picks up where #1116 (the German POC by @kyasu1) left off — same
diagnosis, same parameterize-the-filters approach, credit where due. What
this PR adds on top of the POC:

- the sets are script-independent rather than German-specific (the POC's own
  description notes it "needs to take into account another languages too");
- the end-filter checks `line.trimEnd()` — the packer usually leaves a
  trailing space after a stranded opener, so without this the filter misses
  the most common real-world case entirely;
- straight `"` and `'` are excluded from the end-set (the POC includes them
  as "optional"): they are open/close-ambiguous, and treating them as openers
  breaks possessives — there is a regression test for exactly that;
- hyphens/dashes are not forbidden at line end (hyphenation legitimately ends
  lines with `-`);
- mixed JP+Latin lines get the union of both sets, and the pre-existing
  kinsoku tests pass unchanged.
