### PR TITLE
Fix performance: font deepcopy on renderKey

### DIFF
--- a/packages/ui/src/components/Renderer.tsx
+++ b/packages/ui/src/components/Renderer.tsx
@@ -9,7 +9,7 @@ import {
   Plugin,
   UIOptions,
   cloneDeep,
-  Font,
+  type Font,
 } from '@pdfme/common';
 import { theme as antdTheme } from 'antd';
 import { SELECTABLE_CLASSNAME } from '../constants.js';
@@ -41,14 +41,14 @@ type ReRenderCheckProps = {
 
 const useRenderKey = (arg: ReRenderCheckProps) => {
   const { plugin, value, mode, scale, schema, options } = arg;
-  const { font, ...optionsWithoutFont } = options;
+  const { font: fontOptions, ...optionsWithoutFont } = options;
   const _options: UIOptions = cloneDeep(optionsWithoutFont);
-  if (options.font) {
-    let fontForKey: Font = {};
-    Object.entries(options.font).forEach(([fontName, fontObj]) => {
+  if (fontOptions) {
+    const fontForKey: Font = {};
+    Object.entries(fontOptions).forEach(([fontName, fontObj]) => {
       fontForKey[fontName] = {
         ...fontObj,
-        data: '...'
+        data: '...',
       };
     });
     _options.font = fontForKey;

--- a/packages/ui/src/components/Renderer.tsx
+++ b/packages/ui/src/components/Renderer.tsx
@@ -9,6 +9,7 @@ import {
   Plugin,
   UIOptions,
   cloneDeep,
+  Font,
 } from '@pdfme/common';
 import { theme as antdTheme } from 'antd';
 import { SELECTABLE_CLASSNAME } from '../constants.js';
@@ -40,11 +41,17 @@ type ReRenderCheckProps = {
 
 const useRenderKey = (arg: ReRenderCheckProps) => {
   const { plugin, value, mode, scale, schema, options } = arg;
-  const _options = cloneDeep(options);
-  if (_options.font) {
-    Object.values(_options.font).forEach((fontObj) => {
-      (fontObj as { data: string }).data = '...';
+  const { font, ...optionsWithoutFont } = options;
+  const _options: UIOptions = cloneDeep(optionsWithoutFont);
+  if (options.font) {
+    let font: Font = {};
+    Object.entries(options.font).forEach(([fontName, fontObj]) => {
+      font[fontName] = {
+        ...fontObj,
+        data: '...'
+      };
     });
+    _options.font = font;
   }
   const optionStr = JSON.stringify(_options);
 

--- a/packages/ui/src/components/Renderer.tsx
+++ b/packages/ui/src/components/Renderer.tsx
@@ -44,14 +44,14 @@ const useRenderKey = (arg: ReRenderCheckProps) => {
   const { font, ...optionsWithoutFont } = options;
   const _options: UIOptions = cloneDeep(optionsWithoutFont);
   if (options.font) {
-    let font: Font = {};
+    let fontForKey: Font = {};
     Object.entries(options.font).forEach(([fontName, fontObj]) => {
-      font[fontName] = {
+      fontForKey[fontName] = {
         ...fontObj,
         data: '...'
       };
     });
-    _options.font = font;
+    _options.font = fontForKey;
   }
   const optionStr = JSON.stringify(_options);
 


### PR DESCRIPTION
See https://github.com/pdfme/pdfme/issues/693

Fonts are copied on renderKey resulting in low performance if fonts are used as bytearrays instead of string urls.
This fix avoids copying the font data in renderKey.