### PR TITLE
fix(ui): avoid installing bundled form-render

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-7.2.1.tgz",
       "integrity": "sha512-lCHDcEzieu4GA3n8ELeZ5VQ8pKQAWcGGLRTQ50aQM2iqPpq2evTxER84jfdPvsPAtEcZ7m44NI45edFMo8oOYQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -57,6 +58,7 @@
       "version": "1.24.0",
       "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-1.24.0.tgz",
       "integrity": "sha512-K4cYrJBsgvL+IoozUXYjbT6LHHNt+19a9zkvpBPxLjFHas1UpPM2A5MlhROb0BT8N8WoavM5VsP9MeSeNK/3mg==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -77,6 +79,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@ant-design/cssinjs-utils/-/cssinjs-utils-1.1.3.tgz",
       "integrity": "sha512-nOoQMLW1l+xR1Co8NFVYiP8pZp3VjIIzqV6D6ShYF2ljtdwWJn5WSsH+7kvCktXL/yhEtWURKOfH5Xz/gzlwsg==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -93,6 +96,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@ant-design/fast-color/-/fast-color-2.0.6.tgz",
       "integrity": "sha512-y2217gk4NqL35giHl72o6Zzqji9O7vHh9YmhUVkPtAOpoTCH4uWxo/pr4VE8t0+ChEPs0qo4eJRC5Q1eXWo3vA==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -106,6 +110,7 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.6.1.tgz",
       "integrity": "sha512-0/xS39c91WjPAZOWsvi1//zjx6kAp4kxWwctR6kuU6p133w8RU0D2dSCvZC19uQyharg/sAvYxGYWl01BbZZfg==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -133,6 +138,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-1.1.2.tgz",
       "integrity": "sha512-EzlvzE6xQUBrZuuhSAFTdsr4P2bBBHGZwKFemEfq8gIGyIQCxalYfZW/T2ORbtQx5rU69o+WycP3exY/7T1hGA==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -404,6 +410,7 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
       "integrity": "sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1782,6 +1789,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@rc-component/color-picker/-/color-picker-2.0.1.tgz",
       "integrity": "sha512-WcZYwAThV/b2GISQ8F+7650r5ZZJ043E57aVBFkQ+kSY4C6wdofXgB0hBx+GPGpIU0Z81eETNoDUJMr7oy/P8Q==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1799,6 +1807,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@rc-component/context/-/context-1.4.0.tgz",
       "integrity": "sha512-kFcNxg9oLRMoL3qki0OMxK+7g5mypjgaaJp/pkOis/6rVxma9nJBF/8kCIuTYHUQNr0ii7MxqE33wirPZLJQ2w==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2078,6 +2087,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rc-component/mutate-observer/-/mutate-observer-1.1.0.tgz",
       "integrity": "sha512-QjrOsDXQusNwGZPf4/qRQasg7UFEj06XiCJ8iuiq/Io7CrHrgVi6Uuetw60WAMG1799v+aM8kyc+1L/GBbHSlw==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2202,6 +2212,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-1.1.2.tgz",
       "integrity": "sha512-6f813C0IsasTZms08kfA8kPAGxbbkYToa8ALaiDIGGECU4i9hj8Plgbx0sNJDrey3EtHO30hmdaxtT0138xZcg==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2221,6 +2232,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@rc-component/qrcode/-/qrcode-1.1.2.tgz",
       "integrity": "sha512-CTXG18eP3sO3gc+96ep9HyVI/RzMup7L59apM/D0wWo1SHRdwOb7xyD4bMbmpu4dPlTch59Kxb8lU7U9ME60fg==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2346,6 +2358,7 @@
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/@rc-component/tour/-/tour-1.15.1.tgz",
       "integrity": "sha512-Tr2t7J1DKZUpfJuDZWHxyxWpfmj8EZrqSgyMZ+BCdvKZ6r1UDsfU46M/iWAAFBy961Ssfom2kv5f3UcjIL2CmQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2402,6 +2415,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-2.3.1.tgz",
       "integrity": "sha512-ORENF39PeXTzM+gQEshuk460Z8N4+6DkjpxlpE7Q3gYy1iBpLrx0FOJz3h62ryrJZ/3zCAUIkT1Pb/8hHWpb3A==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2982,6 +2996,7 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
       "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/mdast": {
@@ -3030,7 +3045,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3502,6 +3517,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/add-dom-event-listener/-/add-dom-event-listener-1.1.0.tgz",
       "integrity": "sha512-WCxx1ixHT0GQU9hb0KI/mhgRQhnU+U3GvwY6ZvVjYq8rsihIGoaIOUbY0yMPBxLH5MDtr0kz3fisWGNcbWW7Jw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "object-assign": "4.x"
@@ -3511,6 +3527,7 @@
       "version": "3.9.7",
       "resolved": "https://registry.npmjs.org/ahooks/-/ahooks-3.9.7.tgz",
       "integrity": "sha512-S0lvzhbdlhK36RFBkGv+RbOM/dbbweym+BIHM/bwwuWVSVN5TuVErHPMWo4w0t1NDYg5KPp2iEf7Y7E5LASYiw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.21.0",
@@ -3562,6 +3579,7 @@
       "version": "5.29.3",
       "resolved": "https://registry.npmjs.org/antd/-/antd-5.29.3.tgz",
       "integrity": "sha512-3DdbGCa9tWAJGcCJ6rzR8EJFsv2CtyEbkVabZE14pfgUHfCicWCj0/QzQVLDYg8CPfQk9BH7fHCoTXHTy7MP/A==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3648,12 +3666,14 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/async-validator/-/async-validator-3.5.2.tgz",
       "integrity": "sha512-8eLCg00W9pIRZSB781UUX/H6Oskmm8xloZfr09lz5bikRpBVDlJ3hRVuxxP1SxcwsEYfJ4IU8Q19Y8/893r3rQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-js": "^2.4.0",
@@ -3805,6 +3825,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/clawpdf": {
@@ -3841,6 +3862,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
       "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.3",
@@ -3872,12 +3894,14 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-string": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
       "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "^1.0.0",
@@ -3888,6 +3912,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -3897,6 +3922,7 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/component-classes/-/component-classes-1.2.6.tgz",
       "integrity": "sha512-hPFGULxdwugu1QWW3SvVOCUHLzO34+a2J6Wqy0c5ASQkfi9/8nZcBB0ZohaEbXOQlCflMAEMmEWk7u7BVs4koA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "component-indexof": "0.0.3"
@@ -3905,7 +3931,8 @@
     "node_modules/component-indexof": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/component-indexof/-/component-indexof-0.0.3.tgz",
-      "integrity": "sha512-puDQKvx/64HZXb4hBwIcvQLaLgux8o1CbWl39s41hrIIZDl1lJiD5jc22gj3RBeGK0ovxALDYpIbyjqDUUl0rw=="
+      "integrity": "sha512-puDQKvx/64HZXb4hBwIcvQLaLgux8o1CbWl39s41hrIIZDl1lJiD5jc22gj3RBeGK0ovxALDYpIbyjqDUUl0rw==",
+      "dev": true
     },
     "node_modules/compute-scroll-into-view": {
       "version": "3.1.1",
@@ -3924,6 +3951,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
       "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3935,6 +3963,7 @@
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
       "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
       "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT"
     },
@@ -3942,6 +3971,7 @@
       "version": "15.7.0",
       "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.7.0.tgz",
       "integrity": "sha512-QZv4sFWG9S5RUvkTYWbflxeZX+JG7Cz0Tn33rQBJ+WFQTqTfUTjMjiv9tnfXazjsO5r0KhPs+AqCjyrQX6h2ng==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.3.1",
@@ -3952,6 +3982,7 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/css-animation/-/css-animation-1.6.1.tgz",
       "integrity": "sha512-/48+/BaEaHRY6kNQ2OIPzKf9A6g8WjZYjhiNDNuIVbsm5tXCGIAsHDjB4Xu1C4vXJtUWZo26O68OQkDpNBaPog==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "babel-runtime": "6.x",
@@ -4120,6 +4151,7 @@
       "version": "1.12.4",
       "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.12.4.tgz",
       "integrity": "sha512-R8LUSEay/68zE5c8/3BDxiTEvgb4xZTF0RKmAHfiEVN3klfIpXfi2/QCoiWPccVQ0J/ZGdz9OjzL4uJEP/MRAw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/dompurify": {
@@ -4209,6 +4241,7 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/form-render/-/form-render-2.5.6.tgz",
       "integrity": "sha512-WykpGnVzccZ5MImHiQ/24otmOSKBu/pDwx33gPD2FYbWzIY0fo/0VH2hWQjNQV4T/4RtuIi+KPNHtDRx2ZHgrg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ant-design/icons": "^4.0.2",
@@ -4232,6 +4265,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-6.0.0.tgz",
       "integrity": "sha512-qAZRvPzfdWHtfameEGP2Qvuf838NhergR35o+EuVyB5XvSA98xod5r4utvi4TJ3ywmevm290g9nsCG5MryrdWQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ctrl/tinycolor": "^3.4.0"
@@ -4241,6 +4275,7 @@
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-4.8.3.tgz",
       "integrity": "sha512-HGlIQZzrEbAhpJR6+IGdzfbPym94Owr6JZkJ2QCCnOkPVIWMO2xgIVcOKnl8YcpijIo39V7l2qQL5fmtw56cMw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ant-design/colors": "^6.0.0",
@@ -4262,6 +4297,7 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/rc-color-picker/-/rc-color-picker-1.2.6.tgz",
       "integrity": "sha512-AaC9Pg7qCHSy5M4eVbqDIaNb2FC4SEw82GOHB2C4R/+vF2FVa/r5XA+Igg5+zLPmAvBLhz9tL4MAfkRA8yWNJw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.2.5",
@@ -4279,6 +4315,7 @@
       "version": "4.21.1",
       "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.21.1.tgz",
       "integrity": "sha512-Z+vlkSQVc1l8O2UjR3WQ+XdWlhj5q9BMQNLk2iOBch75CqPfrJyGtcWMcnhRlNuDu0Ndtt4kLVO8JI8BrABobg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "add-dom-event-listener": "^1.1.0",
@@ -4292,12 +4329,14 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/form-render/node_modules/virtualizedtableforantd4": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/virtualizedtableforantd4/-/virtualizedtableforantd4-1.3.2.tgz",
       "integrity": "sha512-XRNhSINFKIywhDwzul9D7jam9l3RmampiVVPlJSpAbbjnON50or7h+Evy5TsgQtEzMxtG7Caofs73mwKCb2I6Q==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "antd": "^4.0.0 || ^5.0.0",
@@ -4416,6 +4455,7 @@
       "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.12.2.tgz",
       "integrity": "sha512-7m1vEcPCxXYI8HqnL8CKI6siDyD+eIWSwgB3DZA+ZTogxk9I4CDnj4wilt9x/+/QbHI4YG5YZNmC6458/e9Ktg==",
       "deprecated": "The Intersection Observer polyfill is no longer needed and can safely be removed. Intersection Observer has been Baseline since 2019.",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/is-ci": {
@@ -4482,12 +4522,14 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
       "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsdom": {
@@ -4830,12 +4872,14 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
       "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/longest-streak": {
@@ -4852,6 +4896,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -5742,6 +5787,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5940,6 +5986,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -6027,6 +6074,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -6038,6 +6086,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/punycode": {
@@ -6054,6 +6103,7 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "performance-now": "^2.1.0"
@@ -6063,6 +6113,7 @@
       "version": "2.4.5",
       "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-2.4.5.tgz",
       "integrity": "sha512-nv9wYUYdfyfK+qskThf4BQUSIadeI/dCsfaMZfNEoxm9HwOIioQ+LyqmMK6jWHAZQgOzMLaqawhuBXlF63vgjw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.26.0",
@@ -6075,6 +6126,7 @@
       "version": "4.21.1",
       "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.21.1.tgz",
       "integrity": "sha512-Z+vlkSQVc1l8O2UjR3WQ+XdWlhj5q9BMQNLk2iOBch75CqPfrJyGtcWMcnhRlNuDu0Ndtt4kLVO8JI8BrABobg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "add-dom-event-listener": "^1.1.0",
@@ -6088,12 +6140,14 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/rc-animate": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/rc-animate/-/rc-animate-2.11.1.tgz",
       "integrity": "sha512-1NyuCGFJG/0Y+9RKh5y/i/AalUCA51opyyS/jO2seELpgymZm2u9QV3xwODwEuzkmeQ1BDPxMLmYLcTJedPlkQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "babel-runtime": "6.x",
@@ -6109,6 +6163,7 @@
       "version": "4.21.1",
       "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.21.1.tgz",
       "integrity": "sha512-Z+vlkSQVc1l8O2UjR3WQ+XdWlhj5q9BMQNLk2iOBch75CqPfrJyGtcWMcnhRlNuDu0Ndtt4kLVO8JI8BrABobg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "add-dom-event-listener": "^1.1.0",
@@ -6122,12 +6177,14 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/rc-cascader": {
       "version": "3.34.0",
       "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.34.0.tgz",
       "integrity": "sha512-KpXypcvju9ptjW9FaN2NFcA2QH9E9LHKq169Y0eWtH4e/wHQ5Wh5qZakAgvb8EKZ736WZ3B0zLLOBsrsja5Dag==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6146,6 +6203,7 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/rc-checkbox/-/rc-checkbox-3.5.0.tgz",
       "integrity": "sha512-aOAQc3E98HteIIsSqm6Xk2FPKIER6+5vyEFMZfo73TqM+VVAIqOkHoPjgKLqSNtVLWScoaM7vY2ZrGEheI79yg==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6162,6 +6220,7 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-3.9.0.tgz",
       "integrity": "sha512-swDdz4QZ4dFTo4RAUMLL50qP0EY62N2kvmk2We5xYdRwcRn8WcYtuetCJpwpaCbUfUt5+huLpVxhvmnK+PHrkA==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6179,6 +6238,7 @@
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-9.6.0.tgz",
       "integrity": "sha512-ApoVi9Z8PaCQg6FsUzS8yvBEQy0ZL2PkuvAgrmohPkN3okps5WZ5WQWPc1RNuiOKaAYv8B97ACdsFU5LizzCqg==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6197,6 +6257,7 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-7.3.0.tgz",
       "integrity": "sha512-DX6CIgiBWNpJIMGFO8BAISFkxiuKitoizooj4BDyee8/SnBn0zwO2FHrNDpqqepj0E/TFTDpmEBCyFuTgC7MOg==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6215,6 +6276,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-4.2.1.tgz",
       "integrity": "sha512-YDAlXsPv3I1n42dv1JpdM7wJ+gSUBfeyPK59ZpBD9jQhK9jVuxpjj3NmWQHOBceA1zEPVX84T2wbdb2SD0UjmA==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6250,6 +6312,7 @@
       "version": "7.12.0",
       "resolved": "https://registry.npmjs.org/rc-image/-/rc-image-7.12.0.tgz",
       "integrity": "sha512-cZ3HTyyckPnNnUb9/DRqduqzLfrQRyi+CdHjdqgsyDpI3Ln5UX1kXnAhPBSJj9pVRzwRFgqkN7p9b6HBDjmu/Q==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6269,6 +6332,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/rc-input/-/rc-input-1.8.0.tgz",
       "integrity": "sha512-KXvaTbX+7ha8a/k+eg6SYRVERK0NddX8QX7a7AnRvUa/rEH0CNMlpcBzBkhI0wp2C8C4HlMoYl8TImSN+fuHKA==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6285,6 +6349,7 @@
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-9.5.0.tgz",
       "integrity": "sha512-bKaEvB5tHebUURAEXw35LDcnRZLq3x1k7GxfAqBMzmpHkDGzjAtnUL8y4y5N15rIFIg5IJgwr211jInl3cipag==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6303,6 +6368,7 @@
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-2.20.0.tgz",
       "integrity": "sha512-w8HCMZEh3f0nR8ZEd466ATqmXFCMGMN5UFCzEUL0bM/nGw/wOS2GgRzKBcm19K++jDyuWCOJOdgcKGXU3fXfbQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6323,6 +6389,7 @@
       "version": "9.16.1",
       "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.16.1.tgz",
       "integrity": "sha512-ghHx6/6Dvp+fw8CJhDUHFHDJ84hJE3BXNCzSgLdmNiFErWSOaZNsihDAsKq9ByTALo/xkNIwtDFGIl6r+RPXBg==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6342,6 +6409,7 @@
       "version": "2.9.5",
       "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.9.5.tgz",
       "integrity": "sha512-w+XTUrfh7ArbYEd2582uDrEhmBHwK1ZENJiSJVb7uRxdE7qJSYjbO2eksRXmndqyKqKoYPc9ClpPh5242mV1vA==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6358,6 +6426,7 @@
       "version": "5.6.4",
       "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-5.6.4.tgz",
       "integrity": "sha512-KcS4O6B4qzM3KH7lkwOB7ooLPZ4b6J+VMmQgT51VZCeEcmghdeR4IrMcFq0LG+RPdnbe/ArT086tGM8Snimgiw==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6378,6 +6447,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/rc-overflow/-/rc-overflow-1.5.0.tgz",
       "integrity": "sha512-Lm/v9h0LymeUYJf0x39OveU52InkdRXqnn2aYXfWmo8WdOonIKB2kfau+GF0fWq6jPgtdO9yMqveGcK6aIhJmg==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6395,6 +6465,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-5.1.0.tgz",
       "integrity": "sha512-8416Yip/+eclTFdHXLKTxZvn70duYVGTvUUWbckCCZoIl3jagqke3GLsFrMs0bsQBikiYpZLD9206Ej4SOdOXQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6411,6 +6482,7 @@
       "version": "4.11.3",
       "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-4.11.3.tgz",
       "integrity": "sha512-MJ5teb7FlNE0NFHTncxXQ62Y5lytq6sh5nUw0iH8OkHL/TjARSEvSHpr940pWgjGANpjCwyMdvsEV55l5tYNSg==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6451,6 +6523,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/rc-progress/-/rc-progress-4.0.0.tgz",
       "integrity": "sha512-oofVMMafOCokIUIBnZLNcOZFsABaUw8PPrf1/y0ZBvKZNpOiu5h4AO9vv11Sw0p4Hb3D0yGWuEattcQGtNJ/aw==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6467,6 +6540,7 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/rc-rate/-/rc-rate-2.13.1.tgz",
       "integrity": "sha512-QUhQ9ivQ8Gy7mtMZPAjLbxBt5y9GRp65VcUyGUMF3N3fhiftivPHdpuDIaWIMOTEprAjZPC08bls1dQB+I1F2Q==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6486,6 +6560,7 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/rc-resize-observer/-/rc-resize-observer-1.4.3.tgz",
       "integrity": "sha512-YZLjUbyIWox8E9i9C3Tm7ia+W7euPItNWSPX5sCcQTYbnwDb5uNpnLHQCG1f22oZWUhLw4Mv2tFmeWe68CDQRQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6503,6 +6578,7 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rc-segmented/-/rc-segmented-2.7.1.tgz",
       "integrity": "sha512-izj1Nw/Dw2Vb7EVr+D/E9lUTkBe+kKC+SAFSU9zqr7WV2W5Ktaa9Gc7cB2jTqgk8GROJayltaec+DBlYKc6d+g==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6520,6 +6596,7 @@
       "version": "14.16.8",
       "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.16.8.tgz",
       "integrity": "sha512-NOV5BZa1wZrsdkKaiK7LHRuo5ZjZYMDxPP6/1+09+FB4KoNi8jcG1ZqLE3AVCxEsYMBe65OBx71wFoHRTP3LRg==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6543,6 +6620,7 @@
       "version": "11.1.9",
       "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-11.1.9.tgz",
       "integrity": "sha512-h8IknhzSh3FEM9u8ivkskh+Ef4Yo4JRIY2nj7MrH6GQmrwV6mcpJf5/4KgH5JaVI1H3E52yCdpOlVyGZIeph5A==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6562,6 +6640,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/rc-steps/-/rc-steps-6.0.1.tgz",
       "integrity": "sha512-lKHL+Sny0SeHkQKKDJlAjV5oZ8DwCdS2hFhAkIjuQt1/pB81M0cA0ErVFdHq9+jmPmFw1vJB2F5NBzFXLJxV+g==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6581,6 +6660,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/rc-switch/-/rc-switch-4.1.0.tgz",
       "integrity": "sha512-TI8ufP2Az9oEbvyCeVE4+90PDSljGyuwix3fV58p7HV2o4wBnVToEyomJRVyTaZeqNPAp+vqeo4Wnj5u0ZZQBg==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6597,6 +6677,7 @@
       "version": "7.54.0",
       "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.54.0.tgz",
       "integrity": "sha512-/wDTkki6wBTjwylwAGjpLKYklKo9YgjZwAU77+7ME5mBoS32Q4nAwoqhA2lSge6fobLW3Tap6uc5xfwaL2p0Sw==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6619,6 +6700,7 @@
       "version": "15.7.0",
       "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-15.7.0.tgz",
       "integrity": "sha512-ZepiE+6fmozYdWf/9gVp7k56PKHB1YYoDsKeQA1CBlJ/POIhjkcYiv0AGP0w2Jhzftd3AVvZP/K+V+Lpi2ankA==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6642,6 +6724,7 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/rc-textarea/-/rc-textarea-1.10.2.tgz",
       "integrity": "sha512-HfaeXiaSlpiSp0I/pvWpecFEHpVysZ9tpDLNkxQbMvMz6gsr7aVZ7FpWP9kt4t7DB+jJXesYS0us1uPZnlRnwQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6660,6 +6743,7 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-6.4.0.tgz",
       "integrity": "sha512-kqyivim5cp8I5RkHmpsp1Nn/Wk+1oeloMv9c7LXNgDxUpGm+RbXJGL+OPvDlcRnx9DBeOe4wyOIl4OKUERyH1g==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6677,6 +6761,7 @@
       "version": "5.13.1",
       "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-5.13.1.tgz",
       "integrity": "sha512-FNhIefhftobCdUJshO7M8uZTA9F4OPGVXqGfZkkD/5soDeOhwO06T/aKTrg0WD8gRg/pyfq+ql3aMymLHCTC4A==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6698,6 +6783,7 @@
       "version": "5.27.0",
       "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-5.27.0.tgz",
       "integrity": "sha512-2qTBTzwIT7LRI1o7zLyrCzmo5tQanmyGbSaGTIf7sYimCklAToVVfpMC6OAldSKolcnjorBYPNSKQqJmN3TCww==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6716,6 +6802,7 @@
       "version": "1.11.5",
       "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-1.11.5.tgz",
       "integrity": "sha512-MBuUPw1nFzA4K7jQOwb7uvFaZFjXGd00EofUYiZ+l/fgKVq8wnLC0lkv36kwqM7vfKyftRo2sh7cWVpdPuNnnw==",
+      "dev": true,
       "dependencies": {
         "babel-runtime": "6.x",
         "create-react-class": "15.x",
@@ -6729,6 +6816,7 @@
       "version": "4.21.1",
       "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.21.1.tgz",
       "integrity": "sha512-Z+vlkSQVc1l8O2UjR3WQ+XdWlhj5q9BMQNLk2iOBch75CqPfrJyGtcWMcnhRlNuDu0Ndtt4kLVO8JI8BrABobg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "add-dom-event-listener": "^1.1.0",
@@ -6742,12 +6830,14 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/rc-upload": {
       "version": "4.11.0",
       "resolved": "https://registry.npmjs.org/rc-upload/-/rc-upload-4.11.0.tgz",
       "integrity": "sha512-ZUyT//2JAehfHzjWowqROcwYJKnZkIUGWaTE/VogVrepSl7AFNbQf4+zGfX4zl9Vrj/Jm8scLO0R6UlPDKK4wA==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6778,6 +6868,7 @@
       "version": "3.19.2",
       "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.19.2.tgz",
       "integrity": "sha512-Ys6NcjwGkuwkeaWBDqfI3xWuZ7rDiQXlH1o2zLfFzATfEgXcqpk8CkgMfbJD81McqjcJVez25a3kPxCR807evA==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6829,6 +6920,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-is": {
@@ -6841,6 +6933,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-moveable": {
@@ -6891,6 +6984,7 @@
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/remark-gfm": {
@@ -6956,6 +7050,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
       "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/restructure": {
@@ -7085,6 +7180,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
       "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7124,6 +7220,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/siginfo": {
@@ -7143,6 +7240,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
       "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.3.1"
@@ -7152,6 +7250,7 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
       "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sirv": {
@@ -7251,6 +7350,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
@@ -7342,6 +7442,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
       "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -7532,6 +7633,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -7986,6 +8088,7 @@
       "version": "4.5.7",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
       "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "use-sync-external-store": "^1.2.2"
@@ -8206,7 +8309,6 @@
         "@scena/react-guides": "^0.28.2",
         "antd": "^6.5.0",
         "dompurify": "^3.4.11",
-        "form-render": "^2.5.5",
         "hotkeys-js": "^4.0.4",
         "lucide-react": "^1.21.0",
         "rc-field-form": "^2.7.1",
@@ -8224,6 +8326,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.3",
         "csstype": "^3.2.3",
+        "form-render": "^2.5.5",
         "vite": "^8.1.0",
         "vite-plugin-css-injected-by-js": "^5.0.1",
         "vite-tsconfig-paths": "^6.1.1"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -55,7 +55,6 @@
     "@scena/react-guides": "^0.28.2",
     "antd": "^6.5.0",
     "dompurify": "^3.4.11",
-    "form-render": "^2.5.5",
     "hotkeys-js": "^4.0.4",
     "lucide-react": "^1.21.0",
     "rc-field-form": "^2.7.1",
@@ -73,6 +72,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",
     "csstype": "^3.2.3",
+    "form-render": "^2.5.5",
     "vite": "^8.1.0",
     "vite-plugin-css-injected-by-js": "^5.0.1",
     "vite-tsconfig-paths": "^6.1.1"


### PR DESCRIPTION
## Summary

- move `form-render` from `@pdfme/ui` runtime dependencies to dev dependencies
- keep it available for the UI build while excluding its legacy peer dependency tree from consumer installs
- update the root lockfile so the `form-render` dependency tree is marked development-only

## Root cause

`@pdfme/ui` bundles `form-render` into `dist/index.js`, but also declared it as a runtime dependency. As a result, npm tried to install `form-render` and resolve its outdated `antd` and React peer dependency tree in consumer projects. This could make `npm install` or `npm ci` loop indefinitely.

The built UI artifact does not contain an external `form-render` import, so consumers do not need the package installed separately.

## Impact

Consumer installs no longer resolve `form-render`, `rc-color-picker`, or `virtualizedtableforantd4`. The Designer property panel remains unchanged because the existing implementation stays bundled in `@pdfme/ui`.

Closes #1566.

## Validation

- `npm run build -w packages/ui`
- `npm run test -w packages/ui` (83 tests passed)
- `npm run lint -w packages/ui`
- `npm run test` (all package tests passed)
- `npm run lint` (passed; existing playground warnings only)
- packed `@pdfme/ui` and installed it in a clean consumer project
- verified `form-render` is absent from the installed dependency tree
- verified the built artifact has no external `form-render` import
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and lockfile classification only; no application logic changes. Slight install-graph risk if the bundle ever stopped inlining `form-render`, but validation confirms consumers no longer resolve it.
> 
> **Overview**
> **`form-render` is no longer a runtime dependency of `@pdfme/ui`.** It is moved to **devDependencies** so it is still available when building the UI package, while consumers of the published package do not install it or its legacy peer tree (`antd` 4/5 peers, `rc-color-picker`, `virtualizedtableforantd4`, etc.).
> 
> The lockfile is refreshed so that **`form-render`’s transitive packages are marked `dev: true`**, matching the new dependency classification. Runtime behavior of the Designer is unchanged because **`form-render` remains bundled into the UI build** rather than required as an external install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b49d007daabc7df1f1f59968c06adb56d35c311. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->