### PR TITLE
fix(tables): omit undefined keys from mapCellStyle

### DIFF
--- a/packages/schemas/__tests__/tableHelper.test.ts
+++ b/packages/schemas/__tests__/tableHelper.test.ts
@@ -1,0 +1,131 @@
+import { getDefaultFont } from '@pdfme/common';
+import type { Schema } from '@pdfme/common';
+import { describe, expect, test } from 'vitest';
+import { createSingleTable } from '../src/tables/tableHelper.js';
+import type { TableSchema } from '../src/tables/types.js';
+
+const basePdf = {
+  width: 210,
+  height: 297,
+  padding: [10, 10, 10, 10] as [number, number, number, number],
+};
+
+const spacingSide = (value: unknown, side: 'top' | 'right' | 'bottom' | 'left'): unknown => {
+  if (typeof value === 'number') return value;
+  if (value && typeof value === 'object') {
+    return (value as Record<string, unknown>)[side];
+  }
+  return value;
+};
+
+const expectUniformSpacing = (value: unknown, expected: number) => {
+  expect(value).not.toBeUndefined();
+  expect(value).not.toBeNull();
+  for (const side of ['top', 'right', 'bottom', 'left'] as const) {
+    expect(spacingSide(value, side)).toBe(expected);
+  }
+};
+
+const expectFiniteGeometry = (table: Awaited<ReturnType<typeof createSingleTable>>) => {
+  expect(Number.isFinite(table.getHeight())).toBe(true);
+  expect(Number.isFinite(table.getWidth())).toBe(true);
+  for (const row of table.allRows()) {
+    expect(Number.isFinite(row.height)).toBe(true);
+    for (const column of table.columns) {
+      const cell = row.cells[column.index];
+      if (!cell) continue;
+      expect(Number.isFinite(cell.width)).toBe(true);
+      expect(Number.isFinite(cell.height)).toBe(true);
+      expect(Number.isFinite(cell.padding('top'))).toBe(true);
+      expect(Number.isFinite(cell.padding('right'))).toBe(true);
+      expect(Number.isFinite(cell.padding('bottom'))).toBe(true);
+      expect(Number.isFinite(cell.padding('left'))).toBe(true);
+    }
+  }
+};
+
+const getPartialTableSchema = (): TableSchema =>
+  ({
+    name: 'items',
+    type: 'table',
+    position: { x: 10, y: 10 },
+    width: 150,
+    height: 20,
+    content: '[]',
+    showHead: true,
+    head: ['Name', 'Qty'],
+    headWidthPercentages: [70, 30],
+    tableStyles: {
+      borderColor: '#000000',
+      borderWidth: 0.3,
+    },
+    // Programmatic / migrated schemas often omit optional style fields.
+    // Designer always fills padding / borderWidth; this path does not.
+    headStyles: {
+      fontSize: 10,
+      alignment: 'center',
+      backgroundColor: '#2980ba',
+      fontColor: '#ffffff',
+    },
+    bodyStyles: {
+      fontSize: 10,
+      alignment: 'left',
+      backgroundColor: '',
+      fontColor: '#000000',
+      alternateBackgroundColor: '#f5f5f5',
+    },
+    columnStyles: {},
+  }) as TableSchema;
+
+const createTable = (schema: TableSchema, body: string[][] = [['Alice', '1']]) =>
+  createSingleTable(body, {
+    schema: schema as Schema,
+    basePdf,
+    options: { font: getDefaultFont() },
+    _cache: new Map(),
+  });
+
+describe('createSingleTable style merge', () => {
+  test('omitted head/body padding and borderWidth fall through to defaults', async () => {
+    const table = await createTable(getPartialTableSchema());
+
+    const headCell = table.head[0].cells[0];
+    const bodyCell = table.body[0].cells[0];
+
+    expect(headCell).toBeDefined();
+    expect(bodyCell).toBeDefined();
+
+    expectUniformSpacing(headCell.styles.cellPadding, 5);
+    expectUniformSpacing(bodyCell.styles.cellPadding, 5);
+    expectUniformSpacing(headCell.styles.lineWidth, 0);
+    expectUniformSpacing(bodyCell.styles.lineWidth, 0);
+
+    expect(headCell.styles.fontSize).toBe(10);
+    expect(headCell.styles.alignment).toBe('center');
+    expect(headCell.styles.backgroundColor).toBe('#2980ba');
+    expect(headCell.styles.textColor).toBe('#ffffff');
+    expect(bodyCell.styles.alignment).toBe('left');
+    expect(bodyCell.styles.textColor).toBe('#000000');
+
+    expectFiniteGeometry(table);
+  });
+
+  test('provided padding and borderWidth are still applied', async () => {
+    const schema = getPartialTableSchema();
+    schema.headStyles.padding = { top: 1, right: 2, bottom: 3, left: 4 };
+    schema.headStyles.borderWidth = { top: 0.2, right: 0.3, bottom: 0.4, left: 0.5 };
+    schema.bodyStyles.padding = { top: 6, right: 7, bottom: 8, left: 9 };
+    schema.bodyStyles.borderWidth = { top: 0.6, right: 0.7, bottom: 0.8, left: 0.9 };
+
+    const table = await createTable(schema);
+    const headCell = table.head[0].cells[0];
+    const bodyCell = table.body[0].cells[0];
+
+    expect(headCell.styles.cellPadding).toEqual({ top: 1, right: 2, bottom: 3, left: 4 });
+    expect(headCell.styles.lineWidth).toEqual({ top: 0.2, right: 0.3, bottom: 0.4, left: 0.5 });
+    expect(bodyCell.styles.cellPadding).toEqual({ top: 6, right: 7, bottom: 8, left: 9 });
+    expect(bodyCell.styles.lineWidth).toEqual({ top: 0.6, right: 0.7, bottom: 0.8, left: 0.9 });
+
+    expectFiniteGeometry(table);
+  });
+});

--- a/packages/schemas/src/tables/tableHelper.ts
+++ b/packages/schemas/src/tables/tableHelper.ts
@@ -18,6 +18,7 @@ import type {
   Section,
 } from './types.js';
 import { Cell, Column, Row, Table } from './classes.js';
+import { createBoxDimension } from '../box.js';
 import { getTableBodyRange } from '../splitRange.js';
 
 type StyleProp = 'styles' | 'headStyles' | 'bodyStyles' | 'alternateRowStyles' | 'columnStyles';
@@ -140,9 +141,9 @@ function cellStyles(
     alignment: 'left',
     verticalAlignment: 'middle',
     fontSize: 10,
-    cellPadding: 5,
+    cellPadding: createBoxDimension(5),
     lineColor: '#000000',
-    lineWidth: 0,
+    lineWidth: createBoxDimension(0),
     minCellHeight: 0,
     minCellWidth: 0,
   };
@@ -150,7 +151,7 @@ function cellStyles(
 }
 
 function mapCellStyle(style: CellStyle): Partial<Styles> {
-  return {
+  const mapping: Partial<Styles> = {
     fontName: style.fontName,
     alignment: style.alignment,
     verticalAlignment: style.verticalAlignment,
@@ -164,6 +165,9 @@ function mapCellStyle(style: CellStyle): Partial<Styles> {
     lineWidth: style.borderWidth,
     cellPadding: style.padding,
   };
+  return Object.fromEntries(
+    Object.entries(mapping).filter(([, value]) => value !== undefined),
+  ) as Partial<Styles>;
 }
 
 function getTableOptions(schema: TableSchema, body: string[][]): UserOptions {


### PR DESCRIPTION
When a Table schema's `headStyles` / `bodyStyles` omit optional fields such as `padding` or `borderWidth`, `mapCellStyle` still emitted those keys as `undefined`. Downstream `Object.assign` copied them over the library defaults (`cellPadding: 5`, `lineWidth: 0`), so `Cell.padding` threw and table geometry collapsed. The Designer always fills every style field, so this mainly hits programmatic or migrated schemas.

Drop undefined keys from `mapCellStyle` so omitted fields fall through to the defaults. The fallback `cellPadding` / `lineWidth` values are box dimensions so `Cell.padding` can read them.

Reported by @sbeisch.

Fixes #1573